### PR TITLE
ux: clarify login vs account generate (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.4 (2026-05-01)
+
+- UX: `aethis login --help` now reads "Sign in and store an API key locally. First-time setup — this is all you need." `aethis account generate --help` clarifies it's for *additional* keys (rotation, multi-machine, scoped access). After successful `aethis login`, a tip line points at `aethis status` / `aethis account keys`. README quickstart collapses any "first login then generate" sequence into a single `aethis login` step. No behaviour change. Closes [#13](https://github.com/Aethis-ai/aethis-cli/issues/13).
+
 ## 0.4.3 (2026-05-01)
 
 - Docs: README install section now leads with `uv tool install aethis-cli` (recommended) and `pipx install aethis-cli`, with `pip install` in a venv as the third option. Pairs with [Aethis-ai/docs#12](https://github.com/Aethis-ai/docs/pull/12). Closes [#14](https://github.com/Aethis-ai/aethis-cli/issues/14).

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ aethis explain -b <bundle_id>
 Rule authoring is **invite-only private beta**. Decision tools (`aethis decide`, `aethis fields`, `aethis explain`) work immediately with no sign-up — this section is for approved beta tenants. [Request access →](https://aethis.ai/sign-up)
 
 ```bash
-# 1. Authenticate (creates a key via browser sign-in)
-aethis account generate
-# Or paste an existing key: aethis login
+# 1. Sign in (creates and stores an API key via browser)
+aethis login
 
 # 2. Initialise a project
 mkdir my-rules && cd my-rules
@@ -67,7 +66,7 @@ A complete, runnable example is included in `examples/spacecraft-crew-rules/`:
 
 ```bash
 cp -r examples/spacecraft-crew-rules my-first-rules && cd my-first-rules
-aethis account generate
+aethis login
 aethis generate --poll
 aethis test
 aethis decide -i '{"space.crew.species": "Human", "space.crew.age": 35, "space.crew.flight_hours": 600, "space.crew.has_pilot_license": true, "space.crew.has_gaa_exam": true, "space.medical.cert_valid": true, "space.mission.type": "suborbital", "space.crew.has_towel": true}'
@@ -120,10 +119,10 @@ Project guidance lives in `.aethis/guidance/hints.yaml` and is uploaded by `aeth
 
 | Command | Description |
 |---------|-------------|
-| `aethis account generate` | Create an API key via browser sign-in |
+| `aethis login` | Sign in and store an API key locally (first-time setup) |
+| `aethis account generate` | Mint an additional API key (rotation, multi-machine, scoped access) |
 | `aethis account keys` | List your API keys (masked) |
 | `aethis account revoke <key_id>` | Revoke a key |
-| `aethis login` | Paste an existing key |
 
 ## Project structure
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/aethis_cli/commands/account_cmd.py
+++ b/aethis_cli/commands/account_cmd.py
@@ -126,7 +126,7 @@ def generate(
     no_save: bool = typer.Option(False, "--no-save", help="Print key but don't save"),
     timeout: int = typer.Option(120, "--timeout", help="Browser auth timeout in seconds"),
 ) -> None:
-    """Create a new API key by signing in through your browser."""
+    """Mint an additional API key (for rotation, multi-machine, or scoped access). For first-time setup use `aethis login` instead."""
     base_url = os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
     if scopes is None:
         scopes = list(DEFAULT_SCOPES)

--- a/aethis_cli/commands/login_cmd.py
+++ b/aethis_cli/commands/login_cmd.py
@@ -85,7 +85,7 @@ def login(
     ),
     timeout: int = typer.Option(120, "--timeout", help="Browser auth timeout in seconds"),
 ) -> None:
-    """Authenticate with Aethis. Opens your browser to sign in and create an API key."""
+    """Sign in and store an API key locally. First-time setup — this is all you need."""
     base_url = os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
     if api_key:
         if not _validate_key(api_key, base_url):
@@ -162,3 +162,4 @@ def login(
 
     _save_key(full_key)
     success("Ready to use. Try: aethis status")
+    info("Tip: run `aethis status` to verify, or `aethis account keys` to see all your keys.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.4.3"
+version = "0.4.4"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Closes #13.

`aethis login` and `aethis account generate` both mint API keys via browser OAuth, and their help text overlapped enough that new users assumed they needed to run both. This is a pure text/UX cleanup — no behaviour change.

## Changes

- `aethis login` docstring: "Sign in and store an API key locally. First-time setup — this is all you need."
- `aethis account generate` docstring: now framed as an additional-key tool (rotation, multi-machine, scoped access) and points first-timers at `aethis login`.
- Post-login success output gains one tip line: `Tip: run aethis status to verify, or aethis account keys to see all your keys.`
- `README.md`:
  - Quickstart "Author your own rules" section: replaced the `aethis account generate` (or `aethis login`) pair with just `aethis login`.
  - Spacecraft example: `aethis account generate` → `aethis login`.
  - Account command table: `aethis login` is now the first row (first-time setup); `aethis account generate` moves to second (additional keys).

## Out of scope (per issue)

- No behaviour change to either command.
- `aethis account generate` is preserved — only its framing changed.
- Auth logic (issue #12) untouched.
- Install section (issue #14) untouched.
- Version bump deferred to merge time.

## Test plan

- [x] `uv run pytest` — 104 passed, 10 deselected, coverage 62% (above the 45% gate).
- [ ] Maintainer eyeballs `aethis login --help` and `aethis account generate --help` post-merge to confirm rendered help reads as intended.