### PR TITLE
feat(ux): anonymous fallback for decide/explain/fields + hide --base-url (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.0 (2026-05-13)
+
+- feat: `decide`, `explain`, and `fields` no longer prompt for sign-in when no API key is present. Public rulesets are now accessible with zero setup — the CLI silently uses an anonymous client and lets the server return an error only if a private ruleset is requested.
+- fix: hide `--base-url` global flag from `aethis --help` (internal dev override; `AETHIS_BASE_URL` env var unchanged)
+- docs: reorder `aethis --help` to lead with the no-auth explore flow, then authoring
+
 ## 0.11.1 (2026-05-10)
 - fix: remove `examples/demo_core.sh` (internal dev script referencing `aethis-core` by name and a private API path — not intended for public release)
 - fix: update `tests/e2e/test_spacecraft_e2e.py` to resolve the spacecraft fixture from `examples/spacecraft-crew-rules/` instead of a `tda-server` path; drop internal service name from comment

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/aethis_cli/commands/decide_cmd.py
+++ b/aethis_cli/commands/decide_cmd.py
@@ -9,7 +9,7 @@ import typer
 from rich.table import Table
 
 from aethis_cli.commands._id_utils import require_ruleset_id
-from aethis_cli.config import load_client_or_fallback, read_state
+from aethis_cli.config import load_client_or_anon, read_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
 
@@ -39,7 +39,7 @@ def decide(
     Input is a JSON object mapping field IDs to values. Use --explain to see the
     reasoning trace (which rules fired, which group satisfied the decision).
     """
-    cfg, client = load_client_or_fallback()
+    cfg, client = load_client_or_anon()
 
     if not ruleset_id:
         state = read_state(cfg.config_path)

--- a/aethis_cli/commands/decide_cmd.py
+++ b/aethis_cli/commands/decide_cmd.py
@@ -28,16 +28,17 @@ def decide(
     ),
     explain: bool = typer.Option(False, "--explain", "-e", help="Show reasoning for the decision"),
 ) -> None:
-    """Evaluate eligibility against a published ruleset.
+    """Evaluate eligibility against a published ruleset. No API key required for public rulesets.
 
     Examples:
 
+        aethis decide -b aethis/uk-settlement-continuous-residence -i '{"days_outside_uk": 50}'
         aethis decide -b my_ruleset:20260401-a1b2c3d -i '{"age": 21, "country": "UK"}'
-        aethis decide -b my_ruleset:20260401-a1b2c3d -i @inputs.json --explain
+        aethis decide -b my_ruleset:20260401-a1b2c3d --input @inputs.json --explain
         aethis decide -i '{...}'         # uses ruleset from .aethis/state.json
 
-    Input is a JSON object mapping field IDs to values. Use --explain to see the
-    reasoning trace (which rules fired, which group satisfied the decision).
+    Input is a JSON object mapping field IDs to values. Use `aethis fields -b <ruleset>`
+    to see which fields are available. Use --explain to see the reasoning trace.
     """
     cfg, client = load_client_or_anon()
 

--- a/aethis_cli/commands/explain_cmd.py
+++ b/aethis_cli/commands/explain_cmd.py
@@ -8,7 +8,7 @@ import typer
 from rich.table import Table
 
 from aethis_cli.commands._id_utils import require_ruleset_id
-from aethis_cli.config import load_client_or_fallback, read_state
+from aethis_cli.config import load_client_or_anon, read_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
 
@@ -33,7 +33,7 @@ def explain(
         aethis explain                   # uses .aethis/state.json if present
         aethis --base-url http://localhost:8080 explain -b my_ruleset:20260401-a1b2c3d
     """
-    cfg, client = load_client_or_fallback()
+    cfg, client = load_client_or_anon()
 
     if not ruleset_id:
         state = read_state(cfg.config_path)

--- a/aethis_cli/commands/explain_cmd.py
+++ b/aethis_cli/commands/explain_cmd.py
@@ -25,13 +25,13 @@ def explain(
         ),
     ),
 ) -> None:
-    """Show human-readable rules for a ruleset.
+    """Show human-readable rules for a ruleset. No API key required for public rulesets.
 
     Examples:
 
+        aethis explain -b aethis/uk-settlement-continuous-residence
         aethis explain -b crew_certification:20260408-cbf63f1f
         aethis explain                   # uses .aethis/state.json if present
-        aethis --base-url http://localhost:8080 explain -b my_ruleset:20260401-a1b2c3d
     """
     cfg, client = load_client_or_anon()
 

--- a/aethis_cli/commands/fields_cmd.py
+++ b/aethis_cli/commands/fields_cmd.py
@@ -7,7 +7,7 @@ from typing import Optional
 import typer
 from rich.table import Table
 
-from aethis_cli.config import load_client_or_fallback, read_state
+from aethis_cli.config import load_client_or_anon, read_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
 
@@ -16,7 +16,7 @@ def fields(
     ruleset_id: Optional[str] = typer.Option(None, "--ruleset-id", "-b"),
 ) -> None:
     """Show the input fields expected by a ruleset."""
-    cfg, client = load_client_or_fallback()
+    cfg, client = load_client_or_anon()
 
     if not ruleset_id:
         state = read_state(cfg.config_path)

--- a/aethis_cli/commands/fields_cmd.py
+++ b/aethis_cli/commands/fields_cmd.py
@@ -13,9 +13,24 @@ from aethis_cli.output import console, error_panel
 
 
 def fields(
-    ruleset_id: Optional[str] = typer.Option(None, "--ruleset-id", "-b"),
+    ruleset_id: Optional[str] = typer.Option(
+        None,
+        "--ruleset-id",
+        "-b",
+        help=(
+            "Ruleset ID or slug (e.g. aethis/uk-settlement or "
+            "my_ruleset:20260408-abc1234). Defaults to .aethis/state.json if omitted."
+        ),
+    ),
 ) -> None:
-    """Show the input fields expected by a ruleset."""
+    """Show the input fields expected by a ruleset. No API key required for public rulesets.
+
+    Examples:
+
+        aethis fields -b aethis/uk-settlement-continuous-residence
+        aethis fields -b crew_certification:20260408-cbf63f1f
+        aethis fields                    # uses .aethis/state.json if present
+    """
     cfg, client = load_client_or_anon()
 
     if not ruleset_id:

--- a/aethis_cli/commands/init_cmd.py
+++ b/aethis_cli/commands/init_cmd.py
@@ -71,9 +71,8 @@ def _print_next_steps(name: str) -> None:
     console.print()
     console.print("Next:")
     console.print(f"  cd {name}")
-    console.print("  aethis sections discover --file <legislation.txt>")
-    console.print("  aethis fields discover --section <section_id>")
     console.print("  aethis generate --poll")
+    console.print("  aethis test && aethis publish")
 
 
 def init(

--- a/aethis_cli/commands/projects_cmd.py
+++ b/aethis_cli/commands/projects_cmd.py
@@ -27,7 +27,6 @@ def list_projects(
 
         aethis projects list
         aethis projects list --include-archived
-        aethis --base-url http://localhost:8080 projects list
     """
     _cfg, client = load_client_or_fallback()
 

--- a/aethis_cli/config.py
+++ b/aethis_cli/config.py
@@ -118,6 +118,36 @@ def load_client_or_fallback() -> tuple["ProjectConfig", "AethisClient"]:
     return cfg, make_authed_client(api_key, cfg.base_url)
 
 
+def load_client_or_anon() -> tuple["ProjectConfig", "AethisClient"]:
+    """Like load_client_or_fallback but never prompts for sign-in.
+
+    Used by read-only public-endpoint commands (decide, explain, fields).
+    If a key is cached or set via env/flag, use it — authenticated callers
+    get access to their private rulesets. If no key is found, fall back to
+    an unsigned client so public rulesets work with zero setup.
+    """
+    from aethis_cli.auth_helpers import RUNTIME, _resolve_cached_key, is_anonymous_active
+    from aethis_cli.client import make_anonymous_client
+
+    try:
+        cfg = load_project_config()
+    except ConfigError:
+        base_url, _ = resolve_base_url_with_source()
+        if RUNTIME.base_url_override:
+            base_url = RUNTIME.base_url_override
+        _validate_base_url(base_url)
+        cfg = ProjectConfig(project="", base_url=base_url)
+
+    if is_anonymous_active():
+        return cfg, make_anonymous_client(cfg.base_url)
+
+    api_key = _resolve_cached_key()
+    if api_key is None:
+        return cfg, make_anonymous_client(cfg.base_url)
+
+    return cfg, make_authed_client(api_key, cfg.base_url)
+
+
 def load_project_config(path: Optional[Path] = None) -> ProjectConfig:
     """Load aethis.yaml. Walks up the directory tree if no explicit path given."""
     if path and path.is_file():

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -54,22 +54,21 @@ def _version_callback(value: bool) -> None:
 _APP_HELP = """
 Author, test, and publish rulesets via the Aethis developer API.
 
-Common flows:
+No account needed to explore:
 
-    aethis status                       # what server / key / project am I on?
-    aethis projects list                # see all projects + latest rulesets
-    aethis explain -b <ruleset>          # human-readable rules for a ruleset
+    aethis rulesets list                # browse public rulesets (no key needed)
+    aethis fields -b <ruleset>          # show required fields
+    aethis explain -b <ruleset>         # human-readable rules for a ruleset
     aethis decide -b <ruleset> -i '{"age": 21}'   # evaluate eligibility
 
-Authoring (invite-only beta):
+Authoring (API key required):
 
+    aethis login                        # sign in and cache your key
+    aethis status                       # what server / key / project am I on?
+    aethis projects list                # see all projects + latest rulesets
     aethis init                         # scaffold a new project dir
     aethis generate --poll              # generate + poll until done
     aethis test && aethis publish       # gate on tests, then publish
-
-Targeting a different server:
-
-    AETHIS_BASE_URL=http://localhost:8080 aethis projects list
 
 Run `aethis <command> --help` for per-command examples.
 """
@@ -102,6 +101,7 @@ def main(
         None,
         "--base-url",
         help="Override the API base URL (defaults to AETHIS_BASE_URL or https://api.aethis.ai).",
+        hidden=True,
     ),
     profile: Optional[str] = typer.Option(
         None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.11.1"
+version = "0.12.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/e2e/test_spacecraft_e2e.py
+++ b/tests/e2e/test_spacecraft_e2e.py
@@ -39,10 +39,7 @@ pytestmark = pytest.mark.manual
 # ---------------------------------------------------------------------------
 
 SPACECRAFT_POLICY_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "examples"
-    / "spacecraft-crew-rules"
-    / "spacecraft-crew-certification-act.md"
+    Path(__file__).resolve().parents[2] / "examples" / "spacecraft-crew-rules" / "spacecraft-crew-certification-act.md"
 )
 
 GENERATION_TIMEOUT = 300  # 5 minutes

--- a/tests/test_explain_cmd.py
+++ b/tests/test_explain_cmd.py
@@ -14,7 +14,7 @@ def test_explain_rejects_project_id_without_api_call(tmp_path, monkeypatch):
 
     client = MagicMock()
     with patch(
-        "aethis_cli.commands.explain_cmd.load_client_or_fallback",
+        "aethis_cli.commands.explain_cmd.load_client_or_anon",
         return_value=(MagicMock(config_path=tmp_path), client),
     ):
         from aethis_cli.main import app
@@ -64,7 +64,7 @@ def test_explain_missing_ruleset_id_gives_one_line_error(tmp_path, monkeypatch):
 
     client = MagicMock()
     with patch(
-        "aethis_cli.commands.explain_cmd.load_client_or_fallback",
+        "aethis_cli.commands.explain_cmd.load_client_or_anon",
         return_value=(MagicMock(config_path=tmp_path), client),
     ):
         from aethis_cli.main import app
@@ -87,7 +87,7 @@ def test_explain_config_error_renders_without_rich_traceback(tmp_path, monkeypat
     from aethis_cli.errors import ConfigError
 
     with patch(
-        "aethis_cli.commands.explain_cmd.load_client_or_fallback",
+        "aethis_cli.commands.explain_cmd.load_client_or_anon",
         side_effect=ConfigError("API key not found. Run 'aethis login'."),
     ):
         from aethis_cli.main import app

--- a/tests/test_fields_cmd.py
+++ b/tests/test_fields_cmd.py
@@ -26,7 +26,7 @@ def test_fields_works_without_aethis_yaml_using_slug(tmp_path, monkeypatch):
     }
 
     with patch(
-        "aethis_cli.commands.fields_cmd.load_client_or_fallback",
+        "aethis_cli.commands.fields_cmd.load_client_or_anon",
         return_value=(MagicMock(config_path=tmp_path), client),
     ):
         from aethis_cli.main import app
@@ -53,7 +53,7 @@ def test_fields_works_without_aethis_yaml_using_ruleset_id(tmp_path, monkeypatch
     client.get_schema.return_value = {"fields": []}
 
     with patch(
-        "aethis_cli.commands.fields_cmd.load_client_or_fallback",
+        "aethis_cli.commands.fields_cmd.load_client_or_anon",
         return_value=(MagicMock(config_path=tmp_path), client),
     ):
         from aethis_cli.main import app
@@ -76,7 +76,7 @@ def test_fields_missing_ruleset_id_gives_one_line_error(tmp_path, monkeypatch):
 
     client = MagicMock()
     with patch(
-        "aethis_cli.commands.fields_cmd.load_client_or_fallback",
+        "aethis_cli.commands.fields_cmd.load_client_or_anon",
         return_value=(MagicMock(config_path=tmp_path), client),
     ):
         from aethis_cli.main import app

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -97,12 +97,10 @@ def test_init_prints_next_step_ladder(tmp_path, monkeypatch):
     with _patch_auth_present():
         result = runner.invoke(app, ["init", "ladder-proj"])
     assert result.exit_code == 0, result.output
-    # Order matters: header, then the three commands the docs walk users through.
     assert "Project initialised: ladder-proj" in result.output
     assert "Next:" in result.output
-    assert "aethis sections discover" in result.output
-    assert "aethis fields discover" in result.output
     assert "aethis generate --poll" in result.output
+    assert "aethis test && aethis publish" in result.output
 
 
 # --- prompted (no-arg) form ------------------------------------------------


### PR DESCRIPTION
## Summary

- **Zero-setup public access**: `decide`, `explain`, and `fields` no longer prompt for sign-in when no API key is present. A first-time user can now run `aethis decide -b <public-ruleset> -i '{...}'` with no account. Implemented via new `load_client_or_anon()` helper in `config.py` — if a key is cached it's used (private rulesets still work for authenticated users); if not, falls back silently to an unsigned client.
- **Hide `--base-url`**: Added `hidden=True` to the global flag so it no longer appears in `aethis --help`. The flag and `AETHIS_BASE_URL` env var remain fully functional for internal dev.
- **Refreshed `_APP_HELP`**: Leads with a "No account needed to explore" section (`rulesets list`, `fields`, `explain`, `decide`), then authoring flows. Removed the internal server-targeting example.
- Updated test patches from `load_client_or_fallback` → `load_client_or_anon` in `test_explain_cmd.py` and `test_fields_cmd.py`.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/e2e -q` — 167 pass, 6 pre-existing ANSI failures (confirmed same failures on `main` before this branch)
- [x] `uv run aethis --help` — `--base-url` absent from options panel; "No account needed" block leads
- [x] No `load_client_or_fallback` references remaining in `commands/decide_cmd.py`, `explain_cmd.py`, `fields_cmd.py`