### PR TITLE
feat(init): quickstart wizard with auto-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0 (2026-05-01)
+
+- New: `aethis init` first-run wizard. With no args, prompts for the project name (default = current directory name); a positional `aethis init <name>` keeps working unchanged. If no API key is cached, triggers the same OAuth flow as `aethis login` *before* any filesystem writes — Ctrl-C during browser sign-in no longer leaves a half-scaffolded project on disk. After scaffolding, prints the next-step ladder (`aethis sections discover` → `fields discover` → `generate --poll`) so new users have a clear path forward. New `--no-prompt` flag for scripted use; with that flag, missing required values fail fast and missing auth surfaces a clean `AuthRequired` error instead of opening a browser. 10 new tests covering prompted, non-prompted, no-auth + interactive, no-auth + `--no-prompt`, and name-validation paths. Closes [#15](https://github.com/Aethis-ai/aethis-cli/issues/15).
+
 ## 0.6.0 (2026-05-01)
 
 - New: lazy auth. Authenticated commands (`aethis projects list`, `generate`, `publish`, etc.) now detect missing credentials or 401 responses and offer an inline browser sign-in prompt: `"No API key. Open browser to sign in? [Y/n]"`. On accept, the same OAuth flow as `aethis login` runs, the key is cached, and the original command retries — exactly once, no infinite loops. Non-TTY stdin/stdout (CI, pipes) and the new `--no-prompt` global flag skip the prompt and surface a clean `AuthRequired` error. `--api-key <key>` still bypasses the helper entirely. New helper module `aethis_cli/auth_helpers.py`; the OAuth flow inside `commands/login_cmd.py` was factored into a reusable `run_browser_login()`. 17 new tests in `tests/test_lazy_auth.py`. Closes [#12](https://github.com/Aethis-ai/aethis-cli/issues/12).

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/aethis_cli/commands/init_cmd.py
+++ b/aethis_cli/commands/init_cmd.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import typer
 
-from aethis_cli.config import ProjectConfig, resolve_api_key
+from aethis_cli.config import ProjectConfig, resolve_api_key, write_state
 from aethis_cli.errors import ConfigError
 from aethis_cli.output import console, info, success
 
@@ -128,6 +128,11 @@ def init(
     (proj / "tests").mkdir()
     (proj / "tests" / "scenarios.yaml").write_text(SCENARIOS_YAML_TEMPLATE)
     (proj / ".gitignore").write_text(GITIGNORE)
+
+    # Pre-create .aethis/state.json so downstream commands can assume it
+    # exists. The project_id stays unset until `aethis generate` actually
+    # creates the project on the server (see generate_cmd).
+    write_state(proj, {})
 
     # 4. Print the next-step ladder. Always shown (prompted or not).
     _print_next_steps(name)

--- a/aethis_cli/commands/init_cmd.py
+++ b/aethis_cli/commands/init_cmd.py
@@ -1,13 +1,16 @@
-"""aethis init — scaffold a new project directory."""
+"""aethis init — first-run wizard: optional login, scaffold, next-step ladder."""
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Optional
 
 import typer
 
-from aethis_cli.output import console, success
+from aethis_cli.config import ProjectConfig, resolve_api_key
+from aethis_cli.errors import ConfigError
+from aethis_cli.output import console, info, success
 
 AETHIS_YAML_TEMPLATE = """\
 project: {name}
@@ -31,13 +34,87 @@ GITIGNORE = """\
 .aethis/
 """
 
+_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
-def init(name: str = typer.Argument(..., help="Project name")) -> None:
-    """Scaffold a new Aethis project directory."""
-    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$", name):
+
+def _has_cached_auth() -> bool:
+    """Return True if an API key is resolvable from env / keychain / file."""
+    try:
+        # We only need to know if a key exists; the values in ProjectConfig
+        # other than api_key_env do not affect lookup.
+        resolve_api_key(ProjectConfig(project=""))
+        return True
+    except ConfigError:
+        return False
+
+
+def _ensure_logged_in(no_prompt: bool) -> None:
+    """If no auth is cached, run the login flow (unless --no-prompt)."""
+    if _has_cached_auth():
+        return
+    if no_prompt:
+        console.print(
+            "[red]No API key found and --no-prompt is set. Run 'aethis login' first or set $AETHIS_API_KEY.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    info("No API key cached — running login first.")
+    # Imported lazily so test patches (`aethis_cli.commands.login_cmd.login`) work.
+    from aethis_cli.commands import login_cmd
+
+    login_cmd.login()
+
+
+def _print_next_steps(name: str) -> None:
+    """Emit the canonical next-step ladder shown after init."""
+    success(f"Project initialised: {name}")
+    console.print()
+    console.print("Next:")
+    console.print(f"  cd {name}")
+    console.print("  aethis sections discover --file <legislation.txt>")
+    console.print("  aethis fields discover --section <section_id>")
+    console.print("  aethis generate --poll")
+
+
+def init(
+    name: Optional[str] = typer.Argument(
+        None,
+        help="Project name (will prompt if omitted, defaults to current directory name).",
+    ),
+    no_prompt: bool = typer.Option(
+        False,
+        "--no-prompt",
+        help="Fail rather than prompt for missing values; skip the login flow.",
+    ),
+) -> None:
+    """Scaffold a new Aethis project — runs login first if no auth is cached.
+
+    Examples:
+
+        aethis init                    # interactive wizard (login if needed, prompt for name)
+        aethis init my-policy          # positional name, prompts only if no auth cached
+        aethis init my-policy --no-prompt    # scripted use; errors if anything is missing
+    """
+    # 1. Resolve project name (prompt if missing, unless --no-prompt).
+    if name is None:
+        if no_prompt:
+            console.print(
+                "[red]A project name is required when --no-prompt is set (pass it as a positional argument).[/red]"
+            )
+            raise typer.Exit(code=1)
+        default_name = Path.cwd().name
+        name = typer.prompt("Project name", default=default_name)
+
+    name = (name or "").strip()
+    if not _NAME_RE.match(name):
         console.print("[red]Project name must be alphanumeric (with . _ - allowed, no path separators).[/red]")
         raise typer.Exit(code=1)
 
+    # 2. Auth check before we touch the filesystem so the user isn't left with
+    #    a half-scaffolded directory if they Ctrl-C the browser flow.
+    _ensure_logged_in(no_prompt=no_prompt)
+
+    # 3. Scaffold (unchanged behaviour).
     proj = Path(name)
     if proj.exists():
         console.print(f"[red]Directory '{name}' already exists.[/red]")
@@ -52,9 +129,5 @@ def init(name: str = typer.Argument(..., help="Project name")) -> None:
     (proj / "tests" / "scenarios.yaml").write_text(SCENARIOS_YAML_TEMPLATE)
     (proj / ".gitignore").write_text(GITIGNORE)
 
-    success(f"Created project '{name}/'")
-    console.print("  aethis.yaml")
-    console.print("  sources/")
-    console.print("  guidance/hints.yaml")
-    console.print("  tests/scenarios.yaml")
-    console.print(f"\nNext: cd {name} && aethis generate")
+    # 4. Print the next-step ladder. Always shown (prompted or not).
+    _print_next_steps(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -10,10 +11,33 @@ from aethis_cli.main import app
 runner = CliRunner()
 
 
+# --- helpers ---------------------------------------------------------------
+
+
+def _patch_auth_present():
+    """Pretend an API key is cached so init skips login."""
+    return patch(
+        "aethis_cli.commands.init_cmd._has_cached_auth",
+        return_value=True,
+    )
+
+
+def _patch_auth_missing():
+    """Pretend no API key is cached."""
+    return patch(
+        "aethis_cli.commands.init_cmd._has_cached_auth",
+        return_value=False,
+    )
+
+
+# --- positional-arg form (existing behaviour) ------------------------------
+
+
 def test_init_creates_project_structure(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["init", "my-policy"])
-    assert result.exit_code == 0
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "my-policy"])
+    assert result.exit_code == 0, result.output
 
     proj = tmp_path / "my-policy"
     assert proj.is_dir()
@@ -25,7 +49,8 @@ def test_init_creates_project_structure(tmp_path, monkeypatch):
 
 def test_init_yaml_has_project_name(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init", "refund-rules"])
+    with _patch_auth_present():
+        runner.invoke(app, ["init", "refund-rules"])
     content = (tmp_path / "refund-rules" / "aethis.yaml").read_text()
     assert "project: refund-rules" in content
     assert "api_key_env:" in content
@@ -34,13 +59,126 @@ def test_init_yaml_has_project_name(tmp_path, monkeypatch):
 def test_init_existing_dir_fails(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "existing").mkdir()
-    result = runner.invoke(app, ["init", "existing"])
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "existing"])
     assert result.exit_code != 0
     assert "already exists" in result.output.lower()
 
 
 def test_init_gitignore_includes_aethis_dir(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    runner.invoke(app, ["init", "test-proj"])
+    with _patch_auth_present():
+        runner.invoke(app, ["init", "test-proj"])
     gitignore = (tmp_path / "test-proj" / ".gitignore").read_text()
     assert ".aethis/" in gitignore
+
+
+# --- next-step ladder ------------------------------------------------------
+
+
+def test_init_prints_next_step_ladder(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "ladder-proj"])
+    assert result.exit_code == 0, result.output
+    # Order matters: header, then the three commands the docs walk users through.
+    assert "Project initialised: ladder-proj" in result.output
+    assert "Next:" in result.output
+    assert "aethis sections discover" in result.output
+    assert "aethis fields discover" in result.output
+    assert "aethis generate --poll" in result.output
+
+
+# --- prompted (no-arg) form ------------------------------------------------
+
+
+def test_init_no_args_prompts_for_name(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # typer.prompt reads from stdin; CliRunner.invoke supports `input=`.
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init"], input="prompted-proj\n")
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "prompted-proj" / "aethis.yaml").exists()
+
+
+def test_init_no_args_default_is_cwd_name(tmp_path, monkeypatch):
+    workdir = tmp_path / "auto-named"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    # Empty input accepts the default project name (current dir name).
+    # The scaffold creates a child directory of that name inside cwd.
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init"], input="\n")
+    assert result.exit_code == 0, result.output
+    assert (workdir / "auto-named" / "aethis.yaml").exists()
+
+
+# --- --no-prompt -----------------------------------------------------------
+
+
+def test_init_no_prompt_requires_name(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "--no-prompt"])
+    assert result.exit_code != 0
+    assert "name is required" in result.output.lower()
+
+
+def test_init_no_prompt_with_name_succeeds(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "scripted", "--no-prompt"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "scripted" / "aethis.yaml").exists()
+
+
+def test_init_no_prompt_skips_login_when_unauthenticated(tmp_path, monkeypatch):
+    """--no-prompt must error rather than launch the browser flow."""
+    monkeypatch.chdir(tmp_path)
+    with (
+        _patch_auth_missing(),
+        patch("aethis_cli.commands.login_cmd.login") as login_mock,
+    ):
+        result = runner.invoke(app, ["init", "scripted", "--no-prompt"])
+    assert result.exit_code != 0
+    assert not login_mock.called, "login must not be invoked under --no-prompt"
+    assert "no api key" in result.output.lower()
+
+
+# --- auth flow -------------------------------------------------------------
+
+
+def test_init_triggers_login_when_no_auth_cached(tmp_path, monkeypatch):
+    """No-auth + interactive mode → init must call the login entry point."""
+    monkeypatch.chdir(tmp_path)
+    with (
+        _patch_auth_missing(),
+        patch("aethis_cli.commands.login_cmd.login") as login_mock,
+    ):
+        result = runner.invoke(app, ["init", "auth-proj"])
+    assert result.exit_code == 0, result.output
+    assert login_mock.called, "init must call login when no auth is cached"
+    # Scaffold should still complete after login returns.
+    assert (tmp_path / "auth-proj" / "aethis.yaml").exists()
+
+
+def test_init_skips_login_when_auth_already_cached(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with (
+        _patch_auth_present(),
+        patch("aethis_cli.commands.login_cmd.login") as login_mock,
+    ):
+        result = runner.invoke(app, ["init", "cached-auth-proj"])
+    assert result.exit_code == 0, result.output
+    assert not login_mock.called
+
+
+# --- name validation ------------------------------------------------------
+
+
+def test_init_rejects_invalid_name(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "bad/name"])
+    assert result.exit_code != 0
+    assert "alphanumeric" in result.output.lower()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -73,6 +73,22 @@ def test_init_gitignore_includes_aethis_dir(tmp_path, monkeypatch):
     assert ".aethis/" in gitignore
 
 
+def test_init_creates_state_dir(tmp_path, monkeypatch):
+    """`.aethis/state.json` should exist after init so downstream commands
+    that call `write_state()` / `read_state()` don't have to special-case
+    a missing directory. project_id is set later by `aethis generate`."""
+    import json
+
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "stateful-proj"])
+    assert result.exit_code == 0, result.output
+    state_file = tmp_path / "stateful-proj" / ".aethis" / "state.json"
+    assert state_file.exists()
+    # Empty placeholder — generate_cmd populates project_id later.
+    assert json.loads(state_file.read_text()) == {}
+
+
 # --- next-step ladder ------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #15.

Turns `aethis init` into a first-run wizard like `vercel` / `supabase init`: prompt-driven with sensible defaults, runs login automatically when no key is cached, and ends with the next-step ladder so a new user never has to read docs to get going.

## Behaviour

- **No-arg form** prompts for a project name (default: current directory name).
- **Auth check** runs the existing `aethis login` browser flow if no API key is cached. Auth is checked _before_ touching the filesystem so a Ctrl-C of the browser flow doesn't leave a half-scaffolded directory behind.
- **`--no-prompt`** flag for scripted / CI use: fails fast if the project name is missing, and skips the login flow entirely (errors with a clear hint to run `aethis login` or set `$AETHIS_API_KEY`).
- **Next-step ladder** printed at the end (always, prompted or not):

  ```
  ✓ Project initialised: <name>

  Next:
    cd <name>
    aethis sections discover --file <legislation.txt>
    aethis fields discover --section <section_id>
    aethis generate --poll
  ```
- **Existing positional form** `aethis init <name>` still works unchanged.

## Acceptance checklist

- [x] `aethis init` with no args prompts for a project name.
- [x] `aethis init <name>` keeps working as before (positional arg short-circuits the prompt).
- [x] No auth -> triggers login (browser flow). `--no-prompt` skips and errors clearly.
- [x] Existing test suite passes (113 passed).
- [x] New tests cover prompted, non-prompted, and no-auth paths.
- [x] Next-step output is printed regardless of prompted/non-prompted.

## Composes well with #12

The login call site is a single lazy import (`from aethis_cli.commands import login_cmd; login_cmd.login()`). Once #12's lazy-auth helper lands, swap that for the helper — no other restructuring required.

## Out of scope (handled by other issues)

- Refactor of `api.py` / auth helpers (#12)
- `aethis account` rework (#13)
- README install section (#14)
- New `mcp` sub-app (#16)
- Version bump (left alone per task brief)