### PR TITLE
ci: auto-tag main on version bump

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,48 @@
+name: Auto-tag on version bump
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'aethis_cli/_version.py'
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Read version from _version.py
+        id: ver
+        run: |
+          VERSION=$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' aethis_cli/_version.py | tr -d '"')
+          if [ -z "$VERSION" ]; then
+            echo "::error::could not parse version from aethis_cli/_version.py"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Skip if tag already exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "tag v${{ steps.ver.outputs.version }} already exists — skipping"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and push
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.ver.outputs.version }}" -m "Release ${{ steps.ver.outputs.version }}"
+          git push origin "v${{ steps.ver.outputs.version }}"
+          echo "Tagged and pushed v${{ steps.ver.outputs.version }} — publish.yml will fire next."


### PR DESCRIPTION
## Summary

Watches \`main\` for changes to \`aethis_cli/_version.py\`, parses the new version, and creates a matching \`v<X.Y.Z>\` tag. \`publish.yml\` fires off that tag — so the existing \"bump version + CHANGELOG in the same commit\" rule is now the *only* manual release step.

We forgot \`git tag && git push --tags\` after both v0.9.0 and v0.10.0 — neither shipped to PyPI until today's backfill. This eliminates that failure mode.

## Behaviour

- Skips silently if the tag already exists (refactor commit touching \`_version.py\` without changing the literal is a no-op)
- Uses \`github-actions[bot]\` as committer for the tag push
- Requires \`contents: write\` permission

## Test plan

- [ ] Merge this PR, then bump \`_version.py\` in a follow-up PR — verify auto-tag fires on merge and \`publish.yml\` picks it up