### PR TITLE
docs: launch-readiness sweep — README Authentication + CLAUDE.md catch-up (0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1 (2026-05-01)
+
+- Docs: README gains a dedicated **Authentication** section explaining the three modes (`aethis login` for explicit setup, lazy auth for inline mid-command sign-in, `--no-prompt` for CI). Authoring quickstart leads with `aethis init` (the v0.7.0 wizard prompts for a name and runs sign-in itself, so `aethis login` as a separate step is no longer needed). Environment-variable table expanded to cover `AETHIS_BASE_URL` and `ANTHROPIC_API_KEY`. Troubleshooting entry for `Auth error` now mentions the lazy-auth prompt and `--no-prompt`. CLAUDE.md updated to document the `aethis mcp install` path, lazy-auth helper, and `--no-prompt` flag for future agents working on the CLI. No behaviour change.
+
 ## 0.7.0 (2026-05-01)
 
 - New: `aethis init` first-run wizard. With no args, prompts for the project name (default = current directory name); a positional `aethis init <name>` keeps working unchanged. If no API key is cached, triggers the same OAuth flow as `aethis login` *before* any filesystem writes — Ctrl-C during browser sign-in no longer leaves a half-scaffolded project on disk. After scaffolding, prints the next-step ladder (`aethis sections discover` → `fields discover` → `generate --poll`) so new users have a clear path forward. New `--no-prompt` flag for scripted use; with that flag, missing required values fail fast and missing auth surfaces a clean `AuthRequired` error instead of opening a browser. 10 new tests covering prompted, non-prompted, no-auth + interactive, no-auth + `--no-prompt`, and name-validation paths. Closes [#15](https://github.com/Aethis-ai/aethis-cli/issues/15).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Decision group (no key needed against public bundles):
 
 Project / authoring group (requires `projects:write`):
 
-- `aethis init <name>` — scaffold `.aethis/` + `aethis.yaml`
+- `aethis init` (or `aethis init <name>`) — first-run wizard: prompts for a name, runs `aethis login` if not authed, scaffolds `.aethis/` + `aethis.yaml`. As of v0.7.0 this runs auth *before* any filesystem writes so a Ctrl-C during the browser flow doesn't leave a half-scaffolded project.
 - `aethis sections discover --file <path>` — phase 1
 - `aethis fields discover --section <id>` / `aethis fields set` — phase 2
 - `aethis generate --poll` + `aethis test` + `aethis refine --hint ...` — phase 3 TDD loop
@@ -39,10 +39,21 @@ Project / authoring group (requires `projects:write`):
 
 Account:
 
-- `aethis login` / `aethis logout` / `aethis status`
-- `aethis account generate` — mint a new key via Clerk
+- `aethis login` / `aethis logout` / `aethis status` — `login` is the canonical first-time setup; mints + caches the key in one step.
+- `aethis account generate` — mint an *additional* key (rotation, multi-machine, scoped access). For first-time setup use `aethis login`.
+- `aethis account keys` / `aethis account revoke <key_id>`
 
-Global flags: `--base-url` and `--api-key` override the environment variables.
+MCP wiring (added v0.5.0):
+
+- `aethis mcp install --target <claude-code|cursor|claude-desktop|windsurf|all>` — writes the MCP server entry into the user's editor config. Idempotent, preserves any other configured servers.
+- `aethis mcp uninstall --target <client>` — reverses the install (removes only the `aethis` entry).
+- This is the documented install path; the [aethis-mcp](../aethis-mcp/) README's "Manual install" tabs are the fallback for users without `aethis-cli`.
+
+Global flags:
+
+- `--api-key <key>` — overrides the cached credential and the lazy-auth helper (one-shot).
+- `--no-prompt` — suppresses lazy-auth's "Open browser to sign in?" prompt (CI / scripts). Combined with no cached key, authenticated commands fail fast with a clean `AuthRequired` error.
+- `AETHIS_BASE_URL` env var — staff/dev override for the API host (staging or self-hosted). Not exposed as a CLI flag in the public build.
 
 ## Architecture
 
@@ -57,6 +68,7 @@ Global flags: `--base-url` and `--api-key` override the environment variables.
 - **Decision endpoints return `undetermined`, not an error, when fields are missing.** The shell exit code is still 0; parse the JSON decision field rather than relying on the exit code for eligibility-vs-incomplete distinctions.
 - **Slug namespace `aethis/*` is reserved.** External tenants will get HTTP 403 with `reason_code: reserved_namespace` if they try `--slug aethis/foo`. Internal use only.
 - **`aethis publish` runs tests server-side as a gate.** A green local `aethis test` can still be rejected at publish if the last generation's tests haven't been re-run after edits.
+- **Lazy auth is the default** (since v0.6.0). Authenticated commands without a cached key prompt the user inline ("Open browser to sign in? [Y/n]") and retry exactly once on success. The OAuth flow lives in [aethis_cli/commands/login_cmd.py](aethis_cli/commands/login_cmd.py) (`run_browser_login()`); the lazy-auth glue is in [aethis_cli/auth_helpers.py](aethis_cli/auth_helpers.py). When extending, reuse `require_auth_or_login_inline()` instead of re-implementing the prompt; honour `--no-prompt` and the `AethisClient.on_auth_required` hook so 401-refresh-and-retry stays consistent.
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -35,30 +35,65 @@ aethis fields -b <bundle_id>
 aethis explain -b <bundle_id>
 ```
 
+## Authentication
+
+Decision tools (`decide`, `fields`, `explain`) call public endpoints and never need a key. **Authoring tools** (`generate`, `publish`, `projects list`, etc.) need an API key — and the CLI manages that for you.
+
+There are three ways the key can arrive:
+
+**1. Explicit sign-in** (the canonical first-time setup):
+
+```bash
+aethis login
+```
+
+Opens your browser, completes Clerk OAuth, mints a fresh `ak_live_...` key, and stores it at `~/.config/aethis/credentials`. One-time per machine.
+
+**2. Lazy auth** (the default — since v0.6.0):
+
+If you skip step 1 and run an authenticated command directly, you'll get an inline prompt:
+
+```
+$ aethis init
+No API key found. Open browser to sign in? [Y/n]
+```
+
+Hit enter, the browser flow runs, the command resumes. Same effect as `aethis login` followed by your original command, in one step.
+
+**3. CI / scripts** — `--no-prompt`:
+
+For any non-interactive context (`stdin` not a TTY, CI runners, piped commands) the CLI auto-skips the prompt and exits with a clear `AuthRequired` error. To force this behaviour even on a TTY:
+
+```bash
+aethis --no-prompt projects list
+```
+
+Pass `--api-key <ak_live_...>` to bypass the cache entirely (useful when you want to test a key without committing to it).
+
+Manage existing keys with `aethis account keys` (list, masked) and `aethis account revoke <key_id>` (revoke). `aethis account generate` mints an *additional* key — for rotation, multi-machine setups, or scoped access. For first-time setup just use `aethis login`.
+
 ## Author your own rules
 
 Rule authoring is **invite-only private beta**. Decision tools (`aethis decide`, `aethis fields`, `aethis explain`) work immediately with no sign-up — this section is for approved beta tenants. [Request access →](https://aethis.ai/sign-up)
 
 ```bash
-# 1. Sign in (creates and stores an API key via browser)
-aethis login
-
-# 2. Initialise a project
-mkdir my-rules && cd my-rules
+# 1. Initialise a project (no-arg form prompts for a name; auto-runs `aethis login` if needed)
 aethis init
 
-# 3. Add source documents and guidance
+# 2. Add source documents and guidance
 #    (put PDFs/text in .aethis/sources/, hints in .aethis/guidance/hints.yaml)
 
-# 4. Generate a rule bundle
+# 3. Generate a rule bundle
 aethis generate
 
-# 5. Run test cases
+# 4. Run test cases
 aethis test
 
-# 6. Publish the bundle
+# 5. Publish the bundle
 aethis publish
 ```
+
+`aethis init` runs as a wizard: prompts for a project name (default = current directory), runs sign-in if you're not authed yet, scaffolds `.aethis/`, and prints the next-step ladder. Pass `--no-prompt` for scripted use (it'll fail fast on missing values rather than prompt).
 
 ## Try the example
 
@@ -196,7 +231,9 @@ tests:
 
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
-| `AETHIS_API_KEY` | Your API key (`ak_live_...`) | Authoring only | — |
+| `AETHIS_API_KEY` | Your API key (`ak_live_...`). Bypasses the cached credential. | Authoring only | — |
+| `AETHIS_BASE_URL` | Override the API host (staff/dev use; staging or self-hosted). | No | `https://api.aethis.ai` |
+| `ANTHROPIC_API_KEY` | Forwarded per-request to the generation endpoint when running `aethis generate`. Never stored server-side. | Authoring only | — |
 
 ## Extending with plugins
 
@@ -253,7 +290,7 @@ python3 -c "from datetime import date; print(date(2025,4,13).toordinal())"
 ```
 
 **`Auth error: …`**
-Your API key is missing, expired, or revoked. Run `aethis login` to paste a new one, or `aethis account generate` to create one.
+Your API key is missing, expired, or revoked. Run `aethis login` to mint a new one. (As of v0.6.0 the CLI prompts for sign-in inline when an authenticated command runs without a key; use `--no-prompt` to suppress that in CI.)
 
 **`403 Forbidden: missing scope`**
 Your key lacks the required scope for the command. `aethis whoami` shows what your current key can do. Contact support to upgrade scopes.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.7.0"
+version = "0.7.1"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Why

Today's session shipped 5 PRs (#17–#21, v0.4.3 → v0.7.0) that landed real UX improvements: lazy auth, init wizard, MCP install, login-vs-generate clarity, modern install instructions. An audit afterwards found the README and CLAUDE.md were still a release behind — they didn't explain lazy auth, didn't surface the new init wizard's no-arg form, and didn't mention `--no-prompt`. This PR closes that drift.

## What changed

**[README.md](README.md):**

- New **Authentication** section explaining the three sign-in modes:
  1. `aethis login` (explicit first-time)
  2. Lazy auth (inline browser prompt mid-command — the v0.6.0 default)
  3. `--no-prompt` for CI / scripts
- Authoring quickstart now leads with `aethis init` (the wizard runs login itself; the old separate `aethis login` step has been folded into the wizard description).
- Environment variables table expanded: adds `AETHIS_BASE_URL` (staff/dev override) and `ANTHROPIC_API_KEY` (forwarded per-request to `aethis generate`).
- Troubleshooting `Auth error` entry now mentions lazy auth and `--no-prompt`.

**[CLAUDE.md](CLAUDE.md):**

- Command taxonomy now lists the new `aethis mcp install` group, with a note that this is the documented install path and the [aethis-mcp](../aethis-mcp/) README's manual JSON tabs are the fallback.
- `aethis init` description updated to reflect the no-arg wizard + auth-before-filesystem-write semantics.
- Account section reframes `aethis login` as the canonical first-time entry; `aethis account generate` as the additional-key path.
- New "Lazy auth" gotcha pointing future agents at `auth_helpers.require_auth_or_login_inline()` and the `AethisClient.on_auth_required` hook so 401-refresh-and-retry stays consistent across new commands.
- New global-flags subsection documenting `--api-key` and `--no-prompt`.

## Pairs with

[Aethis-ai/docs#13](https://github.com/Aethis-ai/docs/pull/13) — the public docs site sweep that fixes `interfaces/cli.mdx` (stale `aethis account generate` first-time step) and `mcp-server/overview.mdx` (no `aethis mcp install` mention).

## Version bump

0.7.0 → **0.7.1** (patch — README + CLAUDE.md only, no code paths touched).

## Verification

Docs-only change. No tests added. README claims should still hold: `aethis init`, `aethis login`, `aethis mcp install`, `--no-prompt` all behave as documented (verified against shipped 0.7.0 code).

Closes the documentation drift identified in the post-merge audit. No specific issue number.