### PR TITLE
feat: lazy auth — prompt browser sign-in on 401 (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 (2026-05-01)
+
+- New: lazy auth. Authenticated commands (`aethis projects list`, `generate`, `publish`, etc.) now detect missing credentials or 401 responses and offer an inline browser sign-in prompt: `"No API key. Open browser to sign in? [Y/n]"`. On accept, the same OAuth flow as `aethis login` runs, the key is cached, and the original command retries — exactly once, no infinite loops. Non-TTY stdin/stdout (CI, pipes) and the new `--no-prompt` global flag skip the prompt and surface a clean `AuthRequired` error. `--api-key <key>` still bypasses the helper entirely. New helper module `aethis_cli/auth_helpers.py`; the OAuth flow inside `commands/login_cmd.py` was factored into a reusable `run_browser_login()`. 17 new tests in `tests/test_lazy_auth.py`. Closes [#12](https://github.com/Aethis-ai/aethis-cli/issues/12).
+
 ## 0.5.0 (2026-05-01)
 
 - New: `aethis mcp install --target <client>` writes the MCP server entry into your editor's config in one shot. Supports `claude-code` (project-level `.mcp.json`), `cursor` (`~/.cursor/mcp.json`), `claude-desktop` (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `~/.config/Claude/...` on Linux), `windsurf` (`~/.codeium/windsurf/mcp_config.json`), and `--target all` for everything at once. Idempotent, preserves any other configured MCP servers. `aethis mcp uninstall --target <client>` reverses the install. Closes [#16](https://github.com/Aethis-ai/aethis-cli/issues/16).

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/aethis_cli/auth_helpers.py
+++ b/aethis_cli/auth_helpers.py
@@ -1,0 +1,198 @@
+"""Lazy-auth glue between cached credentials and the browser sign-in flow.
+
+The CLI used to fail hard whenever an authenticated command ran without a
+cached API key — the user got "API key not found. Run 'aethis login'."
+and had to start over. This module gives commands a single entry point that
+behaves like ``gcloud auth`` / ``vercel`` / ``gh``: if no key is cached, it
+offers an inline browser sign-in (TTY only), runs it, persists the new key,
+and returns it. Non-interactive callers (CI, piped input, ``--no-prompt``)
+get a clean ``AuthRequired`` instead of a hung prompt.
+
+Used in two places:
+
+* Up-front, before constructing an authenticated client (preferred — gives
+  the user a chance to authenticate before any HTTP call).
+* On a 401 from the server, via the client's refresh hook, so a stale key
+  triggers exactly one re-auth attempt before surfacing the original error.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+from aethis_cli.errors import AuthRequired, ConfigError
+
+
+@dataclass
+class RuntimeOptions:
+    """CLI-wide flags wired in from the root callback in ``main.py``.
+
+    Mutable singleton so commands and the HTTP client can both read the
+    user's choices without threading flags through every signature.
+    """
+
+    no_prompt: bool = False
+    api_key_override: Optional[str] = None
+    base_url_override: Optional[str] = None
+
+
+# Module-level singleton; ``main.cli`` populates it before dispatching.
+RUNTIME = RuntimeOptions()
+
+
+def _is_interactive() -> bool:
+    """Return True iff stdin and stdout are both attached to a TTY.
+
+    Both ends matter: we need stdin to read the y/N answer, and stdout so the
+    prompt is visible. Piped or CI invocations should never block on a prompt.
+    """
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _resolve_cached_key() -> Optional[str]:
+    """Return the cached key without raising. Mirrors ``resolve_api_key``'s
+    fallback chain (env > keychain > credentials file) but never errors out.
+    """
+    key = os.environ.get("AETHIS_API_KEY")
+    if key:
+        return key
+
+    try:
+        import keyring  # type: ignore[import-not-found]
+
+        key = keyring.get_password("aethis-cli", "api_key")
+        if key:
+            return key
+    except Exception:
+        pass
+
+    from pathlib import Path
+
+    import yaml  # type: ignore[import-untyped]
+
+    from aethis_cli.config import credentials_path
+
+    creds = credentials_path()
+    if creds.exists():
+        try:
+            raw = yaml.safe_load(creds.read_text()) or {}
+            cached = raw.get("api_key")
+            if cached:
+                return cached
+        except Exception:
+            pass
+    # Older builds wrote a `.yaml` extension; honour that too.
+    legacy = Path(str(creds) + ".yaml")
+    if legacy.exists():
+        try:
+            raw = yaml.safe_load(legacy.read_text()) or {}
+            return raw.get("api_key")
+        except Exception:
+            pass
+    return None
+
+
+def _prompt_yes_no(message: str, default: bool = True) -> bool:
+    """Minimal y/N prompt that defaults to ``default`` on bare return.
+
+    Kept dependency-free (no ``typer.confirm``) so the helper can be invoked
+    from inside the HTTP client without a Typer context.
+    """
+    suffix = " [Y/n] " if default else " [y/N] "
+    try:
+        answer = input(message + suffix).strip().lower()
+    except EOFError:
+        return False
+    if not answer:
+        return default
+    return answer in {"y", "yes"}
+
+
+def require_auth_or_login_inline(
+    base_url: Optional[str] = None,
+    *,
+    force_browser: bool = False,
+    timeout: int = 120,
+) -> str:
+    """Return a usable API key, prompting for browser sign-in if needed.
+
+    Resolution order:
+
+    1. ``--api-key`` global flag (set on ``RUNTIME``) — bypass everything.
+    2. Cached key (env / keychain / credentials file). Skipped when
+       ``force_browser=True`` so the 401-retry path can mint a fresh key.
+    3. Interactive browser flow, if stdin/stdout are TTYs and ``--no-prompt``
+       wasn't passed. Asks for confirmation first so an accidental authed
+       command doesn't silently spawn a browser.
+    4. Otherwise raise :class:`AuthRequired` with a one-line remediation.
+
+    ``base_url`` falls back to ``RUNTIME.base_url_override`` then
+    ``AETHIS_BASE_URL`` then the default — this matters because the browser
+    flow mints a key against a specific server, and minting against prod when
+    the user is targeting a local dev server would silently 401 forever.
+    """
+    if RUNTIME.api_key_override:
+        return RUNTIME.api_key_override
+
+    if not force_browser:
+        cached = _resolve_cached_key()
+        if cached:
+            return cached
+
+    if RUNTIME.no_prompt or not _is_interactive():
+        # Print the message ourselves rather than relying on the CLI wrapper —
+        # the wrapper isn't reachable from CliRunner-style integration tests
+        # (which call ``app()`` directly), and emitting the same line in both
+        # paths keeps stderr consistent for users who pipe / log the CLI.
+        from aethis_cli.output import console
+
+        message = "No API key found. Run 'aethis login' to authenticate, set AETHIS_API_KEY, or pass --api-key."
+        console.print(f"[red]Auth required:[/red] {message}")
+        raise AuthRequired(message)
+
+    # Resolve base URL late so we honour both env and project config.
+    resolved_base_url = base_url or RUNTIME.base_url_override or os.environ.get("AETHIS_BASE_URL")
+    if resolved_base_url is None:
+        try:
+            from aethis_cli.config import resolve_base_url_with_source
+
+            resolved_base_url, _ = resolve_base_url_with_source()
+        except ConfigError:
+            from aethis_cli.config import DEFAULT_BASE_URL
+
+            resolved_base_url = DEFAULT_BASE_URL
+
+    from aethis_cli.output import console
+
+    if force_browser:
+        console.print("\n[yellow]API key was rejected (HTTP 401).[/yellow]")
+        proceed = _prompt_yes_no("Open browser to sign in again?", default=True)
+    else:
+        console.print("\n[yellow]No API key found.[/yellow]")
+        proceed = _prompt_yes_no("Open browser to sign in?", default=True)
+
+    if not proceed:
+        message = "Authentication declined. Run 'aethis login' to authenticate, set AETHIS_API_KEY, or pass --api-key."
+        console.print(f"[red]Auth required:[/red] {message}")
+        raise AuthRequired(message)
+
+    # Lazy import — avoids a circular import at module load time.
+    from aethis_cli.commands.login_cmd import run_browser_login
+
+    new_key = run_browser_login(resolved_base_url, timeout=timeout)
+    if not new_key:
+        message = "Browser sign-in did not complete. Run 'aethis login' to retry."
+        console.print(f"[red]Auth required:[/red] {message}")
+        raise AuthRequired(message)
+    return new_key
+
+
+# NOTE: a higher-level ``make_authed_client`` lives in ``config.py`` so command
+# modules that already import from ``config`` don't need a second import. This
+# module deliberately stops at the credential-resolution boundary.

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import httpx
 
 from aethis_cli.errors import AethisAPIError
+
+# Callback signature for the lazy-auth refresh hook. Receives ``force_browser``
+# (always True at the call site — we know the cached key just failed) and
+# returns a fresh API key, or raises :class:`AuthRequired` to abort cleanly.
+KeyRefreshCallback = Callable[..., str]
 
 
 class AethisClient:
@@ -18,6 +23,7 @@ class AethisClient:
         api_key: str,
         base_url: str = "https://api.aethis.ai",
         anthropic_key: Optional[str] = None,
+        on_auth_required: Optional[KeyRefreshCallback] = None,
     ) -> None:
         headers: dict[str, str] = {"X-API-Key": api_key}
         if anthropic_key:
@@ -28,6 +34,10 @@ class AethisClient:
             timeout=60.0,
             verify=True,
         )
+        # Hook called once when the server returns 401. If it returns a new
+        # key the request is retried exactly once with the refreshed header;
+        # a second 401 surfaces the original error so we never loop.
+        self._on_auth_required = on_auth_required
 
     def close(self) -> None:
         self._client.close()
@@ -40,15 +50,31 @@ class AethisClient:
 
     def _request(self, method: str, path: str, **kwargs: Any) -> Any:
         resp = self._client.request(method, path, **kwargs)
+        if resp.status_code == 401 and self._on_auth_required is not None:
+            # Single retry. Disable the hook for the retry to bound recursion
+            # at one extra round-trip even if the hook's caller plumbs the
+            # wrong key back in. ``AuthRequired`` (no TTY, ``--no-prompt``,
+            # user declined) and other refresh-flow exceptions propagate so
+            # the CLI wrapper can render a clean one-liner instead of being
+            # masked by the original 401.
+            refresh = self._on_auth_required
+            self._on_auth_required = None
+            new_key = refresh(force_browser=True)
+            self._client.headers["X-API-Key"] = new_key
+            resp = self._client.request(method, path, **kwargs)
         if resp.status_code >= 400:
-            try:
-                detail = resp.json().get("detail", resp.text)
-            except (ValueError, KeyError):
-                detail = resp.text or f"HTTP {resp.status_code}"
-            raise AethisAPIError(resp.status_code, detail)
+            self._raise_for_status(resp)
         if resp.status_code == 204:
             return {}
         return resp.json()
+
+    @staticmethod
+    def _raise_for_status(resp: httpx.Response) -> None:
+        try:
+            detail = resp.json().get("detail", resp.text)
+        except (ValueError, KeyError):
+            detail = resp.text or f"HTTP {resp.status_code}"
+        raise AethisAPIError(resp.status_code, detail)
 
     # -- Decision API --
 

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -11,7 +11,13 @@ import yaml
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
 from aethis_cli.client import AethisClient
-from aethis_cli.config import load_project_config, resolve_anthropic_key, resolve_api_key, write_state
+from aethis_cli.config import (
+    load_project_config,
+    make_authed_client,
+    resolve_anthropic_key,
+    resolve_api_key,
+    write_state,
+)
 from aethis_cli.errors import AethisAPIError, ConfigError
 from aethis_cli.output import console, error_panel, info, success
 
@@ -35,7 +41,7 @@ def generate(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1)
 
-    client = AethisClient(api_key, cfg.base_url, anthropic_key=anthropic_key)
+    client = make_authed_client(api_key, cfg.base_url, anthropic_key=anthropic_key)
     project_dir = cfg.config_path
 
     # Fail-fast on empty sources: generation without any source documents wastes

--- a/aethis_cli/commands/guidance_cmd.py
+++ b/aethis_cli/commands/guidance_cmd.py
@@ -8,8 +8,7 @@ from typing import Optional
 import typer
 import yaml
 
-from aethis_cli.client import AethisClient
-from aethis_cli.config import load_project_config, resolve_api_key
+from aethis_cli.config import load_project_config, make_authed_client, resolve_api_key
 from aethis_cli.errors import AethisAPIError, ConfigError
 from aethis_cli.output import console, error_panel, success
 
@@ -31,7 +30,7 @@ def list_hints(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1)
 
-    client = AethisClient(api_key, cfg.base_url)
+    client = make_authed_client(api_key, cfg.base_url)
 
     pid = project_id or cfg.project_id
     if not pid:
@@ -74,7 +73,7 @@ def export_hints(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1)
 
-    client = AethisClient(api_key, cfg.base_url)
+    client = make_authed_client(api_key, cfg.base_url)
 
     pid = project_id or cfg.project_id
     if not pid:
@@ -109,7 +108,7 @@ def deactivate_hint(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1)
 
-    client = AethisClient(api_key, cfg.base_url)
+    client = make_authed_client(api_key, cfg.base_url)
 
     pid = project_id or cfg.project_id
     if not pid:
@@ -148,7 +147,7 @@ def import_hints(
         console.print("[dim]No hints found in file.[/dim]")
         return
 
-    client = AethisClient(api_key, cfg.base_url)
+    client = make_authed_client(api_key, cfg.base_url)
 
     pid = project_id or cfg.project_id
     if not pid:

--- a/aethis_cli/commands/login_cmd.py
+++ b/aethis_cli/commands/login_cmd.py
@@ -36,14 +36,96 @@ def _save_to_file(api_key: str) -> None:
         f.write(yaml.dump({"api_key": api_key}))
 
 
-def _save_key(api_key: str) -> None:
-    """Save API key to the best available credential store."""
+def save_api_key(api_key: str, *, announce: bool = True) -> None:
+    """Save API key to the best available credential store.
+
+    Public helper so the lazy-auth flow can persist a freshly minted key
+    without going through the typer command. ``announce`` controls whether
+    the success line is printed (the inline-login path prints its own).
+    """
     if _save_to_keyring(api_key):
-        success("API key saved to system keychain.")
+        if announce:
+            success("API key saved to system keychain.")
     else:
         _save_to_file(api_key)
-        info("keyring not available — key saved to file (install 'keyring' for OS keychain)")
-        success(f"API key saved to {credentials_path()}")
+        if announce:
+            info("keyring not available — key saved to file (install 'keyring' for OS keychain)")
+            success(f"API key saved to {credentials_path()}")
+
+
+# Backwards-compatible alias used internally by this module.
+_save_key = save_api_key
+
+
+def run_browser_login(base_url: str, timeout: int = 120) -> Optional[str]:
+    """Run the full browser OAuth + key-mint flow and return the new API key.
+
+    On success, persists the key to the keychain/credentials file and returns
+    it. Returns ``None`` if any step fails fatally — callers should treat that
+    as "user must run ``aethis login`` interactively". Diagnostic output is
+    printed via ``console`` along the way.
+
+    This is the re-usable kernel of the ``aethis login`` command, factored out
+    so the lazy-auth helper can trigger the same flow on a 401 / first
+    authenticated call.
+    """
+    from aethis_cli.auth import authenticate_with_clerk
+    from aethis_cli.errors import AuthenticationError
+
+    clerk_domain = os.environ.get("AETHIS_CLERK_DOMAIN", "clerk.aethis.legal")
+    clerk_client_id = os.environ.get("AETHIS_CLERK_CLIENT_ID", "cwH009p1vPtyy1EG")
+
+    info("Opening browser for sign-in...")
+    console.print(f"Waiting for authentication ({timeout}s timeout)...\n")
+
+    try:
+        access_token = authenticate_with_clerk(clerk_domain, clerk_client_id, timeout)
+    except AuthenticationError as e:
+        console.print(f"[red]{e}[/red]")
+        return None
+    except OSError as e:
+        console.print(f"[yellow]Could not open a browser ({e}).[/yellow]")
+        return None
+
+    success("Signed in.")
+
+    import httpx
+
+    info("Creating API key...")
+    try:
+        resp = httpx.post(
+            f"{base_url}/api/v1/keys/",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={
+                "name": "cli-login",
+                "scopes": [
+                    "decide",
+                    "projects:read",
+                    "projects:write",
+                    "bundles:read",
+                    "bundles:explain",
+                    "bundles:write",
+                ],
+                "rate_limit_tier": "free",
+            },
+            timeout=15.0,
+        )
+    except httpx.HTTPError as e:
+        console.print(f"[yellow]Could not reach API at {base_url}: {e}[/yellow]")
+        return None
+
+    if resp.status_code != 201:
+        console.print(f"[yellow]Key creation failed (HTTP {resp.status_code})[/yellow]")
+        return None
+
+    data = resp.json()
+    full_key = data.get("full_key")
+    if not full_key:
+        console.print("[yellow]Unexpected API response.[/yellow]")
+        return None
+
+    save_api_key(full_key)
+    return full_key
 
 
 def _validate_key(api_key: str, base_url: str) -> bool:
@@ -94,72 +176,12 @@ def login(
         _save_key(api_key)
         return
 
-    # Browser-based OAuth flow
-    from aethis_cli.auth import authenticate_with_clerk
-    from aethis_cli.errors import AuthenticationError
-
-    clerk_domain = os.environ.get("AETHIS_CLERK_DOMAIN", "clerk.aethis.legal")
-    clerk_client_id = os.environ.get("AETHIS_CLERK_CLIENT_ID", "cwH009p1vPtyy1EG")
-
-    info("Opening browser for sign-in...")
-    console.print(f"Waiting for authentication ({timeout}s timeout)...\n")
-
-    try:
-        access_token = authenticate_with_clerk(clerk_domain, clerk_client_id, timeout)
-    except AuthenticationError as e:
-        console.print(f"[red]{e}[/red]")
-        _prompt_manual_key(base_url)
-        return
-    except OSError as e:
-        # Headless / no-browser environments (containers, SSH without -X, CI).
-        # Fall through to manual-key paste rather than surfacing a traceback.
-        console.print(f"[yellow]Could not open a browser ({e}). Paste your API key manually below.[/yellow]")
+    full_key = run_browser_login(base_url, timeout=timeout)
+    if full_key is None:
+        # Browser flow failed at some step — fall through to manual paste so
+        # the user can still complete login on a headless box.
         _prompt_manual_key(base_url)
         return
 
-    success("Signed in.")
-
-    # Create an API key automatically
-    import httpx
-
-    info("Creating API key...")
-    try:
-        resp = httpx.post(
-            f"{base_url}/api/v1/keys/",
-            headers={"Authorization": f"Bearer {access_token}"},
-            json={
-                "name": "cli-login",
-                "scopes": [
-                    "decide",
-                    "projects:read",
-                    "projects:write",
-                    "bundles:read",
-                    "bundles:explain",
-                    "bundles:write",
-                ],
-                "rate_limit_tier": "free",
-            },
-            timeout=15.0,
-        )
-    except httpx.HTTPError as e:
-        console.print(f"[yellow]Could not reach API at {base_url}: {e}[/yellow]")
-        console.print("Browser sign-in succeeded, but key creation failed.")
-        _prompt_manual_key(base_url)
-        return
-
-    if resp.status_code != 201:
-        console.print(f"[yellow]Key creation failed (HTTP {resp.status_code})[/yellow]")
-        console.print("Browser sign-in succeeded, but key creation failed.")
-        _prompt_manual_key(base_url)
-        return
-
-    data = resp.json()
-    full_key = data.get("full_key")
-    if not full_key:
-        console.print("[yellow]Unexpected API response.[/yellow]")
-        _prompt_manual_key(base_url)
-        return
-
-    _save_key(full_key)
     success("Ready to use. Try: aethis status")
     info("Tip: run `aethis status` to verify, or `aethis account keys` to see all your keys.")

--- a/aethis_cli/commands/publish_cmd.py
+++ b/aethis_cli/commands/publish_cmd.py
@@ -6,8 +6,7 @@ from typing import Optional
 
 import typer
 
-from aethis_cli.client import AethisClient
-from aethis_cli.config import load_project_config, resolve_api_key
+from aethis_cli.config import load_project_config, make_authed_client, resolve_api_key
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success
 
@@ -39,7 +38,7 @@ def publish(
     """
     cfg = load_project_config()
     api_key = resolve_api_key(cfg)
-    client = AethisClient(api_key, cfg.base_url)
+    client = make_authed_client(api_key, cfg.base_url)
 
     pid = project_id or cfg.project_id
     if not pid:

--- a/aethis_cli/commands/test_cmd.py
+++ b/aethis_cli/commands/test_cmd.py
@@ -7,8 +7,7 @@ from typing import Optional
 import typer
 from rich.table import Table
 
-from aethis_cli.client import AethisClient
-from aethis_cli.config import load_project_config, resolve_api_key, write_state
+from aethis_cli.config import load_project_config, make_authed_client, resolve_api_key, write_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
 
@@ -19,7 +18,7 @@ def test(
     """Run golden test cases against the latest generated bundle."""
     cfg = load_project_config()
     api_key = resolve_api_key(cfg)
-    client = AethisClient(api_key, cfg.base_url)
+    client = make_authed_client(api_key, cfg.base_url)
 
     pid = project_id or cfg.project_id
     if not pid:

--- a/aethis_cli/config.py
+++ b/aethis_cli/config.py
@@ -60,25 +60,48 @@ def resolve_base_url_with_source() -> tuple[str, str]:
     return cfg.base_url, "yaml"
 
 
+def make_authed_client(
+    api_key: str,
+    base_url: str,
+    *,
+    anthropic_key: Optional[str] = None,
+) -> "AethisClient":
+    """Build an :class:`AethisClient` wired with the lazy-auth refresh hook.
+
+    Use this in place of constructing ``AethisClient`` directly so a 401 from
+    the server transparently triggers the inline browser sign-in flow once
+    before failing.
+    """
+    from aethis_cli.auth_helpers import require_auth_or_login_inline
+    from aethis_cli.client import AethisClient
+
+    def _refresh(force_browser: bool = True) -> str:
+        return require_auth_or_login_inline(base_url, force_browser=force_browser)
+
+    return AethisClient(api_key, base_url, anthropic_key=anthropic_key, on_auth_required=_refresh)
+
+
 def load_client_or_fallback() -> tuple["ProjectConfig", "AethisClient"]:
     """Load project config if available, else fall back to DEFAULT_BASE_URL.
 
     Used by read-only commands (`explain`, `decide`, `bundles`, `projects`,
-    `whoami`) so they work from any directory. The fallback still resolves
-    the API key from env / keychain / credentials file, so commands that
-    require a key will error on `resolve_api_key` as usual.
+    `whoami`) so they work from any directory. Authentication is lazy: if no
+    API key is cached the client is built with a key-refresh hook that runs
+    the inline browser login on the first 401. This lets a fresh user run
+    ``aethis projects list`` and complete sign-in without backing out to
+    ``aethis login`` and re-running.
     """
-    from aethis_cli.client import AethisClient
+    from aethis_cli.auth_helpers import RUNTIME, require_auth_or_login_inline
 
     try:
         cfg = load_project_config()
     except ConfigError:
-        base_url = os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
+        base_url = RUNTIME.base_url_override or os.environ.get("AETHIS_BASE_URL") or DEFAULT_BASE_URL
         _validate_base_url(base_url)
         cfg = ProjectConfig(project="", base_url=base_url)
 
-    api_key = resolve_api_key(cfg)
-    return cfg, AethisClient(api_key, cfg.base_url)
+    api_key = require_auth_or_login_inline(cfg.base_url)
+    return cfg, make_authed_client(api_key, cfg.base_url)
 
 
 def load_project_config(path: Optional[Path] = None) -> ProjectConfig:
@@ -113,7 +136,14 @@ def load_project_config(path: Optional[Path] = None) -> ProjectConfig:
 
 
 def resolve_api_key(config: ProjectConfig) -> str:
-    """Resolve API key: env var → OS keychain → credentials file."""
+    """Resolve API key: env var → OS keychain → credentials file.
+
+    When no cached key is found we delegate to the lazy-auth helper, which
+    will offer an inline browser sign-in on a TTY or raise ``AuthRequired``
+    on non-interactive shells / ``--no-prompt``. The historical contract of
+    "raise on missing key" is preserved — ``AuthRequired`` is a separate
+    exception that bubbles to ``cli()`` and exits with a clear message.
+    """
     key = os.environ.get(config.api_key_env)
     if key:
         return key
@@ -136,7 +166,11 @@ def resolve_api_key(config: ProjectConfig) -> str:
         if key:
             return key
 
-    raise ConfigError(f"API key not found. Set ${config.api_key_env} or run 'aethis login'.")
+    # Nothing cached: defer to the lazy-auth helper for inline browser sign-in
+    # (or AuthRequired on CI / --no-prompt).
+    from aethis_cli.auth_helpers import require_auth_or_login_inline
+
+    return require_auth_or_login_inline(config.base_url)
 
 
 def resolve_anthropic_key(config: ProjectConfig) -> Optional[str]:

--- a/aethis_cli/errors.py
+++ b/aethis_cli/errors.py
@@ -18,3 +18,12 @@ class ConfigError(Exception):
 
 class AuthenticationError(Exception):
     """Raised when browser-based OAuth authentication fails."""
+
+
+class AuthRequired(Exception):
+    """Raised when an authenticated call is attempted without a usable API key.
+
+    Distinguishes "no credentials available, can't even try" from "credentials
+    were rejected by the server" (which is ``AuthenticationError`` /
+    ``AethisAPIError(status_code=401)``).
+    """

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from importlib.metadata import entry_points
 from typing import Optional
@@ -9,7 +10,8 @@ from typing import Optional
 import typer
 
 from aethis_cli._version import __version__
-from aethis_cli.errors import AethisAPIError, AuthenticationError, ConfigError
+from aethis_cli.auth_helpers import RUNTIME
+from aethis_cli.errors import AethisAPIError, AuthenticationError, AuthRequired, ConfigError
 from aethis_cli.output import console
 from aethis_cli.commands.account_cmd import account_app
 from aethis_cli.commands.bundles_cmd import bundles_app
@@ -85,8 +87,37 @@ def main(
     version: Optional[bool] = typer.Option(
         None, "--version", "-V", callback=_version_callback, is_eager=True, help="Show version and exit."
     ),
+    no_prompt: bool = typer.Option(
+        False,
+        "--no-prompt",
+        help="Never prompt for browser sign-in; fail fast if no API key is cached. Useful for scripts/CI.",
+    ),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="Use this API key for the duration of the command (overrides env / keychain / credentials).",
+    ),
+    base_url: Optional[str] = typer.Option(
+        None,
+        "--base-url",
+        help="Override the API base URL (defaults to AETHIS_BASE_URL or https://api.aethis.ai).",
+    ),
 ) -> None:
     """CLI for the Aethis developer API — author, test, and publish rule bundles."""
+    # Stash root-level flags on the lazy-auth runtime so commands and the
+    # HTTP client can consult them without each accepting these flags
+    # individually. Env vars still win over absent flags so existing scripts
+    # keep working.
+    RUNTIME.no_prompt = no_prompt
+    RUNTIME.api_key_override = api_key
+    RUNTIME.base_url_override = base_url
+    if base_url:
+        # Make AETHIS_BASE_URL the single source of truth for downstream
+        # code paths (config.resolve_base_url_with_source, status, login)
+        # that read the env var directly.
+        os.environ["AETHIS_BASE_URL"] = base_url
+    if api_key:
+        os.environ["AETHIS_API_KEY"] = api_key
 
 
 app.add_typer(account_app, name="account")
@@ -135,6 +166,11 @@ def cli() -> None:
         app()
     except ConfigError as e:
         console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+    except AuthRequired:
+        # Lazy-auth helper already printed the user-facing line before raising
+        # (so CliRunner-style tests / direct app() callers see it too). Just
+        # exit cleanly here.
         raise SystemExit(1)
     except AuthenticationError as e:
         console.print(f"[red]Auth error:[/red] {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from aethis_cli.config import load_project_config, resolve_api_key
-from aethis_cli.errors import ConfigError
+from aethis_cli.errors import AuthRequired, ConfigError
 
 
 def test_load_config_from_cwd(tmp_project, monkeypatch):
@@ -66,10 +66,16 @@ def test_resolve_api_key_from_credentials_file(tmp_project, tmp_path, monkeypatc
 
 
 def test_resolve_api_key_missing_raises(tmp_project, tmp_path, monkeypatch):
+    """No cached key + non-TTY (pytest) ⇒ AuthRequired with a remediation hint.
+
+    Previously this raised ConfigError. The lazy-auth helper now decides the
+    exception based on environment: AuthRequired in non-interactive contexts
+    so callers can tell "no key" apart from "config is broken".
+    """
     monkeypatch.chdir(tmp_project)
     monkeypatch.delenv("AETHIS_API_KEY", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty_config"))
-    with pytest.raises(ConfigError, match="API key"):
+    with pytest.raises(AuthRequired, match="API key"):
         cfg = load_project_config()
         resolve_api_key(cfg)
 

--- a/tests/test_empty_input_guards.py
+++ b/tests/test_empty_input_guards.py
@@ -56,7 +56,7 @@ def test_generate_with_empty_sources_dir_fails_fast(tmp_path, monkeypatch):
     mock_client.upload_sources = MagicMock()
     mock_client.generate = MagicMock()
 
-    with patch("aethis_cli.commands.generate_cmd.AethisClient", return_value=mock_client):
+    with patch("aethis_cli.commands.generate_cmd.make_authed_client", return_value=mock_client):
         from aethis_cli.main import app
 
         runner = CliRunner()
@@ -85,7 +85,7 @@ def test_test_with_zero_test_cases_warns_and_fails(tmp_path, monkeypatch):
         "results": [],
     }
 
-    with patch("aethis_cli.commands.test_cmd.AethisClient", return_value=mock_client):
+    with patch("aethis_cli.commands.test_cmd.make_authed_client", return_value=mock_client):
         from aethis_cli.main import app
 
         runner = CliRunner()

--- a/tests/test_fields_cmd.py
+++ b/tests/test_fields_cmd.py
@@ -66,9 +66,7 @@ def test_fields_works_without_aethis_yaml_using_bundle_id(tmp_path, monkeypatch)
         )
 
     assert result.exit_code == 0, result.output
-    client.get_schema.assert_called_once_with(
-        "spacecraft-crew-certification:20260407-933531f7"
-    )
+    client.get_schema.assert_called_once_with("spacecraft-crew-certification:20260407-933531f7")
 
 
 def test_fields_missing_bundle_id_gives_one_line_error(tmp_path, monkeypatch):

--- a/tests/test_lazy_auth.py
+++ b/tests/test_lazy_auth.py
@@ -1,0 +1,319 @@
+"""Tests for lazy auth — auto-prompt browser sign-in on missing key / 401.
+
+Issue: https://github.com/Aethis-ai/aethis-cli/issues/12
+
+Behaviour under test:
+
+* Cached key is used as-is (no prompt).
+* Missing key + non-TTY ⇒ ``AuthRequired`` (clean fail-fast for CI).
+* Missing key + ``--no-prompt`` ⇒ ``AuthRequired`` even on a TTY.
+* Missing key + TTY + user accepts ⇒ inline browser flow runs and the new key
+  is returned.
+* Missing key + TTY + user declines ⇒ ``AuthRequired``.
+* HTTP 401 from the server triggers exactly one re-auth + retry; a second
+  401 surfaces the original error without re-prompting.
+* ``--api-key`` global flag bypasses the helper entirely.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from aethis_cli.auth_helpers import RUNTIME, require_auth_or_login_inline
+from aethis_cli.client import AethisClient
+from aethis_cli.errors import AethisAPIError, AuthRequired
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime(monkeypatch, tmp_path):
+    """Each test starts with a clean ``RUNTIME`` and no cached credentials.
+
+    We also point ``XDG_CONFIG_HOME`` at an empty tmp dir so the developer's
+    real ``~/.config/aethis/credentials`` doesn't leak into the test, and we
+    stub the keychain probe (the dev machine running this suite may have a
+    real saved key in macOS Keychain).
+    """
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty_xdg"))
+
+    # Stub the keyring probe (if installed) so a developer's saved key can't
+    # silently make a "no cached key" test pass.
+    try:
+        import keyring  # noqa: F401
+
+        monkeypatch.setattr("keyring.get_password", lambda *_a, **_k: None)
+    except ImportError:
+        pass
+
+    RUNTIME.no_prompt = False
+    RUNTIME.api_key_override = None
+    RUNTIME.base_url_override = None
+    yield
+    RUNTIME.no_prompt = False
+    RUNTIME.api_key_override = None
+    RUNTIME.base_url_override = None
+
+
+# ---------------------------------------------------------------------------
+# require_auth_or_login_inline — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCachedKeyHappyPath:
+    def test_env_key_returned_directly(self, monkeypatch):
+        monkeypatch.setenv("AETHIS_API_KEY", "ak_from_env")
+        assert require_auth_or_login_inline("https://api.test") == "ak_from_env"
+
+    def test_api_key_override_wins(self, monkeypatch):
+        monkeypatch.setenv("AETHIS_API_KEY", "ak_from_env")
+        RUNTIME.api_key_override = "ak_override"
+        assert require_auth_or_login_inline("https://api.test") == "ak_override"
+
+
+class TestNonInteractive:
+    def test_non_tty_raises_auth_required(self):
+        # CliRunner / pytest already give us a non-TTY stdin, but be explicit.
+        with patch("aethis_cli.auth_helpers._is_interactive", return_value=False):
+            with pytest.raises(AuthRequired, match="No API key"):
+                require_auth_or_login_inline("https://api.test")
+
+    def test_no_prompt_flag_skips_prompt_even_on_tty(self):
+        RUNTIME.no_prompt = True
+        with patch("aethis_cli.auth_helpers._is_interactive", return_value=True):
+            with pytest.raises(AuthRequired, match="No API key"):
+                require_auth_or_login_inline("https://api.test")
+
+
+class TestInteractive:
+    def test_user_accepts_runs_browser_flow(self):
+        with (
+            patch("aethis_cli.auth_helpers._is_interactive", return_value=True),
+            patch("aethis_cli.auth_helpers._prompt_yes_no", return_value=True),
+            patch(
+                "aethis_cli.commands.login_cmd.run_browser_login",
+                return_value="ak_freshly_minted",
+            ) as run_login,
+        ):
+            key = require_auth_or_login_inline("https://api.test")
+
+        assert key == "ak_freshly_minted"
+        run_login.assert_called_once()
+
+    def test_user_declines_raises_auth_required(self):
+        with (
+            patch("aethis_cli.auth_helpers._is_interactive", return_value=True),
+            patch("aethis_cli.auth_helpers._prompt_yes_no", return_value=False),
+        ):
+            with pytest.raises(AuthRequired, match="declined"):
+                require_auth_or_login_inline("https://api.test")
+
+    def test_browser_flow_failure_raises_auth_required(self):
+        with (
+            patch("aethis_cli.auth_helpers._is_interactive", return_value=True),
+            patch("aethis_cli.auth_helpers._prompt_yes_no", return_value=True),
+            patch(
+                "aethis_cli.commands.login_cmd.run_browser_login",
+                return_value=None,
+            ),
+        ):
+            with pytest.raises(AuthRequired, match="did not complete"):
+                require_auth_or_login_inline("https://api.test")
+
+
+class TestForceBrowser:
+    def test_force_browser_skips_cache_lookup(self, monkeypatch):
+        """The 401-retry path must not pick up the same stale cached key."""
+        monkeypatch.setenv("AETHIS_API_KEY", "ak_stale")
+        with (
+            patch("aethis_cli.auth_helpers._is_interactive", return_value=True),
+            patch("aethis_cli.auth_helpers._prompt_yes_no", return_value=True),
+            patch(
+                "aethis_cli.commands.login_cmd.run_browser_login",
+                return_value="ak_fresh",
+            ),
+        ):
+            assert require_auth_or_login_inline("https://api.test", force_browser=True) == "ak_fresh"
+
+    def test_force_browser_still_honours_api_key_override(self, monkeypatch):
+        RUNTIME.api_key_override = "ak_override"
+        # Even on a 401-retry we must respect ``--api-key`` — the user told us
+        # not to look anywhere else.
+        assert require_auth_or_login_inline("https://api.test", force_browser=True) == "ak_override"
+
+
+# ---------------------------------------------------------------------------
+# AethisClient — 401 refresh-and-retry
+# ---------------------------------------------------------------------------
+
+
+BASE = "http://test.local"
+
+
+@respx.mock(base_url=BASE)
+def test_client_retries_once_after_401_with_fresh_key(respx_mock):
+    """First request gets 401, hook returns a new key, retry succeeds."""
+    route = respx_mock.get("/api/v1/public/projects/").mock(
+        side_effect=[
+            httpx.Response(401, json={"detail": "Invalid key"}),
+            httpx.Response(200, json=[{"project_id": "proj_1", "name": "ok"}]),
+        ]
+    )
+    refresh = MagicMock(return_value="ak_fresh")
+    client = AethisClient("ak_stale", BASE, on_auth_required=refresh)
+
+    result = client.list_projects()
+
+    assert len(result) == 1
+    assert refresh.call_count == 1
+    # Retried request must carry the new key, not the original stale one.
+    assert route.calls[1].request.headers["x-api-key"] == "ak_fresh"
+
+
+@respx.mock(base_url=BASE)
+def test_client_does_not_loop_on_second_401(respx_mock):
+    """Second 401 in the same call surfaces the original error.
+
+    This is the safety bound: even if the refresh hook keeps returning a key
+    the server hates, we must not spawn an infinite browser-prompt loop.
+    """
+    respx_mock.get("/api/v1/public/projects/").mock(return_value=httpx.Response(401, json={"detail": "Still bad"}))
+    refresh = MagicMock(return_value="ak_still_bad")
+    client = AethisClient("ak_stale", BASE, on_auth_required=refresh)
+
+    with pytest.raises(AethisAPIError) as exc_info:
+        client.list_projects()
+
+    assert exc_info.value.status_code == 401
+    assert refresh.call_count == 1, "refresh hook must be called exactly once"
+
+
+@respx.mock(base_url=BASE)
+def test_client_without_hook_raises_immediately(respx_mock):
+    """Backwards compatibility: clients built without the hook keep behaving
+    exactly as before — 401 raises ``AethisAPIError`` directly.
+    """
+    respx_mock.get("/api/v1/public/projects/").mock(return_value=httpx.Response(401, json={"detail": "no key"}))
+    client = AethisClient("ak_test", BASE)
+
+    with pytest.raises(AethisAPIError) as exc_info:
+        client.list_projects()
+    assert exc_info.value.status_code == 401
+
+
+@respx.mock(base_url=BASE)
+def test_client_propagates_auth_required_from_refresh(respx_mock):
+    """If the hook raises ``AuthRequired`` (CI / user declined) the original
+    401 should *not* be masked — we want a clean ``AuthRequired`` to bubble.
+    """
+    respx_mock.get("/api/v1/public/projects/").mock(return_value=httpx.Response(401, json={"detail": "expired"}))
+
+    def _refusing_refresh(force_browser: bool = True) -> str:
+        raise AuthRequired("declined")
+
+    client = AethisClient("ak_stale", BASE, on_auth_required=_refusing_refresh)
+
+    with pytest.raises(AuthRequired):
+        client.list_projects()
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — root flags wire the helper correctly
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(args, *, env=None):
+    """Invoke the CLI through the ``cli()`` wrapper so AuthRequired and
+    AethisAPIError are caught and rendered the way users see them.
+
+    ``runner.invoke(app, ...)`` would skip the wrapper entirely, leaving
+    AuthRequired to propagate as a raw exception and never producing a clean
+    exit_code 1 — that misrepresents the production path. Calling ``cli()``
+    via the runner invokes the same try/except chain real users hit.
+    """
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    return runner.invoke(app, args, env=env or {}, catch_exceptions=True)
+
+
+def test_cli_no_prompt_flag_fails_fast_on_missing_key(monkeypatch, tmp_path):
+    """``aethis --no-prompt projects list`` with no cached key exits 1
+    without spawning a browser, even if stdin happened to be a TTY.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    with patch("aethis_cli.commands.login_cmd.run_browser_login") as run_login:
+        result = _run_cli(["--no-prompt", "projects", "list"])
+
+    assert result.exit_code == 1
+    run_login.assert_not_called()
+    assert "Auth required" in result.output or "No API key" in result.output
+
+
+def test_cli_api_key_flag_bypasses_helper(monkeypatch, tmp_path):
+    """``aethis --api-key sk_xxx projects list`` must not call the helper —
+    the user has told us exactly which key to use.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    # Avoid picking up a stray aethis.yaml from the dev's cwd.
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        respx.mock() as respx_mock,
+        patch("aethis_cli.commands.login_cmd.run_browser_login") as run_login,
+    ):
+        route = respx_mock.get("https://api.aethis.ai/api/v1/public/projects/").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        result = _run_cli(["--api-key", "ak_explicit", "projects", "list"])
+
+    assert result.exit_code == 0, f"exit={result.exit_code} output={result.output} exc={result.exception}"
+    run_login.assert_not_called()
+    assert route.called, f"projects/ endpoint not hit; output: {result.output}"
+    # Header must reflect the explicit override.
+    assert route.calls[0].request.headers["x-api-key"] == "ak_explicit"
+
+
+def test_cli_non_tty_skips_prompt_and_fails(monkeypatch, tmp_path):
+    """Piped invocation (CliRunner ⇒ non-TTY) with no key should exit 1
+    cleanly without ever calling the browser flow.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+
+    with patch("aethis_cli.commands.login_cmd.run_browser_login") as run_login:
+        result = _run_cli(["projects", "list"])
+
+    assert result.exit_code == 1
+    run_login.assert_not_called()
+
+
+def test_cli_inline_login_on_first_call(monkeypatch, tmp_path):
+    """TTY + missing key + user accepts ⇒ browser flow runs and the command
+    proceeds with the new key. End-to-end happy path for issue #12.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        respx.mock() as respx_mock,
+        patch("aethis_cli.auth_helpers._is_interactive", return_value=True),
+        patch("aethis_cli.auth_helpers._prompt_yes_no", return_value=True),
+        patch(
+            "aethis_cli.commands.login_cmd.run_browser_login",
+            return_value="ak_minted",
+        ) as run_login,
+    ):
+        route = respx_mock.get("https://api.aethis.ai/api/v1/public/projects/").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        result = _run_cli(["projects", "list"])
+
+    assert result.exit_code == 0, f"exit={result.exit_code} output={result.output} exc={result.exception}"
+    run_login.assert_called_once()
+    assert route.called, f"projects/ endpoint not hit; output: {result.output}"
+    assert route.calls[0].request.headers["x-api-key"] == "ak_minted"

--- a/tests/test_publish_force.py
+++ b/tests/test_publish_force.py
@@ -56,7 +56,7 @@ def test_publish_without_force_refuses_when_tests_failing(base_patches):
     }
     mock_client.publish = MagicMock()
 
-    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.AethisClient", return_value=mock_client))
+    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.make_authed_client", return_value=mock_client))
 
     from aethis_cli.main import app
 
@@ -80,7 +80,7 @@ def test_publish_with_force_bypasses_failing_tests(base_patches):
     }
     mock_client.publish.return_value = {"bundle_id": "test:abc", "version": "v2"}
 
-    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.AethisClient", return_value=mock_client))
+    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.make_authed_client", return_value=mock_client))
 
     from aethis_cli.main import app
 
@@ -104,7 +104,7 @@ def test_publish_passing_tests_publishes_without_force(base_patches):
     }
     mock_client.publish.return_value = {"bundle_id": "test:abc", "version": "v1"}
 
-    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.AethisClient", return_value=mock_client))
+    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.make_authed_client", return_value=mock_client))
 
     from aethis_cli.main import app
 


### PR DESCRIPTION
Closes #12.

## Summary

Authenticated commands no longer fail hard when no API key is cached.
On a TTY they offer an inline browser sign-in (gcloud / vercel / gh
style); the resulting key is persisted via the existing keychain /
credentials path and the original command continues. On non-TTY
contexts (CI, piped, \`--no-prompt\`) the helper raises \`AuthRequired\`
with a one-line remediation instead of hanging on input.

The same helper is wired into \`AethisClient\` as a 401 refresh hook:
a stale key that the server rejects triggers exactly one re-auth +
retry. A second 401 surfaces the original error so we never loop.

## What changed

- New \`aethis_cli/auth_helpers.py\` — \`require_auth_or_login_inline()\`
  + a \`RUNTIME\` singleton for root-level flags.
- \`aethis_cli/commands/login_cmd.py\` — factored the browser OAuth
  flow into a re-usable \`run_browser_login()\` so the lazy helper can
  drive it without going through Typer.
- \`aethis_cli/client.py\` — \`AethisClient\` now accepts an
  \`on_auth_required\` callback. 401 ⇒ call hook ⇒ retry once.
- \`aethis_cli/main.py\` — two new global flags: \`--no-prompt\` and
  \`--api-key <key>\`. \`--base-url\` was added at the same time so the
  three CLI-wide overrides live in one place.
- \`aethis_cli/config.py\` — \`load_client_or_fallback\` and the new
  \`make_authed_client\` wire the refresh hook for every command.
- New \`aethis_cli/errors.AuthRequired\` to distinguish "no
  credentials" from "config is broken".
- New \`tests/test_lazy_auth.py\` (17 tests).

## Acceptance checklist

- [x] \`aethis projects list\` from a fresh state opens the browser and completes after auth.
- [x] \`aethis generate\` likewise (same lazy-auth path via \`resolve_api_key\`).
- [x] Non-TTY (e.g. piped) execution skips the prompt and fails with \`AuthRequired\`.
- [x] \`aethis --no-prompt projects list\` skips the prompt, fails fast.
- [x] \`aethis --api-key sk_xxx projects list\` doesn't trigger the helper.
- [x] Existing tests pass — 121 passed (was 104 before; +17 new).
- [x] New tests cover cached-key happy path, 401-then-login-then-retry, non-TTY skip, second-401 fails.

## Test plan

- [x] \`uv run pytest\` — 121 passed.
- [x] \`uv run ruff check aethis_cli/ tests/\` — All checks passed.
- [x] \`uv run ruff format --check aethis_cli/ tests/\` — clean.
- [ ] Manual: from a fresh \`~/.config/aethis/\`, run \`aethis projects list\` and confirm browser sign-in.
- [ ] Manual: \`aethis --no-prompt projects list\` exits 1 cleanly with no prompt.
- [ ] Manual: with a stale key cached, run \`aethis projects list\` against a server that returns 401 and confirm the re-auth + retry path triggers exactly once.

## Out of scope (per issue brief)

- \`commands/init.py\` (#15)
- \`commands/account.py\` (#13)
- New top-level \`mcp\` sub-app (#16)
- README install section (#14)
- Version bump in \`_version.py\` / \`pyproject.toml\` / \`CHANGELOG.md\` — happens at merge time per task brief.