### PR TITLE
feat(publish): thread --force to server-side TDD gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.9.0 (2026-05-08)
+
+- feat(publish): thread `--force` through to the server-side TDD gate
+  introduced in `aethis-core` 0.11.0. `client.publish()` gains a
+  `force_unsafe: bool = False` keyword; `aethis publish --force` now
+  passes `force_unsafe: true` in the request body so the server-side
+  gate is bypassed (and a `publish_force_bypass` audit event is
+  recorded). Older engines ignore the field — no breakage. Without
+  `--force`, the new gate refuses publishing over a failing test
+  suite even when the CLI's own test gate is bypassed (e.g. by a
+  direct curl that doesn't use the CLI). Closes the cli/server
+  asymmetry that nearly shipped a 10/11 ruleset to a canonical
+  `aethis/*` slug on 2026-05-07.
+
 ## 0.8.4 (2026-05-07)
 
 - docs: link to docs.aethis.ai/agents/onboarding from MCP one-liner section

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.8.4"
+__version__ = "0.9.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -181,10 +181,21 @@ class AethisClient:
     def run_tests(self, project_id: str) -> dict:
         return self._request("POST", f"/api/v1/public/projects/{project_id}/test-run")
 
-    def publish(self, project_id: str, *, slug: str | None = None) -> dict:
+    def publish(
+        self,
+        project_id: str,
+        *,
+        slug: str | None = None,
+        force_unsafe: bool = False,
+    ) -> dict:
         body: dict = {}
         if slug is not None:
             body["slug"] = slug
+        if force_unsafe:
+            # Tell the server-side TDD gate (aethis-core 0.11+) to refuse a
+            # publish when stored test cases fail; force_unsafe=True records
+            # an audit event and proceeds. Older engines ignore the field.
+            body["force_unsafe"] = True
         kwargs: dict = {}
         if body:
             kwargs["json"] = body

--- a/aethis_cli/commands/publish_cmd.py
+++ b/aethis_cli/commands/publish_cmd.py
@@ -75,7 +75,11 @@ def publish(
             )
 
     try:
-        result = client.publish(pid, slug=slug)
+        # Thread --force to the server-side TDD gate (aethis-core 0.11+).
+        # Older engines ignore the field; newer ones refuse a publish over
+        # failing tests unless force_unsafe=True is explicit, in which case
+        # they record a publish_force_bypass audit event.
+        result = client.publish(pid, slug=slug, force_unsafe=force)
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.8.4"
+version = "0.9.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_publish_force.py
+++ b/tests/test_publish_force.py
@@ -113,3 +113,75 @@ def test_publish_passing_tests_publishes_without_force(base_patches):
 
     assert result.exit_code == 0, result.output
     mock_client.publish.assert_called_once()
+    # No --force on the wire either: server-side gate runs.
+    _, call_kwargs = mock_client.publish.call_args
+    assert call_kwargs.get("force_unsafe", False) is False
+
+
+def test_publish_force_threads_force_unsafe_to_server(base_patches):
+    """publish --force must pass force_unsafe=True so the server-side gate (aethis-core 0.11+) is also bypassed.
+
+    Without this, --force only bypassed the CLI's local gate while a direct
+    curl would have been refused by the server — and worse, prior to 0.11
+    the server didn't gate at all, so --force hid a real failure mode.
+    """
+    mock_client = MagicMock()
+    mock_client.run_tests.return_value = {
+        "passed": 2, "total": 5, "failed": 3, "errors": 0, "results": [],
+    }
+    mock_client.publish.return_value = {"ruleset_id": "test:abc", "version": "v2"}
+
+    base_patches.enter_context(patch("aethis_cli.commands.publish_cmd.make_authed_client", return_value=mock_client))
+
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["publish", "--force"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    mock_client.publish.assert_called_once()
+    _, call_kwargs = mock_client.publish.call_args
+    assert call_kwargs.get("force_unsafe") is True, (
+        "publish --force must pass force_unsafe=True to the client, "
+        f"got call_kwargs={call_kwargs}"
+    )
+
+
+def test_client_publish_includes_force_unsafe_in_body_when_set():
+    """AethisClient.publish(force_unsafe=True) puts the field on the wire."""
+    from aethis_cli.client import AethisClient
+
+    captured: dict = {}
+
+    class _StubClient(AethisClient):
+        def _request(self, method, path, **kw):
+            captured["method"] = method
+            captured["path"] = path
+            captured["kwargs"] = kw
+            return {"ok": True}
+
+    client = _StubClient(base_url="http://test.invalid", api_key="ak_test")
+    client.publish("proj_x", slug="foo/bar", force_unsafe=True)
+
+    assert captured["kwargs"]["json"]["force_unsafe"] is True
+    assert captured["kwargs"]["json"]["slug"] == "foo/bar"
+
+
+def test_client_publish_omits_force_unsafe_when_default():
+    """force_unsafe defaults to False and is omitted from the body to keep the wire payload minimal and old-engine compatible."""
+    from aethis_cli.client import AethisClient
+
+    captured: dict = {}
+
+    class _StubClient(AethisClient):
+        def _request(self, method, path, **kw):
+            captured["method"] = method
+            captured["path"] = path
+            captured["kwargs"] = kw
+            return {"ok": True}
+
+    client = _StubClient(base_url="http://test.invalid", api_key="ak_test")
+    client.publish("proj_x")
+
+    # No body => no kwargs at all
+    assert "json" not in captured["kwargs"], captured


### PR DESCRIPTION
## Summary

- `AethisClient.publish(force_unsafe=False)` is the new wire-level gate. When `True`, the body includes `force_unsafe: true`; otherwise the body stays minimal.
- `aethis publish --force` now threads `force_unsafe=True` through, matching the server-side gate landing in [aethis-core #76](https://github.com/Aethis-ai/aethis-core/pull/76).
- 3 new tests: `--force` → `force_unsafe=True`, default omits the field, body shape stays old-engine compatible.

## Why

The TDD gate at publish time has lived in this CLI: `client.run_tests()` then refuse on failures. `--force` bypassed that — but only client-side. A direct curl `POST /publish` was not gated at all on aethis-core ≤ 0.10.x, so the failure mode "ship a 10/11 ruleset to a canonical `aethis/*` slug" relied entirely on CLI users not passing `--force`. We hit that on 2026-05-07 with the construction-all-risks republish.

aethis-core 0.11.0 adds a server-side gate. This PR makes `--force` thread the bypass through so the gate behaviour is symmetric: with `--force`, both gates yield (and the server records a `publish_force_bypass` audit event). Without `--force`, both gates run.

## Compatibility

- Against engines `<= 0.10.x`: `force_unsafe` is silently ignored. Behaviour unchanged.
- Against engines `>= 0.11.0`: gate is enforced; `--force` bypasses with audit-log entry.

## Test plan

- [x] `uv run pytest tests/test_publish_force.py` — 6/6 pass (3 new + 3 pre-existing).
- [x] `uv run pytest` — full suite 144 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)