### PR TITLE
feat: public ruleset discovery + named credential profiles (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.10.0 (2026-05-10)
+
+- feat(rulesets): `aethis rulesets list --public` lists the cross-tenant
+  public showcase catalogue (no auth required). When run with no
+  `--project-id` and no project context, falls through to the public
+  catalogue automatically with a one-line hint — so a fresh signup
+  sees something the moment they install the CLI instead of an empty
+  list. Combine with `aethis fields -b <slug>` /
+  `aethis explain -b <slug>` / `aethis decide -b <slug>` to fully
+  exercise a ruleset without an API key.
+- feat(profiles): named credential profiles with both per-invocation
+  flag (`aethis --profile new-dev …`) and sticky default
+  (`aethis profile use new-dev`). Manage with `aethis profile
+  list/use/add/remove`. Reserved profile name `anonymous` forces
+  unsigned mode — handy for testing what a fresh signup sees without
+  losing your admin key. `aethis login --profile <name>` writes into
+  the named slot. Credentials file format upgraded to
+  `{active_profile, profiles: {...}}`; legacy single-key files are
+  read transparently and rewritten to the new shape on next save.
+- feat(client): `AethisClient(unsigned=True)` and
+  `make_anonymous_client()` helper for paths that must hit the
+  anonymous surface without accidentally sending a cached key.
+- feat(client): `client.list_public_rulesets(limit, offset)` wrapping
+  `GET /api/v1/public/rulesets`.
+
 ## 0.9.0 (2026-05-08)
 
 - feat(publish): thread `--force` through to the server-side TDD gate

--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ pip install aethis-cli
 No sign-up needed. Decision tools work immediately.
 
 ```bash
-# Evaluate eligibility against a published ruleset
-aethis decide -b <ruleset_id> -i '{"space.crew.age": 35, "space.medical.cert_valid": true}'
+# Browse the public showcase catalogue — no API key required
+aethis rulesets list
 
 # Inspect the input fields a ruleset expects
-aethis fields -b <ruleset_id>
+aethis fields -b <slug-or-ruleset_id>
 
 # Get human-readable rule descriptions
-aethis explain -b <ruleset_id>
+aethis explain -b <slug-or-ruleset_id>
+
+# Evaluate eligibility against a published ruleset
+aethis decide -b <slug-or-ruleset_id> -i '{"some.field": 35, "other.field": true}'
 ```
 
 ## Authentication
@@ -122,9 +125,11 @@ See `examples/spacecraft-crew-rules/README.md` for details.
 
 | Command | Description |
 |---------|-------------|
-| `aethis decide -b <ruleset_id> -i '<json>'` | Evaluate eligibility. Add `--explain` for trace output. |
-| `aethis fields -b <ruleset_id>` | Show input fields the ruleset expects |
-| `aethis explain -b <ruleset_id>` | Human-readable rule descriptions |
+| `aethis rulesets list` | Browse the public showcase catalogue (auto-falls through when no project context) |
+| `aethis rulesets list --public` | Same, explicit form |
+| `aethis decide -b <slug-or-ruleset_id> -i '<json>'` | Evaluate eligibility. Add `--explain` for trace output. |
+| `aethis fields -b <slug-or-ruleset_id>` | Show input fields the ruleset expects |
+| `aethis explain -b <slug-or-ruleset_id>` | Human-readable rule descriptions |
 
 ### Authoring
 
@@ -162,9 +167,50 @@ Project guidance lives in `.aethis/guidance/hints.yaml` and is uploaded by `aeth
 | Command | Description |
 |---------|-------------|
 | `aethis login` | Sign in and store an API key locally (first-time setup) |
+| `aethis login --profile <name>` | Sign in into a named profile slot (keeps `default` untouched) |
 | `aethis account generate` | Mint an additional API key (rotation, multi-machine, scoped access) |
 | `aethis account keys` | List your API keys (masked) |
 | `aethis account revoke <key_id>` | Revoke a key |
+
+### Profiles
+
+Multiple credential profiles let you keep separate personas — say, an admin
+key plus a "fresh signup" perspective — and switch between them without
+re-authenticating. The reserved profile name `anonymous` forces unsigned
+mode (no `X-API-Key` header sent), so you can verify exactly what an
+unauthenticated user would see.
+
+```bash
+# Create profiles (or use `aethis login --profile <name>` for OAuth)
+aethis profile add admin --api-key ak_live_…
+aethis profile add new-dev --api-key ak_test_…
+
+# See them, with `*` next to the active one
+aethis profile list
+
+# Switch the sticky default
+aethis profile use new-dev
+
+# One-off override (doesn't change the sticky default)
+aethis --profile admin rulesets list
+aethis --profile anonymous rulesets list   # forces public-mode
+
+# Delete one
+aethis profile remove new-dev
+```
+
+Profile selection order: `--profile` flag > `AETHIS_PROFILE` env > the
+sticky `active_profile` field in `~/.config/aethis/credentials` >
+`default`. The `AETHIS_API_KEY` env var still takes precedence over all
+profile machinery — set it to short-circuit the cache for one
+invocation.
+
+| Command | Description |
+|---------|-------------|
+| `aethis profile list` | Show all profiles + which one is active |
+| `aethis profile use <name>` | Set the sticky default profile |
+| `aethis profile add <name> [--api-key …]` | Create or update a named profile |
+| `aethis profile remove <name>` | Delete a profile |
 
 ## MCP one-liner
 
@@ -240,7 +286,8 @@ tests:
 
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
-| `AETHIS_API_KEY` | Your API key (`ak_live_...`). Bypasses the cached credential. | Authoring only | — |
+| `AETHIS_API_KEY` | Your API key (`ak_live_...`). Bypasses the cached credential and any profile machinery. | Authoring only | — |
+| `AETHIS_PROFILE` | Select a named credential profile (overrides the sticky default; see `aethis profile`). | No | `default` |
 | `AETHIS_BASE_URL` | Override the API host (staff/dev use; staging or self-hosted). | No | `https://api.aethis.ai` |
 | `ANTHROPIC_API_KEY` | Forwarded per-request to the generation endpoint when running `aethis generate`. Never stored server-side. | Authoring only | — |
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/aethis_cli/auth_helpers.py
+++ b/aethis_cli/auth_helpers.py
@@ -37,6 +37,7 @@ class RuntimeOptions:
     no_prompt: bool = False
     api_key_override: Optional[str] = None
     base_url_override: Optional[str] = None
+    profile_override: Optional[str] = None
 
 
 # Module-level singleton; ``main.cli`` populates it before dispatching.
@@ -56,46 +57,77 @@ def _is_interactive() -> bool:
 
 
 def _resolve_cached_key() -> Optional[str]:
-    """Return the cached key without raising. Mirrors ``resolve_api_key``'s
-    fallback chain (env > keychain > credentials file) but never errors out.
+    """Return the cached key for the active profile, or None if none is found.
+
+    Resolution order:
+
+    1. ``AETHIS_API_KEY`` env — always wins (back-compat with single-key
+       scripts; matches the precedent that direct env overrides beat any
+       profile machinery).
+    2. The active profile's ``api_key`` field in ``~/.config/aethis/credentials``.
+    3. For the ``default`` profile only: the OS keychain (legacy single-key
+       storage location).
+    4. Legacy ``.yaml``-suffixed credentials file (older builds).
     """
     key = os.environ.get("AETHIS_API_KEY")
     if key:
         return key
 
-    try:
-        import keyring  # type: ignore[import-not-found]
+    from aethis_cli.config import (
+        ANONYMOUS_PROFILE,
+        DEFAULT_PROFILE,
+        active_profile_name,
+        get_profile,
+    )
 
-        key = keyring.get_password("aethis-cli", "api_key")
-        if key:
-            return key
-    except Exception:
-        pass
+    profile_name = active_profile_name()
+    if profile_name == ANONYMOUS_PROFILE:
+        return None
 
-    from pathlib import Path
+    profile = get_profile(profile_name)
+    if profile.get("api_key"):
+        return profile["api_key"]
 
-    import yaml  # type: ignore[import-untyped]
-
-    from aethis_cli.config import credentials_path
-
-    creds = credentials_path()
-    if creds.exists():
+    # Keychain only stores the default profile's key. Other profiles are
+    # file-only — keep the keychain interface single-tenant to stay
+    # backwards-compatible with pre-profile installs.
+    if profile_name == DEFAULT_PROFILE:
         try:
-            raw = yaml.safe_load(creds.read_text()) or {}
-            cached = raw.get("api_key")
+            import keyring  # type: ignore[import-not-found]
+
+            cached = keyring.get_password("aethis-cli", "api_key")
             if cached:
                 return cached
         except Exception:
             pass
-    # Older builds wrote a `.yaml` extension; honour that too.
-    legacy = Path(str(creds) + ".yaml")
-    if legacy.exists():
-        try:
-            raw = yaml.safe_load(legacy.read_text()) or {}
-            return raw.get("api_key")
-        except Exception:
-            pass
+
+        from pathlib import Path
+
+        import yaml  # type: ignore[import-untyped]
+
+        from aethis_cli.config import credentials_path
+
+        legacy = Path(str(credentials_path()) + ".yaml")
+        if legacy.exists():
+            try:
+                raw = yaml.safe_load(legacy.read_text()) or {}
+                return raw.get("api_key")
+            except Exception:
+                pass
     return None
+
+
+def is_anonymous_active() -> bool:
+    """Return True when the active profile is the reserved ``anonymous`` slot.
+
+    Callers that build an authenticated client should use this to short-circuit
+    to ``make_anonymous_client`` instead, so an admin who runs
+    ``aethis --profile anonymous rulesets list`` doesn't accidentally fall
+    through to the inline browser sign-in flow.
+    """
+    from aethis_cli.config import ANONYMOUS_PROFILE, active_profile_name
+
+    return active_profile_name() == ANONYMOUS_PROFILE
 
 
 def _prompt_yes_no(message: str, default: bool = True) -> bool:
@@ -139,6 +171,18 @@ def require_auth_or_login_inline(
     """
     if RUNTIME.api_key_override:
         return RUNTIME.api_key_override
+
+    if is_anonymous_active():
+        # ``--profile anonymous`` is an explicit "use no key" — surface that
+        # decision instead of silently falling into the browser flow.
+        message = (
+            "Active profile is 'anonymous' — this command requires an API key. "
+            "Switch profiles with `aethis profile use <name>` or pass --profile <name>."
+        )
+        from aethis_cli.output import console
+
+        console.print(f"[red]Auth required:[/red] {message}")
+        raise AuthRequired(message)
 
     if not force_browser:
         cached = _resolve_cached_key()

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -20,12 +20,18 @@ class AethisClient:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: Optional[str] = None,
         base_url: str = "https://api.aethis.ai",
         anthropic_key: Optional[str] = None,
         on_auth_required: Optional[KeyRefreshCallback] = None,
+        *,
+        unsigned: bool = False,
     ) -> None:
-        headers: dict[str, str] = {"X-API-Key": api_key}
+        # ``unsigned=True`` skips the X-API-Key header so anonymous endpoints
+        # (e.g. the public ruleset catalogue) can be hit from the same client.
+        headers: dict[str, str] = {}
+        if api_key and not unsigned:
+            headers["X-API-Key"] = api_key
         if anthropic_key:
             headers["X-Anthropic-Key"] = anthropic_key
         self._client = httpx.Client(
@@ -36,8 +42,9 @@ class AethisClient:
         )
         # Hook called once when the server returns 401. If it returns a new
         # key the request is retried exactly once with the refreshed header;
-        # a second 401 surfaces the original error so we never loop.
-        self._on_auth_required = on_auth_required
+        # a second 401 surfaces the original error so we never loop. Disabled
+        # for unsigned clients — there's no key to refresh.
+        self._on_auth_required = None if unsigned else on_auth_required
 
     def close(self) -> None:
         self._client.close()
@@ -211,6 +218,19 @@ class AethisClient:
             params["status"] = status
         return self._request("GET", f"/api/v1/public/projects/{project_id}/rulesets", params=params)
 
+    def list_public_rulesets(self, limit: int = 20, offset: int = 0) -> list[dict]:
+        """List published rulesets visible to anonymous callers.
+
+        Hits the cross-tenant catalogue (``visibility="public"`` only). Works
+        whether the client was constructed with ``unsigned=True`` or with a
+        valid key — the server filters on visibility either way.
+        """
+        return self._request(
+            "GET",
+            "/api/v1/public/rulesets",
+            params={"limit": str(limit), "offset": str(offset)},
+        )
+
     def archive_project(self, project_id: str) -> dict:
         return self._request("POST", f"/api/v1/public/projects/{project_id}/archive")
 
@@ -233,3 +253,14 @@ class AethisClient:
 
     def list_domain_guidance(self, domain: str) -> list:
         return self._request("GET", f"/api/v1/public/domains/{domain}/guidance")
+
+
+def make_anonymous_client(base_url: str = "https://api.aethis.ai") -> AethisClient:
+    """Construct a key-less client for anonymous endpoints (public catalogue, decide).
+
+    Skips the ``X-API-Key`` header and disables the 401-refresh hook. Use this
+    in command paths that explicitly target the public surface so an admin's
+    cached key doesn't accidentally promote anonymous calls to authenticated
+    ones (which would leak their tenant's rulesets into the response).
+    """
+    return AethisClient(api_key=None, base_url=base_url, unsigned=True)

--- a/aethis_cli/commands/account_cmd.py
+++ b/aethis_cli/commands/account_cmd.py
@@ -9,7 +9,7 @@ import httpx
 import typer
 
 from aethis_cli.auth import authenticate_with_clerk
-from aethis_cli.commands.login_cmd import _save_to_keyring, _save_to_file
+from aethis_cli.commands.login_cmd import save_api_key
 from aethis_cli.config import DEFAULT_BASE_URL
 from aethis_cli.errors import AuthenticationError
 from aethis_cli.output import console, info, success
@@ -184,11 +184,7 @@ def generate(
     if no_save:
         info("--no-save specified. Key not saved to credential store.")
     else:
-        if _save_to_keyring(full_key):
-            success("API key saved to system keychain.")
-        else:
-            _save_to_file(full_key)
-            success("API key saved to credentials file.")
+        save_api_key(full_key)
 
 
 @account_app.command()

--- a/aethis_cli/commands/login_cmd.py
+++ b/aethis_cli/commands/login_cmd.py
@@ -6,9 +6,16 @@ import os
 from typing import Optional
 
 import typer
-import yaml
 
-from aethis_cli.config import DEFAULT_BASE_URL, credentials_path
+from aethis_cli.config import (
+    ANONYMOUS_PROFILE,
+    DEFAULT_BASE_URL,
+    DEFAULT_PROFILE,
+    active_profile_name,
+    credentials_path,
+    set_profile,
+)
+from aethis_cli.errors import ConfigError
 from aethis_cli.output import console, info, success
 
 _KEYRING_SERVICE = "aethis-cli"
@@ -26,38 +33,44 @@ def _save_to_keyring(api_key: str) -> bool:
         return False
 
 
-def _save_to_file(api_key: str) -> None:
-    """Fallback: store key in ~/.config/aethis/credentials (0600)."""
-    creds = credentials_path()
-    creds.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    # Atomic create with correct permissions — avoids TOCTOU race
-    fd = os.open(str(creds), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(yaml.dump({"api_key": api_key}))
-
-
-def save_api_key(api_key: str, *, announce: bool = True) -> None:
-    """Save API key to the best available credential store.
+def save_api_key(api_key: str, *, profile: Optional[str] = None, announce: bool = True) -> None:
+    """Save API key to the best available credential store for ``profile``.
 
     Public helper so the lazy-auth flow can persist a freshly minted key
     without going through the typer command. ``announce`` controls whether
     the success line is printed (the inline-login path prints its own).
+
+    Resolution:
+    * ``profile=None`` → use the currently active profile.
+    * Default profile → try OS keychain first (legacy single-key location);
+      fall back to the credentials file's ``profiles.default`` slot.
+    * Any other profile → write directly to the credentials file.
+    * Reserved ``anonymous`` profile → refuse.
     """
-    if _save_to_keyring(api_key):
+    target = profile or active_profile_name()
+    if target == ANONYMOUS_PROFILE:
+        raise ConfigError(
+            f"Cannot save a key to the reserved '{ANONYMOUS_PROFILE}' profile. "
+            "Pick a different profile name with --profile."
+        )
+
+    if target == DEFAULT_PROFILE and _save_to_keyring(api_key):
         if announce:
-            success("API key saved to system keychain.")
-    else:
-        _save_to_file(api_key)
-        if announce:
+            success("API key saved to system keychain (profile: default).")
+        return
+
+    set_profile(target, api_key=api_key)
+    if announce:
+        if target == DEFAULT_PROFILE:
             info("keyring not available — key saved to file (install 'keyring' for OS keychain)")
-            success(f"API key saved to {credentials_path()}")
+        success(f"API key saved to {credentials_path()} (profile: {target}).")
 
 
 # Backwards-compatible alias used internally by this module.
 _save_key = save_api_key
 
 
-def run_browser_login(base_url: str, timeout: int = 120) -> Optional[str]:
+def run_browser_login(base_url: str, timeout: int = 120, *, profile: Optional[str] = None) -> Optional[str]:
     """Run the full browser OAuth + key-mint flow and return the new API key.
 
     On success, persists the key to the keychain/credentials file and returns
@@ -124,7 +137,7 @@ def run_browser_login(base_url: str, timeout: int = 120) -> Optional[str]:
         console.print("[yellow]Unexpected API response.[/yellow]")
         return None
 
-    save_api_key(full_key)
+    save_api_key(full_key, profile=profile)
     return full_key
 
 
@@ -143,7 +156,7 @@ def _validate_key(api_key: str, base_url: str) -> bool:
         return True  # Network error — don't block save, let commands fail with context
 
 
-def _prompt_manual_key(base_url: str) -> None:
+def _prompt_manual_key(base_url: str, *, profile: Optional[str] = None) -> None:
     """Fall back to manual key entry."""
     console.print()
     console.print("Paste an API key from https://aethis.legal/dashboard/api-keys")
@@ -155,7 +168,7 @@ def _prompt_manual_key(base_url: str) -> None:
     if not _validate_key(api_key, base_url):
         console.print("[red]That key was rejected by the API (HTTP 401). Check it and try again.[/red]")
         raise typer.Exit(code=1)
-    _save_key(api_key)
+    _save_key(api_key, profile=profile)
 
 
 def login(
@@ -166,21 +179,35 @@ def login(
         help="Paste an existing API key instead of browser sign-in.",
     ),
     timeout: int = typer.Option(120, "--timeout", help="Browser auth timeout in seconds"),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help=(
+            "Save the new key into a named profile slot instead of the active one. "
+            "Useful for keeping admin and dev personas side-by-side."
+        ),
+    ),
 ) -> None:
     """Sign in and store an API key locally. First-time setup — this is all you need."""
+    if profile == ANONYMOUS_PROFILE:
+        console.print(
+            f"[red]Cannot log in to the reserved '{ANONYMOUS_PROFILE}' profile — it always means 'use no key'.[/red]"
+        )
+        raise typer.Exit(code=1)
+
     base_url = os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
     if api_key:
         if not _validate_key(api_key, base_url):
             console.print("[red]That key was rejected by the API (HTTP 401). Check it and try again.[/red]")
             raise typer.Exit(code=1)
-        _save_key(api_key)
+        _save_key(api_key, profile=profile)
         return
 
-    full_key = run_browser_login(base_url, timeout=timeout)
+    full_key = run_browser_login(base_url, timeout=timeout, profile=profile)
     if full_key is None:
         # Browser flow failed at some step — fall through to manual paste so
         # the user can still complete login on a headless box.
-        _prompt_manual_key(base_url)
+        _prompt_manual_key(base_url, profile=profile)
         return
 
     success("Ready to use. Try: aethis status")

--- a/aethis_cli/commands/profile_cmd.py
+++ b/aethis_cli/commands/profile_cmd.py
@@ -1,0 +1,153 @@
+"""aethis profile — manage named credential profiles (admin/dev personas).
+
+Profiles let you keep multiple API keys side by side and switch between them
+either per-invocation (``aethis --profile new-dev rulesets list``) or
+stickily (``aethis profile use new-dev``). The reserved name ``anonymous``
+forces unsigned mode so you can see exactly what a fresh signup would see.
+
+The credentials are stored at ``~/.config/aethis/credentials`` (mode 0600);
+see :mod:`aethis_cli.config` for the file format.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+from rich.table import Table
+
+from aethis_cli.config import (
+    ANONYMOUS_PROFILE,
+    DEFAULT_PROFILE,
+    active_profile_name,
+    get_profile,
+    load_credentials,
+    remove_profile,
+    set_active_profile,
+    set_profile,
+)
+from aethis_cli.errors import ConfigError
+from aethis_cli.output import console, success
+
+profile_app = typer.Typer(
+    name="profile",
+    help="Manage named credential profiles (switch between admin / dev personas).",
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,
+)
+
+
+def _mask_key(api_key: Optional[str]) -> str:
+    if not api_key:
+        return "[dim](unsigned)[/dim]"
+    if len(api_key) <= 12:
+        return "***"
+    return f"{api_key[:7]}…{api_key[-4:]}"
+
+
+@profile_app.command(name="list")
+def list_profiles() -> None:
+    """Show all configured profiles and which one is active."""
+    creds = load_credentials()
+    active = active_profile_name()
+    profiles = creds["profiles"]
+
+    # Always surface the reserved 'anonymous' slot so users know it's available
+    # even before they configure a real profile.
+    names = sorted(set(profiles.keys()) | {DEFAULT_PROFILE, ANONYMOUS_PROFILE})
+
+    table = Table(title="Profiles")
+    table.add_column("", width=1)
+    table.add_column("Name", style="cyan")
+    table.add_column("API Key")
+    table.add_column("Base URL")
+
+    for name in names:
+        profile = profiles.get(name, {})
+        marker = "*" if name == active else ""
+        if name == ANONYMOUS_PROFILE:
+            key_display = "[dim](no key — anonymous mode)[/dim]"
+        else:
+            key_display = _mask_key(profile.get("api_key"))
+        base_display = profile.get("base_url", "[dim](default)[/dim]")
+        table.add_row(marker, name, key_display, base_display)
+
+    console.print(table)
+    console.print(f"\nActive: [cyan]{active}[/cyan]")
+
+
+@profile_app.command(name="use")
+def use_profile(name: str = typer.Argument(..., help="Profile name to make sticky")) -> None:
+    """Set the sticky default profile.
+
+    The new profile takes effect for all subsequent ``aethis`` invocations
+    unless overridden by ``--profile`` or ``AETHIS_PROFILE``.
+    """
+    if name != ANONYMOUS_PROFILE and not get_profile(name):
+        console.print(
+            f"[yellow]Profile '{name}' is empty (no API key set).[/yellow] "
+            f"Run `aethis login --profile {name}` to populate it."
+        )
+    try:
+        set_active_profile(name)
+    except ConfigError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+    success(f"Active profile is now '{name}'.")
+
+
+@profile_app.command(name="add")
+def add_profile(
+    name: str = typer.Argument(..., help="Profile name (e.g. 'admin', 'new-dev')"),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        "-k",
+        help="API key for this profile (omit to OAuth-login later via `aethis login --profile <name>`).",
+    ),
+    base_url: Optional[str] = typer.Option(
+        None,
+        "--base-url",
+        help="Override the API base URL for this profile (e.g. http://localhost:8080).",
+    ),
+) -> None:
+    """Create or update a named profile."""
+    try:
+        set_profile(name, api_key=api_key, base_url=base_url)
+    except ConfigError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+    if api_key:
+        success(f"Profile '{name}' saved.")
+    else:
+        success(f"Profile '{name}' created without a key. Run `aethis login --profile {name}` to authenticate.")
+
+
+@profile_app.command(name="remove")
+def remove_profile_cmd(
+    name: str = typer.Argument(..., help="Profile name to delete"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Allow removing the currently active profile (resets active to 'default').",
+    ),
+) -> None:
+    """Delete a profile from the credentials file."""
+    if name == ANONYMOUS_PROFILE:
+        console.print(
+            f"[yellow]'{ANONYMOUS_PROFILE}' is a reserved profile, not stored on disk — nothing to remove.[/yellow]"
+        )
+        return
+    if name == active_profile_name() and not force:
+        console.print(
+            f"[red]Refusing to remove active profile '{name}'.[/red] "
+            "Switch with `aethis profile use <other>` first, or pass --force."
+        )
+        raise typer.Exit(code=1)
+    try:
+        remove_profile(name)
+    except ConfigError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+    success(f"Profile '{name}' removed.")

--- a/aethis_cli/commands/rulesets_cmd.py
+++ b/aethis_cli/commands/rulesets_cmd.py
@@ -7,8 +7,9 @@ from typing import Optional
 import typer
 from rich.table import Table
 
+from aethis_cli.client import make_anonymous_client
 from aethis_cli.commands._id_utils import require_ruleset_id
-from aethis_cli.config import load_client_or_fallback
+from aethis_cli.config import load_client_or_fallback, resolve_base_url_with_source
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success, warn
 
@@ -20,28 +21,93 @@ rulesets_app = typer.Typer(
 )
 
 
+def _print_public_table(rulesets: list[dict]) -> None:
+    table = Table(title="Public showcase rulesets")
+    table.add_column("Slug", style="cyan")
+    table.add_column("Ruleset ID", style="dim")
+    table.add_column("Description")
+    table.add_column("Fields", justify="right")
+    table.add_column("Rules", justify="right")
+
+    for r in rulesets:
+        table.add_row(
+            r.get("slug") or "[dim]—[/dim]",
+            r.get("ruleset_id", ""),
+            r.get("description", "") or "[dim]—[/dim]",
+            str(r.get("field_count", 0)),
+            str(r.get("rule_count", 0)),
+        )
+
+    console.print(table)
+
+
+def _list_public(limit: int, offset: int) -> None:
+    """Hit the anonymous catalogue endpoint and render the result."""
+    base_url, _ = resolve_base_url_with_source()
+    with make_anonymous_client(base_url) as client:
+        try:
+            rulesets = client.list_public_rulesets(limit=limit, offset=offset)
+        except AethisAPIError as e:
+            error_panel(e)
+            raise typer.Exit(code=1)
+
+    if not rulesets:
+        console.print("[dim]No public rulesets published yet.[/dim]")
+        return
+
+    _print_public_table(rulesets)
+    console.print(
+        "\n[dim]Try: aethis fields -b <slug>  ·  aethis explain -b <slug>  ·  aethis decide -b <slug> -i '{...}'[/dim]"
+    )
+
+
 @rulesets_app.command(name="list")
 def list_rulesets(
     project_id: Optional[str] = typer.Option(None, "--project-id", "-p", help="Project ID"),
     status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (comma-separated)"),
+    public: bool = typer.Option(
+        False,
+        "--public",
+        help="List the cross-tenant public showcase catalogue (no auth required).",
+    ),
+    limit: int = typer.Option(20, "--limit", min=1, max=50, help="Max rulesets to return (public mode)."),
+    offset: int = typer.Option(0, "--offset", min=0, help="Pagination offset (public mode)."),
 ) -> None:
-    """List rulesets for a project.
+    """List rulesets for a project, or the public showcase catalogue.
 
     Examples:
 
-        aethis rulesets list -p proj_i1HyinBtFJniayUC
+        aethis rulesets list                                  # auto: showcase if no project context
+        aethis rulesets list --public                         # explicit: anonymous catalogue
+        aethis rulesets list -p proj_i1HyinBtFJniayUC         # tenant-scoped
         aethis rulesets list -p proj_i1HyinBtFJniayUC -s active,archived
-        aethis rulesets list              # uses project_id from .aethis/state.json
     """
-    cfg, client = load_client_or_fallback()
-    pid = project_id or cfg.project_id
+    if public:
+        _list_public(limit=limit, offset=offset)
+        return
+
+    # Resolve the project id without forcing a login first — if there's no
+    # project context we want to fall through to the public catalogue rather
+    # than ask the user to authenticate just to discover what's available.
+    from aethis_cli.config import load_project_config, read_state
+    from aethis_cli.errors import ConfigError
+
+    pid: Optional[str] = project_id
+    if not pid:
+        try:
+            cfg = load_project_config()
+            pid = read_state(cfg.config_path).get("project_id")
+        except ConfigError:
+            pid = None
 
     if not pid:
         console.print(
-            "[red]No project_id.[/red] Pass --project-id or run from a project "
-            "directory where `aethis generate` has created .aethis/state.json."
+            "[dim]No project context — showing public showcase rulesets. Pass --project-id <id> to list your own.[/dim]"
         )
-        raise typer.Exit(code=1)
+        _list_public(limit=limit, offset=offset)
+        return
+
+    cfg, client = load_client_or_fallback()
 
     try:
         rulesets = client.list_rulesets(pid, status=status)

--- a/aethis_cli/config.py
+++ b/aethis_cli/config.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from aethis_cli.client import AethisClient
 
 DEFAULT_BASE_URL = "https://api.aethis.ai"
+DEFAULT_PROFILE = "default"
+ANONYMOUS_PROFILE = "anonymous"
 
 _LOCAL_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "host.docker.internal"}
 
@@ -43,21 +45,24 @@ class ProjectConfig:
 
 
 def resolve_base_url_with_source() -> tuple[str, str]:
-    """Return (base_url, source) where source is 'env', 'yaml', or 'default'.
+    """Return (base_url, source) where source is 'env', 'yaml', 'profile', or 'default'.
 
     Resolution order matches what every read-only command sees:
-      AETHIS_BASE_URL env var > aethis.yaml > DEFAULT_BASE_URL
+      AETHIS_BASE_URL env var > aethis.yaml > active profile > DEFAULT_BASE_URL
     """
     env = os.environ.get("AETHIS_BASE_URL")
     if env:
         return env, "env"
     try:
         cfg = load_project_config()
+        if cfg.base_url != DEFAULT_BASE_URL:
+            return cfg.base_url, "yaml"
     except ConfigError:
-        return DEFAULT_BASE_URL, "default"
-    if cfg.base_url == DEFAULT_BASE_URL:
-        return cfg.base_url, "default"
-    return cfg.base_url, "yaml"
+        pass
+    profile = get_profile(active_profile_name())
+    if profile.get("base_url"):
+        return profile["base_url"], "profile"
+    return DEFAULT_BASE_URL, "default"
 
 
 def make_authed_client(
@@ -90,15 +95,24 @@ def load_client_or_fallback() -> tuple["ProjectConfig", "AethisClient"]:
     the inline browser login on the first 401. This lets a fresh user run
     ``aethis projects list`` and complete sign-in without backing out to
     ``aethis login`` and re-running.
+
+    When the active profile is ``anonymous`` the function returns an unsigned
+    client immediately — no lazy-auth, no browser prompt.
     """
-    from aethis_cli.auth_helpers import RUNTIME, require_auth_or_login_inline
+    from aethis_cli.auth_helpers import RUNTIME, is_anonymous_active, require_auth_or_login_inline
+    from aethis_cli.client import make_anonymous_client
 
     try:
         cfg = load_project_config()
     except ConfigError:
-        base_url = RUNTIME.base_url_override or os.environ.get("AETHIS_BASE_URL") or DEFAULT_BASE_URL
+        base_url, _ = resolve_base_url_with_source()
+        if RUNTIME.base_url_override:
+            base_url = RUNTIME.base_url_override
         _validate_base_url(base_url)
         cfg = ProjectConfig(project="", base_url=base_url)
+
+    if is_anonymous_active():
+        return cfg, make_anonymous_client(cfg.base_url)
 
     api_key = require_auth_or_login_inline(cfg.base_url)
     return cfg, make_authed_client(api_key, cfg.base_url)
@@ -136,39 +150,30 @@ def load_project_config(path: Optional[Path] = None) -> ProjectConfig:
 
 
 def resolve_api_key(config: ProjectConfig) -> str:
-    """Resolve API key: env var → OS keychain → credentials file.
+    """Resolve API key: env var → active profile → keychain (default only) → lazy-auth.
 
-    When no cached key is found we delegate to the lazy-auth helper, which
-    will offer an inline browser sign-in on a TTY or raise ``AuthRequired``
-    on non-interactive shells / ``--no-prompt``. The historical contract of
-    "raise on missing key" is preserved — ``AuthRequired`` is a separate
-    exception that bubbles to ``cli()`` and exits with a clear message.
+    See :func:`aethis_cli.auth_helpers._resolve_cached_key` for the resolution
+    chain. When no cached key is found we delegate to the lazy-auth helper,
+    which will offer an inline browser sign-in on a TTY or raise
+    ``AuthRequired`` on non-interactive shells / ``--no-prompt``.
     """
-    key = os.environ.get(config.api_key_env)
-    if key:
-        return key
+    from aethis_cli.auth_helpers import _resolve_cached_key, require_auth_or_login_inline
 
-    # Try OS keychain (if keyring is installed)
-    try:
-        import keyring
+    cached = _resolve_cached_key()
+    if cached:
+        # Honour the project's ``api_key_env`` override only when set to the
+        # non-default name — the standard ``AETHIS_API_KEY`` path is already
+        # covered by ``_resolve_cached_key``.
+        if config.api_key_env != "AETHIS_API_KEY":
+            override = os.environ.get(config.api_key_env)
+            if override:
+                return override
+        return cached
 
-        key = keyring.get_password("aethis-cli", "api_key")
-        if key:
-            return key
-    except Exception:
-        pass
-
-    # Fall back to plaintext credentials file
-    creds_path = credentials_path()
-    if creds_path.exists():
-        raw = yaml.safe_load(creds_path.read_text()) or {}
-        key = raw.get("api_key")
-        if key:
-            return key
-
-    # Nothing cached: defer to the lazy-auth helper for inline browser sign-in
-    # (or AuthRequired on CI / --no-prompt).
-    from aethis_cli.auth_helpers import require_auth_or_login_inline
+    if config.api_key_env != "AETHIS_API_KEY":
+        override = os.environ.get(config.api_key_env)
+        if override:
+            return override
 
     return require_auth_or_login_inline(config.base_url)
 
@@ -223,3 +228,135 @@ def credentials_path() -> Path:
     if xdg:
         return Path(xdg) / "aethis" / "credentials"
     return Path.home() / ".config" / "aethis" / "credentials"
+
+
+# -- Profiles -----------------------------------------------------------------
+#
+# The credentials file at ``credentials_path()`` stores one or more named
+# profiles. The structure is::
+#
+#     active_profile: default
+#     profiles:
+#       default:
+#         api_key: ak_live_...
+#         base_url: https://api.aethis.ai
+#       new-dev:
+#         api_key: ak_test_...
+#       anonymous: {}
+#
+# The reserved name ``anonymous`` is recognised even when not present in the
+# file: selecting it yields no API key (and the client runs in unsigned mode).
+#
+# Backwards compatibility: legacy single-key files of the shape
+# ``{api_key: ...}`` are read as if they declared ``profiles.default.api_key``.
+# The first save after a legacy read upgrades the file to the new format.
+
+
+def _normalize_credentials(raw: object) -> dict:
+    """Coerce a raw YAML payload into ``{active_profile, profiles}``.
+
+    Handles three shapes:
+    * Legacy single-key ``{api_key: ...}`` → treated as the default profile.
+    * New multi-profile ``{active_profile, profiles: {...}}`` → returned as-is
+      with missing fields filled in.
+    * Anything else (None, malformed) → empty multi-profile skeleton.
+    """
+    if not isinstance(raw, dict):
+        return {"active_profile": DEFAULT_PROFILE, "profiles": {}}
+
+    if "profiles" in raw and isinstance(raw["profiles"], dict):
+        active = raw.get("active_profile") or DEFAULT_PROFILE
+        return {"active_profile": str(active), "profiles": dict(raw["profiles"])}
+
+    # Legacy: bare api_key (and maybe base_url) at the top level.
+    legacy_default: dict = {}
+    if "api_key" in raw and raw["api_key"]:
+        legacy_default["api_key"] = raw["api_key"]
+    if "base_url" in raw and raw["base_url"]:
+        legacy_default["base_url"] = raw["base_url"]
+    profiles = {DEFAULT_PROFILE: legacy_default} if legacy_default else {}
+    return {"active_profile": DEFAULT_PROFILE, "profiles": profiles}
+
+
+def load_credentials() -> dict:
+    """Read the credentials file and return a normalised ``{active_profile, profiles}``.
+
+    Returns the empty skeleton if the file is missing or unreadable.
+    """
+    path = credentials_path()
+    if not path.exists():
+        return {"active_profile": DEFAULT_PROFILE, "profiles": {}}
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except yaml.YAMLError:
+        return {"active_profile": DEFAULT_PROFILE, "profiles": {}}
+    return _normalize_credentials(raw)
+
+
+def save_credentials(data: dict) -> None:
+    """Atomically write the credentials file with mode 0600."""
+    path = credentials_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(yaml.dump(data, sort_keys=False))
+
+
+def active_profile_name() -> str:
+    """Return the name of the active profile.
+
+    Resolution order: ``--profile`` flag > ``AETHIS_PROFILE`` env >
+    ``active_profile`` field in credentials > ``"default"``.
+    """
+    from aethis_cli.auth_helpers import RUNTIME
+
+    if RUNTIME.profile_override:
+        return RUNTIME.profile_override
+    env = os.environ.get("AETHIS_PROFILE")
+    if env:
+        return env
+    return load_credentials().get("active_profile") or DEFAULT_PROFILE
+
+
+def get_profile(name: str) -> dict:
+    """Return the profile dict for ``name`` (or empty dict if not present)."""
+    creds = load_credentials()
+    return dict(creds["profiles"].get(name, {}))
+
+
+def set_profile(name: str, *, api_key: Optional[str] = None, base_url: Optional[str] = None) -> None:
+    """Create or update a named profile in the credentials file.
+
+    Only fields passed as non-None are written; existing fields are preserved.
+    """
+    if name == ANONYMOUS_PROFILE:
+        raise ConfigError(
+            f"Profile name '{ANONYMOUS_PROFILE}' is reserved — selecting it always "
+            "uses no API key. Pick a different name."
+        )
+    creds = load_credentials()
+    profile = dict(creds["profiles"].get(name, {}))
+    if api_key is not None:
+        profile["api_key"] = api_key
+    if base_url is not None:
+        profile["base_url"] = base_url
+    creds["profiles"][name] = profile
+    save_credentials(creds)
+
+
+def remove_profile(name: str) -> None:
+    """Delete a profile. Raises ``ConfigError`` if it doesn't exist."""
+    creds = load_credentials()
+    if name not in creds["profiles"]:
+        raise ConfigError(f"Profile '{name}' does not exist.")
+    del creds["profiles"][name]
+    if creds.get("active_profile") == name:
+        creds["active_profile"] = DEFAULT_PROFILE
+    save_credentials(creds)
+
+
+def set_active_profile(name: str) -> None:
+    """Set the sticky default profile name."""
+    creds = load_credentials()
+    creds["active_profile"] = name
+    save_credentials(creds)

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -17,6 +17,7 @@ from aethis_cli.commands.account_cmd import account_app
 from aethis_cli.commands.rulesets_cmd import rulesets_app
 from aethis_cli.commands.guidance_cmd import guidance_app
 from aethis_cli.commands.mcp_cmd import mcp_app
+from aethis_cli.commands.profile_cmd import profile_app
 from aethis_cli.commands.projects_cmd import projects_app
 from aethis_cli.commands.init_cmd import init
 from aethis_cli.commands.login_cmd import login
@@ -102,6 +103,15 @@ def main(
         "--base-url",
         help="Override the API base URL (defaults to AETHIS_BASE_URL or https://api.aethis.ai).",
     ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help=(
+            "Use a named credential profile for this command (overrides "
+            "AETHIS_PROFILE and the sticky default). Pass 'anonymous' to force "
+            "unsigned mode. Manage with `aethis profile`."
+        ),
+    ),
 ) -> None:
     """CLI for the Aethis developer API — author, test, and publish rulesets."""
     # Stash root-level flags on the lazy-auth runtime so commands and the
@@ -111,6 +121,7 @@ def main(
     RUNTIME.no_prompt = no_prompt
     RUNTIME.api_key_override = api_key
     RUNTIME.base_url_override = base_url
+    RUNTIME.profile_override = profile
     if base_url:
         # Make AETHIS_BASE_URL the single source of truth for downstream
         # code paths (config.resolve_base_url_with_source, status, login)
@@ -124,6 +135,7 @@ app.add_typer(account_app, name="account")
 app.add_typer(rulesets_app, name="rulesets")
 app.add_typer(guidance_app, name="guidance")
 app.add_typer(mcp_app, name="mcp")
+app.add_typer(profile_app, name="profile")
 app.add_typer(projects_app, name="projects")
 app.command()(init)
 app.command()(login)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.9.0"
+version = "0.10.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_account_cmd.py
+++ b/tests/test_account_cmd.py
@@ -44,30 +44,30 @@ MOCK_KEYS_LIST = [
 
 class TestAccountGenerate:
     @patch("aethis_cli.commands.account_cmd._fetch_permissions", return_value=([], set(VALID_SCOPES)))
-    @patch("aethis_cli.commands.account_cmd._save_to_keyring", return_value=True)
+    @patch("aethis_cli.commands.account_cmd.save_api_key")
     @patch("aethis_cli.commands.account_cmd.httpx.post")
     @patch("aethis_cli.commands.account_cmd._clerk_auth", return_value=MOCK_ACCESS_TOKEN)
-    def test_generate_success(self, mock_auth, mock_post, mock_keyring, mock_permissions):
+    def test_generate_success(self, mock_auth, mock_post, mock_save, mock_permissions):
         mock_post.return_value = MagicMock(status_code=201, json=MagicMock(return_value=MOCK_KEY_RESPONSE))
 
         result = runner.invoke(app, ["account", "generate", "--name", "test-key"])
         assert result.exit_code == 0
         assert "ak_test123" in result.output
         assert "ak_live_abcdef123456" in result.output
-        assert "saved" in result.output.lower()
+        mock_save.assert_called_once_with("ak_live_abcdef123456")
 
     @patch("aethis_cli.commands.account_cmd._fetch_permissions", return_value=([], set(VALID_SCOPES)))
-    @patch("aethis_cli.commands.account_cmd._save_to_keyring", return_value=True)
+    @patch("aethis_cli.commands.account_cmd.save_api_key")
     @patch("aethis_cli.commands.account_cmd.httpx.post")
     @patch("aethis_cli.commands.account_cmd._clerk_auth", return_value=MOCK_ACCESS_TOKEN)
-    def test_generate_no_save(self, mock_auth, mock_post, mock_keyring, mock_permissions):
+    def test_generate_no_save(self, mock_auth, mock_post, mock_save, mock_permissions):
         mock_post.return_value = MagicMock(status_code=201, json=MagicMock(return_value=MOCK_KEY_RESPONSE))
 
         result = runner.invoke(app, ["account", "generate", "--no-save"])
         assert result.exit_code == 0
         assert "ak_live_abcdef123456" in result.output
         assert "--no-save" in result.output
-        mock_keyring.assert_not_called()
+        mock_save.assert_not_called()
 
     @patch("aethis_cli.commands.account_cmd._fetch_permissions", return_value=([], set(VALID_SCOPES)))
     @patch("aethis_cli.commands.account_cmd.httpx.post")
@@ -94,10 +94,10 @@ class TestAccountGenerate:
         assert "Invalid tier" in result.output
 
     @patch("aethis_cli.commands.account_cmd._fetch_permissions", return_value=([], set(VALID_SCOPES)))
-    @patch("aethis_cli.commands.account_cmd._save_to_keyring", return_value=True)
+    @patch("aethis_cli.commands.account_cmd.save_api_key")
     @patch("aethis_cli.commands.account_cmd.httpx.post")
     @patch("aethis_cli.commands.account_cmd._clerk_auth", return_value=MOCK_ACCESS_TOKEN)
-    def test_generate_sends_bearer_token(self, mock_auth, mock_post, mock_keyring, mock_permissions):
+    def test_generate_sends_bearer_token(self, mock_auth, mock_post, mock_save, mock_permissions):
         mock_post.return_value = MagicMock(status_code=201, json=MagicMock(return_value=MOCK_KEY_RESPONSE))
 
         runner.invoke(app, ["account", "generate"])

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,124 @@
+"""Profile machinery + backwards-compat for the legacy single-key credentials file."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from aethis_cli import config
+from aethis_cli.auth_helpers import RUNTIME, _resolve_cached_key, is_anonymous_active
+from aethis_cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ~/.config/aethis to a temp dir and clear all env shorthands."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.delenv("AETHIS_PROFILE", raising=False)
+    # Reset the runtime singleton so a stale --profile from another test
+    # doesn't bleed into the resolver.
+    RUNTIME.no_prompt = False
+    RUNTIME.api_key_override = None
+    RUNTIME.base_url_override = None
+    RUNTIME.profile_override = None
+    return tmp_path
+
+
+def _write_legacy_single_key(tmp_path: Path, api_key: str) -> Path:
+    """Write a pre-profile credentials file ({api_key: ...}) at the XDG path."""
+    creds_dir = tmp_path / "aethis"
+    creds_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    creds = creds_dir / "credentials"
+    fd = os.open(str(creds), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(yaml.dump({"api_key": api_key}))
+    return creds
+
+
+def test_legacy_single_key_loads_as_default_profile(tmp_path: Path) -> None:
+    _write_legacy_single_key(tmp_path, "ak_legacy_xyz")
+
+    creds = config.load_credentials()
+    assert creds["active_profile"] == "default"
+    assert creds["profiles"]["default"]["api_key"] == "ak_legacy_xyz"
+
+
+def test_legacy_single_key_resolves_for_default_profile(tmp_path: Path) -> None:
+    _write_legacy_single_key(tmp_path, "ak_legacy_xyz")
+
+    assert _resolve_cached_key() == "ak_legacy_xyz"
+
+
+def test_save_upgrades_legacy_to_multi_profile(tmp_path: Path) -> None:
+    creds_path = _write_legacy_single_key(tmp_path, "ak_legacy_xyz")
+
+    config.set_profile("new-dev", api_key="ak_test_abc")
+    raw = yaml.safe_load(creds_path.read_text())
+    assert raw["active_profile"] == "default"
+    assert raw["profiles"]["default"]["api_key"] == "ak_legacy_xyz"
+    assert raw["profiles"]["new-dev"]["api_key"] == "ak_test_abc"
+
+
+def test_anonymous_profile_yields_no_key(tmp_path: Path) -> None:
+    _write_legacy_single_key(tmp_path, "ak_legacy_xyz")
+    config.set_active_profile("anonymous")
+
+    assert is_anonymous_active() is True
+    assert _resolve_cached_key() is None
+
+
+def test_profile_override_beats_sticky_default(tmp_path: Path) -> None:
+    config.set_profile("admin", api_key="ak_admin")
+    config.set_profile("new-dev", api_key="ak_dev")
+    config.set_active_profile("admin")
+
+    RUNTIME.profile_override = "new-dev"
+    try:
+        assert config.active_profile_name() == "new-dev"
+        assert _resolve_cached_key() == "ak_dev"
+    finally:
+        RUNTIME.profile_override = None
+
+
+def test_env_api_key_beats_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config.set_profile("admin", api_key="ak_admin")
+    config.set_active_profile("admin")
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_env_override")
+
+    # AETHIS_API_KEY remains the absolute override, even with a configured profile.
+    assert _resolve_cached_key() == "ak_env_override"
+
+
+def test_reserved_anonymous_name_rejected_at_set(tmp_path: Path) -> None:
+    with pytest.raises(config.ConfigError):
+        config.set_profile("anonymous", api_key="ak_should_not_save")
+
+
+def test_remove_profile_resets_active_when_active(tmp_path: Path) -> None:
+    config.set_profile("new-dev", api_key="ak_dev")
+    config.set_active_profile("new-dev")
+
+    config.remove_profile("new-dev")
+    assert config.active_profile_name() == "default"
+
+
+def test_profile_list_command_marks_active(tmp_path: Path) -> None:
+    config.set_profile("admin", api_key="ak_admin_with_long_suffix_xyz")
+    config.set_active_profile("admin")
+
+    result = runner.invoke(app, ["profile", "list"])
+    assert result.exit_code == 0
+    # Active marker, masked key, and the reserved 'anonymous' slot all visible.
+    assert "* " in result.output
+    assert "admin" in result.output
+    assert "anonymous" in result.output
+    assert "ak_admi" in result.output  # mask shows first 7 chars
+    assert "ak_admin_with_long_suffix_xyz" not in result.output  # full key never printed

--- a/tests/test_publish_force.py
+++ b/tests/test_publish_force.py
@@ -127,7 +127,11 @@ def test_publish_force_threads_force_unsafe_to_server(base_patches):
     """
     mock_client = MagicMock()
     mock_client.run_tests.return_value = {
-        "passed": 2, "total": 5, "failed": 3, "errors": 0, "results": [],
+        "passed": 2,
+        "total": 5,
+        "failed": 3,
+        "errors": 0,
+        "results": [],
     }
     mock_client.publish.return_value = {"ruleset_id": "test:abc", "version": "v2"}
 
@@ -142,8 +146,7 @@ def test_publish_force_threads_force_unsafe_to_server(base_patches):
     mock_client.publish.assert_called_once()
     _, call_kwargs = mock_client.publish.call_args
     assert call_kwargs.get("force_unsafe") is True, (
-        "publish --force must pass force_unsafe=True to the client, "
-        f"got call_kwargs={call_kwargs}"
+        f"publish --force must pass force_unsafe=True to the client, got call_kwargs={call_kwargs}"
     )
 
 


### PR DESCRIPTION
## Summary

Two complementary changes that close the new-developer experience gap:

1. **Public ruleset discovery** — `aethis rulesets list` now surfaces the cross-tenant public catalogue (anonymous, no key required). With no project context it auto-falls through to the catalogue plus a one-line hint, so a fresh signup sees something useful immediately.
2. **Named credential profiles** — flag (`aethis --profile new-dev …`) + sticky (`aethis profile use new-dev`), AWS/gh-style. Reserved profile name \`anonymous\` forces unsigned mode, so the admin can verify exactly what an unauthenticated user would see without losing their cached key.

## What this fixes

A brand-new developer signing up sees \`aethis rulesets list\` return zero results and has no path to discover public rulesets — even though \`aethis decide / fields / explain\` against \`-b <slug>\` already work anonymously. Today's catalogue has 6+ public rulesets (\`aethis/construction-all-risks\`, several \`aethis/uk-fsm/*\`, \`aethis/consumer-credit-…\`) sitting unreachable from the CLI.

## API key & profile resolution

| What | Order |
|------|-------|
| API key | \`AETHIS_API_KEY\` env > active profile's \`api_key\` > keychain (default profile only) > lazy-auth |
| Active profile | \`--profile\` flag > \`AETHIS_PROFILE\` env > \`active_profile\` field > \`default\` |
| Base URL | \`AETHIS_BASE_URL\` env > \`aethis.yaml\` > active profile > default |

## Backwards compatibility

- Legacy single-key \`{api_key: ak_…}\` credentials files load as \`profiles.default.api_key\`; rewritten on next save.
- Existing keychain entry remains the default-profile storage.
- All previously-working invocations behave identically (\`aethis rulesets list -p proj_xxx\` unchanged).

## Test plan

- [x] \`uv run pytest -q\` — 173 passed, 10 deselected
- [x] New \`tests/test_profiles.py\` (9 tests) covers legacy upgrade, env precedence, anonymous semantics, list rendering
- [x] \`uv tool run ruff check / format\` — clean
- [x] Smoke: \`unset AETHIS_API_KEY && aethis --profile anonymous rulesets list --public\` against prod returns the catalogue
- [x] Smoke: \`aethis rulesets list\` from \`/tmp\` (no project context) auto-falls through with hint
- [x] Smoke: \`aethis profile add/use/list/remove\` round-trip in an isolated XDG dir
- [x] Smoke: \`aethis login --help\` shows the new \`--profile\` slot
- [x] Smoke: \`aethis --profile anonymous projects list\` returns clean 401 (server enforces auth)

## Catalogue follow-up (out of scope, not blocking)

Memory note flagged \`aethis/uk-fsm\` data drift (aethis-core#90). The catalogue includes uk-fsm variants today; they should be sanity-checked before being held up as showcase examples. Tracked separately.