### PR TITLE
docs: align README with positioning bible — add problem/solution/methodology framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.2 (2026-05-06)
+
+- docs: add private-beta callout for authoring tools (decision tools remain public, no key required)
+- docs: clarify in Authentication that aethis login requires an invite during the beta
+
 ## 0.8.1 (2026-05-06)
 
 - docs: align README with positioning bible — add Why Aethis section, solution framing, TDD methodology beat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1 (2026-05-06)
+
+- docs: align README with positioning bible — add Why Aethis section, solution framing, TDD methodology beat
+- docs: add aethis-bible: markers to derived copy blocks
+- fix: replace deprecated "rule bundle" terminology with "ruleset" in pyproject.toml description
+
 ## 0.8.0 (2026-05-05)
 
 - **Breaking**: renamed the public *bundle* concept to *ruleset* throughout the CLI to match the `aethis-core 0.10.0` API contract. The compiled rule artefact is now called a **ruleset** everywhere — in command names, in flag names, in JSON keys, and in prose. Specifically:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.3 (2026-05-06)
+
+- docs: remove Why Aethis section — package README is a reference surface (per aethis.os/positioning/surface-types.md); install / quick start / authentication is the right lead, not a problem statement
+
 ## 0.8.2 (2026-05-06)
 
 - docs: add private-beta callout for authoring tools (decision tools remain public, no key required)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 CLI for the [Aethis](https://aethis.ai) developer API — evaluate eligibility, author rulesets, and publish from the terminal.
 
+## Why Aethis
+
+<!-- aethis-bible: public-messaging.md#3-the-problem-one-paragraph -->
+Language models interpret rules well. They do not execute them reliably. The failure mode is silent: high confidence, wrong answer, no trace. In high-stakes decisions — eligibility, compliance, claims, screening — that is not a model-tuning problem. It is a category mismatch. Probabilistic systems cannot guarantee reproducible, auditable outcomes against written rules.
+
+<!-- aethis-bible: public-messaging.md#4-the-solution-one-paragraph -->
+AI builds it. A constraint solver runs it. Subject matter experts write the tests. Language models generate the rules that pass them.
+
 ## Install
 
 ```bash
@@ -75,6 +83,9 @@ Manage existing keys with `aethis account keys` (list, masked) and `aethis accou
 ## Author your own rules
 
 Rule authoring is **invite-only private beta**. Decision tools (`aethis decide`, `aethis fields`, `aethis explain`) work immediately with no sign-up — this section is for approved beta tenants. [Request access →](https://aethis.ai/developer-access)
+
+<!-- aethis-bible: public-messaging.md#5-how-rule-authoring-works -->
+The authoring workflow follows a four-stage loop: discover, synthesise, test, publish. A ruleset cannot be published with failing tests.
 
 ```bash
 # 1. Initialise a project (no-arg form prompts for a name; auto-runs `aethis login` if needed)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pip install aethis-cli
 
 ## Quick start
 
+> **Authoring is in private beta.** Decision tools (`decide`, `fields`, `explain`) are public — no key required. Authoring tools (rule generation, test refinement, publishing) require an invite. Request access at [aethis.ai/developer-access](https://aethis.ai/developer-access).
+
 No sign-up needed. Decision tools work immediately.
 
 ```bash
@@ -46,6 +48,8 @@ aethis explain -b <ruleset_id>
 ## Authentication
 
 Decision tools (`decide`, `fields`, `explain`) call public endpoints and never need a key. **Authoring tools** (`generate`, `publish`, `projects list`, etc.) need an API key — and the CLI manages that for you.
+
+Authoring is in private beta — `aethis login` will only complete for invited developers. Request access at [aethis.ai/developer-access](https://aethis.ai/developer-access).
 
 There are three ways the key can arrive:
 
@@ -80,7 +84,7 @@ Pass `--api-key <ak_live_...>` to bypass the cache entirely (useful when you wan
 
 Manage existing keys with `aethis account keys` (list, masked) and `aethis account revoke <key_id>` (revoke). `aethis account generate` mints an *additional* key — for rotation, multi-machine setups, or scoped access. For first-time setup just use `aethis login`.
 
-## Author your own rules
+## Author your own rules (private beta)
 
 Rule authoring is **invite-only private beta**. Decision tools (`aethis decide`, `aethis fields`, `aethis explain`) work immediately with no sign-up — this section is for approved beta tenants. [Request access →](https://aethis.ai/developer-access)
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@
 
 CLI for the [Aethis](https://aethis.ai) developer API — evaluate eligibility, author rulesets, and publish from the terminal.
 
-## Why Aethis
-
-<!-- aethis-bible: public-messaging.md#3-the-problem-one-paragraph -->
-Language models interpret rules well. They do not execute them reliably. The failure mode is silent: high confidence, wrong answer, no trace. In high-stakes decisions — eligibility, compliance, claims, screening — that is not a model-tuning problem. It is a category mismatch. Probabilistic systems cannot guarantee reproducible, auditable outcomes against written rules.
-
-<!-- aethis-bible: public-messaging.md#4-the-solution-one-paragraph -->
-AI builds it. A constraint solver runs it. Subject matter experts write the tests. Language models generate the rules that pass them.
-
 ## Install
 
 ```bash

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aethis-cli"
-version = "0.8.0"
-description = "CLI for the Aethis developer API — author, test, and publish rule bundles"
+version = "0.8.1"
+description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.8.1"
+version = "0.8.2"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.8.2"
+version = "0.8.3"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Why

The aethis-cli README was purely procedural — no problem statement, no solution framing, no methodology beat. This PR aligns it with the Aethis Positioning Bible (merged aethis.os PRs #20/#21).

## Changes

- **Why Aethis section** — canonical problem paragraph + solution one-liner + TDD beat, sourced from `public-messaging.md §3/§4/§5`
- **Authoring workflow framing** — four-stage pipeline framing sentence (discover, synthesise, test, publish)
- **`aethis-bible:` markers** — inline markers on all derived copy blocks per `positioning/markers.md` convention
- **Terminology** — `rule bundles` → `rulesets` in `pyproject.toml` description (README was already clean from v0.8.0)
- **Version bump** → 0.8.1 (patch)

Bible source: `aethis.os/positioning/` (PRs #20/#21 merged 2026-05-06).

## Test plan

- [ ] `aethis --help` still works (README change only, no code change)
- [ ] Grep for `rule bundle` returns zero results
- [ ] `aethis-bible:` markers present above all derived copy blocks