### PR TITLE
docs: sweep /sign-up references to /developer-access (v0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2 (2026-05-03)
+
+- Docs: replaced the stale `aethis.ai/sign-up` request-access link with `aethis.ai/developer-access` in the README "Author your own rules" section and in the `aethis whoami` hint shown when the active key has no authoring scope. After the Clerk cutover, `/sign-up` serves the Clerk SignUp form for invitees rather than the Notion request-access form, so external "Request access" pointers were broken. No code path changes.
+
 ## 0.7.1 (2026-05-01)
 
 - Docs: README gains a dedicated **Authentication** section explaining the three modes (`aethis login` for explicit setup, lazy auth for inline mid-command sign-in, `--no-prompt` for CI). Authoring quickstart leads with `aethis init` (the v0.7.0 wizard prompts for a name and runs sign-in itself, so `aethis login` as a separate step is no longer needed). Environment-variable table expanded to cover `AETHIS_BASE_URL` and `ANTHROPIC_API_KEY`. Troubleshooting entry for `Auth error` now mentions the lazy-auth prompt and `--no-prompt`. CLAUDE.md updated to document the `aethis mcp install` path, lazy-auth helper, and `--no-prompt` flag for future agents working on the CLI. No behaviour change.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Manage existing keys with `aethis account keys` (list, masked) and `aethis accou
 
 ## Author your own rules
 
-Rule authoring is **invite-only private beta**. Decision tools (`aethis decide`, `aethis fields`, `aethis explain`) work immediately with no sign-up — this section is for approved beta tenants. [Request access →](https://aethis.ai/sign-up)
+Rule authoring is **invite-only private beta**. Decision tools (`aethis decide`, `aethis fields`, `aethis explain`) work immediately with no sign-up — this section is for approved beta tenants. [Request access →](https://aethis.ai/developer-access)
 
 ```bash
 # 1. Initialise a project (no-arg form prompts for a name; auto-runs `aethis login` if needed)

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/aethis_cli/commands/whoami_cmd.py
+++ b/aethis_cli/commands/whoami_cmd.py
@@ -76,5 +76,5 @@ def whoami() -> None:
     else:
         console.print("[yellow]✗ Authoring not available[/yellow] — this key can only evaluate bundles.")
         console.print(
-            "[dim]Rule authoring is invite-only private beta. Request access at https://aethis.ai/sign-up[/dim]"
+            "[dim]Rule authoring is invite-only private beta. Request access at https://aethis.ai/developer-access[/dim]"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.7.1"
+version = "0.7.2"
 description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_whoami_cmd.py
+++ b/tests/test_whoami_cmd.py
@@ -64,7 +64,7 @@ def test_whoami_without_authoring_scope_points_to_signup():
     result = _run(client_mock=client)
     assert result.exit_code == 0, result.output
     assert "Authoring not available" in result.output
-    assert "aethis.ai/sign-up" in result.output
+    assert "aethis.ai/developer-access" in result.output
 
 
 def test_whoami_without_api_key_exits_with_hint():


### PR DESCRIPTION
## Summary

After the Clerk cutover, `aethis.ai/sign-up` now serves the Clerk SignUp form for invitees rather than the Notion request-access form. Two pointers in this repo were broken:

- `README.md` "Author your own rules" → "Request access →"
- `aethis whoami` hint shown when the active key lacks `projects:write`

Both now point at `aethis.ai/developer-access`. Test assertion updated to match.

Bumps patch `0.7.1 → 0.7.2` and rolls `CHANGELOG.md`. No code path changes.

Part of Epic A — Launch-ready DX (Aethis-ai/aethis-workspace#30, sub-issue A1b).
Closes #26.

## Test plan

- [x] `uv run pytest tests/test_whoami_cmd.py` — 3 passed.
- [x] `grep -rn "aethis.ai/sign-up" --include="*.py" --include="*.md" .` returns zero matches.
- [ ] Post-merge: tag `v0.7.2`, verify PyPI publishes.