### PR TITLE
feat(updater): gh-style update-check banner (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.11.0 (2026-05-10)
+
+- feat(updater): gh-style update-check banner. On startup the CLI
+  kicks off a background thread that queries PyPI; if a newer release
+  is available it prints a one-line notice to stderr at exit:
+  "A new release of aethis-cli is available: 0.11.0 → 0.12.0 — to
+  upgrade, run: <method-aware command>". Detects whether the install
+  came via uv tool, pipx, or pip and renders the matching upgrade
+  command. Result is cached for 24 h at
+  `~/.config/aethis/update_check.json`. Suppressed automatically when
+  stderr is not a TTY (CI, piped output). Disable with
+  `AETHIS_DISABLE_UPDATE_CHECK=1`. The check never blocks the
+  command — failures are silent.
+
 ## 0.10.0 (2026-05-10)
 
 - feat(rulesets): `aethis rulesets list --public` lists the cross-tenant

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -174,6 +174,9 @@ _load_plugins(app)
 
 def cli() -> None:
     """Entry point wrapper that catches config/auth errors cleanly."""
+    from aethis_cli.update_check import start_background_check
+
+    start_background_check("aethis-cli", __version__)
     try:
         app()
     except ConfigError as e:

--- a/aethis_cli/update_check.py
+++ b/aethis_cli/update_check.py
@@ -1,0 +1,180 @@
+"""Background update-check banner for the aethis CLI.
+
+Prints a one-line "newer release available" banner to stderr at exit
+when a newer version is on PyPI. Modelled on `gh`'s notify-only DX:
+non-blocking, never errors loudly, and easy to disable.
+
+Disable with `AETHIS_DISABLE_UPDATE_CHECK=1`. Also auto-skipped when
+stderr is not a TTY (CI / piped output) and on `--version` / `--help`
+short-circuits (the caller decides when to invoke this).
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import re
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+_CACHE_TTL_SECONDS = 24 * 60 * 60
+_PYPI_TIMEOUT_SECONDS = 3.0
+_JOIN_TIMEOUT_SECONDS = 0.05
+_DISABLE_ENV = "AETHIS_DISABLE_UPDATE_CHECK"
+
+
+def _config_dir() -> Path:
+    """Return ~/.config/aethis (XDG-aware). Mirrors config.credentials_path."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / "aethis"
+    return Path.home() / ".config" / "aethis"
+
+
+def _cache_path() -> Path:
+    return _config_dir() / "update_check.json"
+
+
+def _load_cache() -> Optional[dict]:
+    try:
+        raw = _cache_path().read_text()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _save_cache(latest: str) -> None:
+    payload = {"checked_at": int(time.time()), "latest": latest}
+    try:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
+    except OSError:
+        pass
+
+
+def _fetch_latest_pypi(package: str) -> Optional[str]:
+    url = f"https://pypi.org/pypi/{package}/json"
+    try:
+        resp = httpx.get(url, timeout=_PYPI_TIMEOUT_SECONDS)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    info = data.get("info") or {}
+    latest = info.get("version")
+    if isinstance(latest, str) and latest:
+        return latest
+    return None
+
+
+_VERSION_RE = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?")
+
+
+def _parse_version(v: str) -> tuple[int, int, int]:
+    """Loose semver-ish tuple. Suffixes (a/b/rc/dev) sort lower at same triple."""
+    m = _VERSION_RE.match(v.strip())
+    if not m:
+        return (0, 0, 0)
+    return (int(m.group(1) or 0), int(m.group(2) or 0), int(m.group(3) or 0))
+
+
+def _is_newer(latest: str, current: str) -> bool:
+    if not latest or not current:
+        return False
+    if latest == current:
+        return False
+    return _parse_version(latest) > _parse_version(current)
+
+
+def _detect_install_method(package: str) -> tuple[str, str]:
+    """Return (method, upgrade_command). Heuristic on sys.executable."""
+    exe = (sys.executable or "").lower()
+    prefix = (sys.prefix or "").lower()
+    if "/uv/tools/" in exe or "/uv/tools/" in prefix:
+        return ("uv", f"uv tool install --upgrade {package}")
+    if "/pipx/venvs/" in exe or "/pipx/venvs/" in prefix:
+        return ("pipx", f"pipx upgrade {package}")
+    return ("pip", f"pip install --upgrade {package}")
+
+
+def _print_banner(package: str, current: str, latest: str) -> None:
+    _, command = _detect_install_method(package)
+    msg = (
+        f"\nA new release of {package} is available: {current} → {latest}\n"
+        f"To upgrade, run: {command}\n"
+    )
+    try:
+        sys.stderr.write(msg)
+        sys.stderr.flush()
+    except OSError:
+        pass
+
+
+def _should_skip() -> bool:
+    if os.environ.get(_DISABLE_ENV):
+        return True
+    try:
+        if not sys.stderr.isatty():
+            return True
+    except (AttributeError, ValueError):
+        return True
+    return False
+
+
+def _check_worker(package: str, holder: dict) -> None:
+    cache = _load_cache()
+    now = int(time.time())
+    if cache and isinstance(cache.get("checked_at"), int):
+        if now - cache["checked_at"] < _CACHE_TTL_SECONDS:
+            latest = cache.get("latest")
+            if isinstance(latest, str):
+                holder["latest"] = latest
+            return
+    latest = _fetch_latest_pypi(package)
+    if latest:
+        _save_cache(latest)
+        holder["latest"] = latest
+
+
+def start_background_check(package: str, current_version: str) -> None:
+    """Kick off a daemon thread that checks PyPI; show banner at exit."""
+    if _should_skip():
+        return
+
+    holder: dict = {}
+    thread = threading.Thread(
+        target=_check_worker,
+        args=(package, holder),
+        daemon=True,
+        name="aethis-update-check",
+    )
+    thread.start()
+
+    def _on_exit() -> None:
+        thread.join(timeout=_JOIN_TIMEOUT_SECONDS)
+        latest = holder.get("latest")
+        if not isinstance(latest, str):
+            return
+        if _is_newer(latest, current_version):
+            _print_banner(package, current_version, latest)
+
+    atexit.register(_on_exit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.10.0"
+version = "0.11.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,227 @@
+"""Tests for the update-check banner."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from aethis_cli import update_check as uc
+
+
+@pytest.fixture
+def fake_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the cache to a tmp dir; clear the disable flag."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv(uc._DISABLE_ENV, raising=False)
+    return tmp_path / "aethis"
+
+
+def test_is_newer_basic() -> None:
+    assert uc._is_newer("0.10.0", "0.9.0") is True
+    assert uc._is_newer("1.0.0", "0.99.99") is True
+    assert uc._is_newer("0.9.0", "0.9.0") is False
+    assert uc._is_newer("0.9.0", "0.10.0") is False
+    assert uc._is_newer("", "0.9.0") is False
+    assert uc._is_newer("0.9.0", "") is False
+
+
+def test_parse_version_handles_garbage() -> None:
+    assert uc._parse_version("not-a-version") == (0, 0, 0)
+    assert uc._parse_version("1") == (1, 0, 0)
+    assert uc._parse_version("1.2") == (1, 2, 0)
+    assert uc._parse_version("1.2.3rc4") == (1, 2, 3)
+
+
+def test_detect_install_method_uv() -> None:
+    with patch.object(uc.sys, "executable", "/Users/x/.local/share/uv/tools/aethis-cli/bin/python"):
+        method, cmd = uc._detect_install_method("aethis-cli")
+    assert method == "uv"
+    assert cmd == "uv tool install --upgrade aethis-cli"
+
+
+def test_detect_install_method_pipx() -> None:
+    with patch.object(uc.sys, "executable", "/Users/x/.local/pipx/venvs/aethis-cli/bin/python"):
+        method, cmd = uc._detect_install_method("aethis-cli")
+    assert method == "pipx"
+    assert cmd == "pipx upgrade aethis-cli"
+
+
+def test_detect_install_method_falls_back_to_pip() -> None:
+    with patch.object(uc.sys, "executable", "/usr/local/bin/python3"), patch.object(
+        uc.sys, "prefix", "/usr/local"
+    ):
+        method, cmd = uc._detect_install_method("aethis-cli")
+    assert method == "pip"
+    assert cmd == "pip install --upgrade aethis-cli"
+
+
+def test_save_and_load_cache(fake_config_dir: Path) -> None:
+    uc._save_cache("1.2.3")
+    cache = uc._load_cache()
+    assert cache is not None
+    assert cache["latest"] == "1.2.3"
+    assert isinstance(cache["checked_at"], int)
+
+
+def test_load_cache_missing_returns_none(fake_config_dir: Path) -> None:
+    assert uc._load_cache() is None
+
+
+def test_load_cache_corrupt_returns_none(fake_config_dir: Path) -> None:
+    cache_path = uc._cache_path()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text("{not json")
+    assert uc._load_cache() is None
+
+
+@respx.mock
+def test_fetch_latest_pypi_happy_path() -> None:
+    respx.get("https://pypi.org/pypi/aethis-cli/json").mock(
+        return_value=httpx.Response(200, json={"info": {"version": "0.11.0"}})
+    )
+    assert uc._fetch_latest_pypi("aethis-cli") == "0.11.0"
+
+
+@respx.mock
+def test_fetch_latest_pypi_404_returns_none() -> None:
+    respx.get("https://pypi.org/pypi/aethis-cli/json").mock(return_value=httpx.Response(404))
+    assert uc._fetch_latest_pypi("aethis-cli") is None
+
+
+@respx.mock
+def test_fetch_latest_pypi_network_error_returns_none() -> None:
+    respx.get("https://pypi.org/pypi/aethis-cli/json").mock(side_effect=httpx.ConnectError("boom"))
+    assert uc._fetch_latest_pypi("aethis-cli") is None
+
+
+def test_check_worker_uses_fresh_cache(fake_config_dir: Path) -> None:
+    """Cache <24h old: no HTTP call, just read latest from cache."""
+    uc._save_cache("0.99.0")
+    holder: dict = {}
+    with patch.object(uc, "_fetch_latest_pypi") as mock_fetch:
+        uc._check_worker("aethis-cli", holder)
+    mock_fetch.assert_not_called()
+    assert holder["latest"] == "0.99.0"
+
+
+def test_check_worker_skips_stale_cache(fake_config_dir: Path) -> None:
+    """Cache >24h old: HTTP call refreshes it."""
+    cache_path = uc._cache_path()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps({"checked_at": int(time.time()) - (uc._CACHE_TTL_SECONDS + 60), "latest": "0.5.0"})
+    )
+    holder: dict = {}
+    with patch.object(uc, "_fetch_latest_pypi", return_value="0.99.0") as mock_fetch:
+        uc._check_worker("aethis-cli", holder)
+    mock_fetch.assert_called_once_with("aethis-cli")
+    assert holder["latest"] == "0.99.0"
+    refreshed = uc._load_cache()
+    assert refreshed is not None
+    assert refreshed["latest"] == "0.99.0"
+
+
+def test_should_skip_when_env_var_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(uc._DISABLE_ENV, "1")
+    assert uc._should_skip() is True
+
+
+def test_should_skip_when_stderr_not_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(uc._DISABLE_ENV, raising=False)
+
+    class _NotTty:
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr(uc.sys, "stderr", _NotTty())
+    assert uc._should_skip() is True
+
+
+def test_start_background_check_skips_when_disabled(
+    fake_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disabled: no thread spawned, no atexit registered."""
+    monkeypatch.setenv(uc._DISABLE_ENV, "1")
+    with patch.object(uc.threading, "Thread") as mock_thread:
+        uc.start_background_check("aethis-cli", "0.10.0")
+    mock_thread.assert_not_called()
+
+
+def test_print_banner_writes_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    uc._print_banner("aethis-cli", "0.10.0", "0.11.0")
+    captured = capsys.readouterr()
+    assert "A new release of aethis-cli is available: 0.10.0 → 0.11.0" in captured.err
+    assert "To upgrade, run:" in captured.err
+    assert captured.out == ""
+
+
+class _SyncThread:
+    """Runs target synchronously on .start(); makes background_check deterministic."""
+
+    def __init__(self, target=None, args=(), daemon=None, name=None) -> None:
+        self._target = target
+        self._args = args
+
+    def start(self) -> None:
+        self._target(*self._args)
+
+    def join(self, timeout: float | None = None) -> None:
+        pass
+
+
+def _wire_sync(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Make start_background_check fully synchronous and capture atexit callbacks."""
+    monkeypatch.delenv(uc._DISABLE_ENV, raising=False)
+    monkeypatch.setattr(uc, "_should_skip", lambda: False)
+    monkeypatch.setattr(uc.threading, "Thread", _SyncThread)
+    callbacks: list = []
+    monkeypatch.setattr(uc.atexit, "register", lambda fn: callbacks.append(fn))
+    return callbacks
+
+
+def test_start_background_check_prints_banner_when_newer(
+    fake_config_dir: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Newer version on PyPI → banner appears on stderr when atexit fires."""
+    callbacks = _wire_sync(monkeypatch)
+    monkeypatch.setattr(uc, "_fetch_latest_pypi", lambda pkg: "0.11.0")
+
+    uc.start_background_check("aethis-cli", "0.10.0")
+
+    assert len(callbacks) == 1
+    callbacks[0]()
+    captured = capsys.readouterr()
+    assert "A new release of aethis-cli is available: 0.10.0 → 0.11.0" in captured.err
+    assert "To upgrade, run:" in captured.err
+
+
+def test_start_background_check_no_banner_when_current(
+    fake_config_dir: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    callbacks = _wire_sync(monkeypatch)
+    monkeypatch.setattr(uc, "_fetch_latest_pypi", lambda pkg: "0.10.0")
+
+    uc.start_background_check("aethis-cli", "0.10.0")
+
+    callbacks[0]()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_start_background_check_no_banner_on_network_failure(
+    fake_config_dir: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    callbacks = _wire_sync(monkeypatch)
+    monkeypatch.setattr(uc, "_fetch_latest_pypi", lambda pkg: None)
+
+    uc.start_background_check("aethis-cli", "0.10.0")
+
+    callbacks[0]()
+    captured = capsys.readouterr()
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

- Background PyPI check on startup; one-line stderr banner at exit when a newer release is available
- Install-method aware: renders \`uv tool install --upgrade\` / \`pipx upgrade\` / \`pip install --upgrade\` based on heuristics on \`sys.executable\`
- 24 h cache at \`~/.config/aethis/update_check.json\`
- Suppressed on non-TTY stderr; disable with \`AETHIS_DISABLE_UPDATE_CHECK=1\`
- Never blocks the command — failures are silent

Banner format (gh-style, no emoji):

\`\`\`
A new release of aethis-cli is available: 0.11.0 → 0.12.0
To upgrade, run: uv tool install --upgrade aethis-cli
\`\`\`

## Test plan

- [x] 20 new unit tests in \`tests/test_update_check.py\` (version cmp, install-method detection, cache hit/stale/corrupt, env disable, banner output, full flow)
- [x] Full suite green: 173 tests pass with the v0.10.0 \`--profile\` and public-discovery features composed
- [ ] Manual: \`uv tool install aethis-cli==0.10.0 && aethis status\` → banner shows on exit
- [ ] Manual: \`AETHIS_DISABLE_UPDATE_CHECK=1 aethis status\` → no banner
- [ ] Manual: \`aethis status | cat\` → no banner (non-TTY)

## Sibling PRs

- Aethis-ai/aethis-admin#17 — same banner, PyPI variant, v0.10.0 (merged)
- Aethis-ai/aethis-cli-internal#1 — git-installed variant against \`commits/main\`, v0.2.0 (merged)