### PR TITLE
docs: recommend uv tool / pipx over pip (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3 (2026-05-01)
+
+- Docs: README install section now leads with `uv tool install aethis-cli` (recommended) and `pipx install aethis-cli`, with `pip install` in a venv as the third option. Pairs with [Aethis-ai/docs#12](https://github.com/Aethis-ai/docs/pull/12). Closes [#14](https://github.com/Aethis-ai/aethis-cli/issues/14).
+
 ## 0.4.2 (2026-04-28)
 
 Two bug fixes that block the documented quickstart against public bundles.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ CLI for the [Aethis](https://aethis.ai) developer API — evaluate eligibility, 
 ## Install
 
 ```bash
+# Recommended — isolated, no venv juggling:
+uv tool install aethis-cli
+
+# Or, with pipx:
+pipx install aethis-cli
+
+# Or in a venv:
+python -m venv .venv && source .venv/bin/activate
 pip install aethis-cli
 ```
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.4.2"
+version = "0.4.3"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Closes #14.

Updates the README `Install` section to recommend `uv tool install aethis-cli` first, with `pipx install aethis-cli` as an alternative and `pip install` inside a venv as the third fallback. Aligns the README with what users actually want — an isolated CLI install that doesn't pollute the system Python or require manual venv management.

## Related

- Paired docs PR (mintlify): Aethis-ai/docs#12 — same install snippet propagated to `interfaces/cli`, `getting-started/introduction`, `getting-started/try-it`, `api-reference/introduction`, and `interfaces/which-to-use`.

## Test plan

- [ ] README renders correctly on PyPI / GitHub
- [ ] Snippet matches the corresponding section on docs.aethis.ai once the docs PR ships