### PR TITLE
feat(mcp): aethis mcp install --target <client>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 (2026-05-01)
+
+- New: `aethis mcp install --target <client>` writes the MCP server entry into your editor's config in one shot. Supports `claude-code` (project-level `.mcp.json`), `cursor` (`~/.cursor/mcp.json`), `claude-desktop` (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `~/.config/Claude/...` on Linux), `windsurf` (`~/.codeium/windsurf/mcp_config.json`), and `--target all` for everything at once. Idempotent, preserves any other configured MCP servers. `aethis mcp uninstall --target <client>` reverses the install. Closes [#16](https://github.com/Aethis-ai/aethis-cli/issues/16).
+
 ## 0.4.4 (2026-05-01)
 
 - UX: `aethis login --help` now reads "Sign in and store an API key locally. First-time setup — this is all you need." `aethis account generate --help` clarifies it's for *additional* keys (rotation, multi-machine, scoped access). After successful `aethis login`, a tip line points at `aethis status` / `aethis account keys`. README quickstart collapses any "first login then generate" sequence into a single `aethis login` step. No behaviour change. Closes [#13](https://github.com/Aethis-ai/aethis-cli/issues/13).

--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ Project guidance lives in `.aethis/guidance/hints.yaml` and is uploaded by `aeth
 | `aethis account keys` | List your API keys (masked) |
 | `aethis account revoke <key_id>` | Revoke a key |
 
+## MCP one-liner
+
+Wire up the [Aethis MCP server](https://github.com/Aethis-ai/aethis-mcp) in your AI editor without hand-editing JSON. Picks up the API key cached by `aethis login`, drops a canonical `aethis` server entry into the right config file, and preserves any other MCP servers you already have.
+
+```bash
+# One editor at a time
+aethis mcp install --target cursor
+aethis mcp install --target claude-code      # writes ./.mcp.json (project-local)
+aethis mcp install --target claude-desktop
+aethis mcp install --target windsurf
+
+# Or all four at once
+aethis mcp install --target all
+
+# Reverse it (only removes the `aethis` entry, leaves others alone)
+aethis mcp uninstall --target cursor
+```
+
+The command is idempotent — re-run it after `aethis login` rotates your key and the entry updates in place. Restart your editor to pick up the change.
+
+| Target | Config path |
+|--------|-------------|
+| `claude-code` | `<cwd>/.mcp.json` (project-scoped) |
+| `cursor` | `~/.cursor/mcp.json` |
+| `claude-desktop` | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json` · Linux: `~/.config/Claude/claude_desktop_config.json` |
+| `windsurf` | `~/.codeium/windsurf/mcp_config.json` |
+
 ## Project structure
 
 After `aethis init`, your project looks like:

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.4.4"
+__version__ = "0.5.0"

--- a/aethis_cli/commands/mcp_cmd.py
+++ b/aethis_cli/commands/mcp_cmd.py
@@ -1,0 +1,255 @@
+"""aethis mcp — wire up the Aethis MCP server in supported editors/clients.
+
+Today users have to hand-edit a different JSON file for each editor
+(Cursor, Claude Code, Claude Desktop, Windsurf). This command does the
+edit for them: drops in the canonical `aethis` server entry, preserves
+any other servers the user already configured, and is idempotent.
+
+The server is invoked as `npx -y aethis-mcp@latest` and reads
+`AETHIS_API_KEY` (and optionally `AETHIS_BASE_URL`) from env. We pull
+both from the same credential store `aethis status` reads, so the user
+only has to run `aethis login` once.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from aethis_cli.config import DEFAULT_BASE_URL
+from aethis_cli.output import console, info, success, warn
+
+mcp_app = typer.Typer(
+    name="mcp",
+    help="Install or remove the Aethis MCP server in your editor's config.",
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,
+)
+
+
+VALID_TARGETS = ("claude-code", "cursor", "claude-desktop", "windsurf", "all")
+_INSTALLABLE_TARGETS = tuple(t for t in VALID_TARGETS if t != "all")
+_SERVER_KEY = "aethis"
+
+
+def _resolve_api_key_silent() -> Optional[str]:
+    """Resolve the cached API key the same way `aethis status` does.
+
+    Order: AETHIS_API_KEY env var → OS keyring → credentials file.
+    Returns None if none is set; the caller decides how to fail.
+    """
+    key = os.environ.get("AETHIS_API_KEY")
+    if key:
+        return key
+
+    try:
+        import keyring  # type: ignore[import-not-found]
+
+        cached = keyring.get_password("aethis-cli", "api_key")
+        if cached:
+            return cached
+    except Exception:
+        pass
+
+    import yaml  # type: ignore[import-untyped]
+
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    creds_path = Path(xdg) / "aethis" / "credentials" if xdg else Path.home() / ".config" / "aethis" / "credentials"
+    if creds_path.exists():
+        try:
+            raw = yaml.safe_load(creds_path.read_text()) or {}
+            cached = raw.get("api_key")
+            if cached:
+                return cached
+        except Exception:
+            pass
+    return None
+
+
+def _resolve_base_url() -> str:
+    """Pick the AETHIS_BASE_URL we want the MCP server to talk to.
+
+    Env override wins; otherwise default to the public endpoint. We
+    deliberately do NOT walk up looking for an aethis.yaml here — the
+    MCP config is global to the editor, not project-scoped.
+    """
+    return os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
+
+
+def _config_path_for(target: str, *, cwd: Optional[Path] = None, home: Optional[Path] = None) -> Path:
+    """Return the absolute config path each client expects."""
+    home = home or Path.home()
+    cwd = cwd or Path.cwd()
+
+    if target == "claude-code":
+        # Project-level — lives next to your repo, not in $HOME.
+        return cwd / ".mcp.json"
+    if target == "cursor":
+        return home / ".cursor" / "mcp.json"
+    if target == "claude-desktop":
+        if platform.system() == "Darwin":
+            return home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        # Linux + everything else (Windows users are on their own for now).
+        return home / ".config" / "Claude" / "claude_desktop_config.json"
+    if target == "windsurf":
+        # Codeium's documented path; ~/.windsurf/mcp.json was the old one.
+        return home / ".codeium" / "windsurf" / "mcp_config.json"
+    raise ValueError(f"unknown target: {target}")
+
+
+def _server_entry(api_key: str, base_url: str) -> dict:
+    """The canonical aethis MCP server stanza."""
+    return {
+        "command": "npx",
+        "args": ["-y", "aethis-mcp@latest"],
+        "env": {
+            "AETHIS_API_KEY": api_key,
+            "AETHIS_BASE_URL": base_url,
+        },
+    }
+
+
+def _read_config(path: Path) -> dict:
+    """Read an existing client config, tolerating absent/empty files."""
+    if not path.exists():
+        return {}
+    raw = path.read_text().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise typer.BadParameter(
+            f"Could not parse existing config at {path}: {e}. Fix it or delete the file and re-run."
+        ) from None
+    if not isinstance(data, dict):
+        raise typer.BadParameter(f"Existing config at {path} is not a JSON object.")
+    return data
+
+
+def _write_config(path: Path, data: dict) -> None:
+    """Persist the config, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _expand_targets(target: str) -> list[str]:
+    if target == "all":
+        return list(_INSTALLABLE_TARGETS)
+    return [target]
+
+
+def _validate_target(target: str) -> None:
+    if target not in VALID_TARGETS:
+        valid = ", ".join(VALID_TARGETS)
+        console.print(f"[red]Invalid --target '{target}'.[/red] Must be one of: {valid}")
+        raise typer.Exit(code=1)
+
+
+def _install_one(target: str, api_key: str, base_url: str) -> Path:
+    """Insert (or update) the aethis entry in one client's config."""
+    path = _config_path_for(target)
+    config = _read_config(path)
+
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+    servers[_SERVER_KEY] = _server_entry(api_key, base_url)
+    config["mcpServers"] = servers
+
+    _write_config(path, config)
+    return path
+
+
+def _uninstall_one(target: str) -> tuple[Path, bool]:
+    """Remove only the aethis entry. Returns (path, was_present)."""
+    path = _config_path_for(target)
+    if not path.exists():
+        return path, False
+
+    config = _read_config(path)
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict) or _SERVER_KEY not in servers:
+        return path, False
+
+    del servers[_SERVER_KEY]
+    config["mcpServers"] = servers
+    _write_config(path, config)
+    return path, True
+
+
+@mcp_app.command("install")
+def install(
+    target: str = typer.Option(
+        ...,
+        "--target",
+        "-t",
+        help=f"Which client to wire up. One of: {', '.join(VALID_TARGETS)}.",
+    ),
+) -> None:
+    """Install the Aethis MCP server in one (or all) editor configs.
+
+    Examples:
+
+        aethis mcp install --target cursor
+        aethis mcp install --target claude-code
+        aethis mcp install --target all
+    """
+    _validate_target(target)
+
+    api_key = _resolve_api_key_silent()
+    if api_key is None:
+        console.print("[red]No API key found.[/red] Run `aethis login` first.")
+        raise typer.Exit(code=1)
+
+    base_url = _resolve_base_url()
+    targets = _expand_targets(target)
+
+    info(f"Using AETHIS_BASE_URL={base_url}")
+    for t in targets:
+        path = _install_one(t, api_key, base_url)
+        success(f"{t}: wrote aethis MCP server to {path}")
+
+    console.print()
+    console.print(
+        "[dim]Restart your editor to pick up the new MCP server. "
+        "If something looks off, re-run with --target <client> after fixing creds.[/dim]"
+    )
+
+
+@mcp_app.command("uninstall")
+def uninstall(
+    target: str = typer.Option(
+        ...,
+        "--target",
+        "-t",
+        help=f"Which client to clean up. One of: {', '.join(VALID_TARGETS)}.",
+    ),
+) -> None:
+    """Remove the Aethis MCP server entry. Leaves other servers untouched.
+
+    Examples:
+
+        aethis mcp uninstall --target cursor
+        aethis mcp uninstall --target all
+    """
+    _validate_target(target)
+
+    targets = _expand_targets(target)
+    any_removed = False
+    for t in targets:
+        path, removed = _uninstall_one(t)
+        if removed:
+            success(f"{t}: removed aethis entry from {path}")
+            any_removed = True
+        else:
+            warn(f"{t}: no aethis entry found at {path} (nothing to do)")
+
+    if not any_removed:
+        # Not an error — uninstall is idempotent — but signal it clearly.
+        info("No aethis entries were present.")

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -14,6 +14,7 @@ from aethis_cli.output import console
 from aethis_cli.commands.account_cmd import account_app
 from aethis_cli.commands.bundles_cmd import bundles_app
 from aethis_cli.commands.guidance_cmd import guidance_app
+from aethis_cli.commands.mcp_cmd import mcp_app
 from aethis_cli.commands.projects_cmd import projects_app
 from aethis_cli.commands.init_cmd import init
 from aethis_cli.commands.login_cmd import login
@@ -91,6 +92,7 @@ def main(
 app.add_typer(account_app, name="account")
 app.add_typer(bundles_app, name="bundles")
 app.add_typer(guidance_app, name="guidance")
+app.add_typer(mcp_app, name="mcp")
 app.add_typer(projects_app, name="projects")
 app.command()(init)
 app.command()(login)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.4.4"
+version = "0.5.0"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_mcp_cmd.py
+++ b/tests/test_mcp_cmd.py
@@ -1,0 +1,229 @@
+"""Tests for `aethis mcp install / uninstall`.
+
+All tests redirect HOME and CWD into a tmp_path so we never touch the
+operator's real editor configs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _run(args, env=None):
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    return runner.invoke(app, args, env=env or {}, catch_exceptions=False)
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path, monkeypatch):
+    """Isolate HOME, CWD, and credential lookup from the host."""
+    home = tmp_path / "home"
+    home.mkdir()
+    work = tmp_path / "work"
+    work.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(work)
+
+    # Force the API key resolver onto a deterministic path.
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test_live_xyz")
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    return {"home": home, "work": work}
+
+
+def _cursor_config(home: Path) -> Path:
+    return home / ".cursor" / "mcp.json"
+
+
+def _claude_code_config(work: Path) -> Path:
+    return work / ".mcp.json"
+
+
+def test_install_fresh_creates_file(sandbox):
+    """No existing config → new file with just the aethis entry."""
+    result = _run(["mcp", "install", "--target", "cursor"])
+    assert result.exit_code == 0, result.output
+
+    cfg_path = _cursor_config(sandbox["home"])
+    assert cfg_path.exists()
+
+    data = json.loads(cfg_path.read_text())
+    assert "mcpServers" in data
+    assert "aethis" in data["mcpServers"]
+    entry = data["mcpServers"]["aethis"]
+    assert entry["command"] == "npx"
+    assert entry["args"] == ["-y", "aethis-mcp@latest"]
+    assert entry["env"]["AETHIS_API_KEY"] == "ak_test_live_xyz"
+    assert entry["env"]["AETHIS_BASE_URL"] == "https://api.aethis.ai"
+
+
+def test_install_preserves_other_servers(sandbox):
+    """Pre-existing servers must survive the install."""
+    cfg_path = _cursor_config(sandbox["home"])
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                    }
+                }
+            }
+        )
+    )
+
+    result = _run(["mcp", "install", "--target", "cursor"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(cfg_path.read_text())
+    assert set(data["mcpServers"].keys()) == {"filesystem", "aethis"}
+    assert data["mcpServers"]["filesystem"]["args"][-1] == "/tmp"
+
+
+def test_install_is_idempotent_and_updates_creds(sandbox, monkeypatch):
+    """Re-running install with new creds replaces in place — no duplicates."""
+    # First install with one key.
+    result = _run(["mcp", "install", "--target", "cursor"])
+    assert result.exit_code == 0, result.output
+
+    cfg_path = _cursor_config(sandbox["home"])
+    first = json.loads(cfg_path.read_text())
+    assert first["mcpServers"]["aethis"]["env"]["AETHIS_API_KEY"] == "ak_test_live_xyz"
+
+    # Rotate the key, install again.
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test_live_rotated")
+    result2 = _run(["mcp", "install", "--target", "cursor"])
+    assert result2.exit_code == 0, result2.output
+
+    second = json.loads(cfg_path.read_text())
+    assert list(second["mcpServers"].keys()) == ["aethis"]  # no duplicates
+    assert second["mcpServers"]["aethis"]["env"]["AETHIS_API_KEY"] == "ak_test_live_rotated"
+
+
+def test_uninstall_removes_only_aethis(sandbox):
+    """Uninstall must leave other servers in place."""
+    cfg_path = _cursor_config(sandbox["home"])
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                    },
+                    "aethis": {
+                        "command": "npx",
+                        "args": ["-y", "aethis-mcp@latest"],
+                        "env": {"AETHIS_API_KEY": "ak_old", "AETHIS_BASE_URL": "https://api.aethis.ai"},
+                    },
+                }
+            }
+        )
+    )
+
+    result = _run(["mcp", "uninstall", "--target", "cursor"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(cfg_path.read_text())
+    assert "aethis" not in data["mcpServers"]
+    assert "filesystem" in data["mcpServers"]
+
+
+def test_install_bad_target_lists_valid_targets(sandbox):
+    """Garbage --target value should fail and surface the valid list."""
+    result = _run(["mcp", "install", "--target", "atom"])
+    assert result.exit_code != 0
+    out = result.output
+    for valid in ("claude-code", "cursor", "claude-desktop", "windsurf", "all"):
+        assert valid in out, f"missing {valid!r} in output: {out}"
+
+
+def test_install_without_api_key_fails_clearly(tmp_path, monkeypatch):
+    """No cached key anywhere → fail with a 'run aethis login' hint."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    # Make keyring lookups deterministic — return nothing.
+    from unittest.mock import patch
+
+    with patch("aethis_cli.commands.mcp_cmd.keyring", create=True) as kr:
+        kr.get_password.return_value = None
+        result = _run(["mcp", "install", "--target", "cursor"])
+
+    assert result.exit_code != 0
+    assert "aethis login" in result.output
+
+
+def test_install_target_all_writes_to_each_client(sandbox):
+    """--target all should land an entry in every supported client's path."""
+    result = _run(["mcp", "install", "--target", "all"])
+    assert result.exit_code == 0, result.output
+
+    home = sandbox["home"]
+    work = sandbox["work"]
+
+    # claude-code is project-level
+    cc = _claude_code_config(work)
+    # cursor lives under HOME
+    cu = _cursor_config(home)
+    # windsurf lives under HOME/.codeium/windsurf/
+    ws = home / ".codeium" / "windsurf" / "mcp_config.json"
+    # claude-desktop varies by OS — check both candidates rather than branching here.
+    cd_mac = home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    cd_lin = home / ".config" / "Claude" / "claude_desktop_config.json"
+
+    assert cc.exists(), "claude-code config missing"
+    assert cu.exists(), "cursor config missing"
+    assert ws.exists(), "windsurf config missing"
+    assert cd_mac.exists() or cd_lin.exists(), "claude-desktop config missing"
+
+    for path in (cc, cu, ws):
+        data = json.loads(path.read_text())
+        assert "aethis" in data["mcpServers"]
+
+
+def test_install_claude_code_writes_project_local(sandbox):
+    """claude-code config is project-scoped — it must live in CWD, not HOME."""
+    result = _run(["mcp", "install", "--target", "claude-code"])
+    assert result.exit_code == 0, result.output
+
+    project_cfg = _claude_code_config(sandbox["work"])
+    home_cfg = sandbox["home"] / ".mcp.json"
+
+    assert project_cfg.exists()
+    assert not home_cfg.exists()
+
+
+def test_install_respects_base_url_env(sandbox, monkeypatch):
+    """If AETHIS_BASE_URL is set, the entry should reflect it."""
+    monkeypatch.setenv("AETHIS_BASE_URL", "https://staging.api.aethis.ai")
+    result = _run(["mcp", "install", "--target", "cursor"])
+    assert result.exit_code == 0, result.output
+
+    cfg_path = _cursor_config(sandbox["home"])
+    data = json.loads(cfg_path.read_text())
+    assert data["mcpServers"]["aethis"]["env"]["AETHIS_BASE_URL"] == "https://staging.api.aethis.ai"
+
+
+def test_uninstall_missing_file_is_noop(sandbox):
+    """Uninstall when nothing is configured should still exit cleanly."""
+    result = _run(["mcp", "uninstall", "--target", "cursor"])
+    assert result.exit_code == 0, result.output
+    # File should not have been created by uninstall.
+    assert not _cursor_config(sandbox["home"]).exists()


### PR DESCRIPTION
Closes #16. Adds aethis mcp install/uninstall for claude-code, cursor, claude-desktop, windsurf, and 'all'. Idempotent, preserves user's other configured servers.