### PR TITLE
ci: chain auto-tag → publish via workflow_dispatch

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write   # needed to dispatch publish.yml after pushing the tag
     steps:
       - uses: actions/checkout@v6
         with:
@@ -45,4 +46,16 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "v${{ steps.ver.outputs.version }}" -m "Release ${{ steps.ver.outputs.version }}"
           git push origin "v${{ steps.ver.outputs.version }}"
-          echo "Tagged and pushed v${{ steps.ver.outputs.version }} — publish.yml will fire next."
+
+      # GITHUB_TOKEN-pushed tags do NOT fire `push: tags` workflows, so we
+      # explicitly dispatch publish.yml. workflow_dispatch is one of the two
+      # events GITHUB_TOKEN is allowed to trigger.
+      - name: Dispatch publish workflow
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish.yml \
+            --ref main \
+            -f tag="v${{ steps.ver.outputs.version }}"
+          echo "Dispatched publish.yml for v${{ steps.ver.outputs.version }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  # Manual / chained trigger. GitHub deliberately does not fire `push: tags`
+  # workflows for tags pushed by GITHUB_TOKEN (e.g. from auto-tag.yml), so we
+  # expose a workflow_dispatch entry point that auto-tag.yml chains into.
+  # workflow_dispatch + repository_dispatch are the only events GITHUB_TOKEN
+  # is allowed to trigger.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and publish (e.g. v0.12.1)'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -11,6 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0   # setuptools-scm needs full history for versioning
           fetch-tags: true # …and tags, explicitly (actions/checkout no longer fetches tags by default)
 


### PR DESCRIPTION
## Summary

- `auto-tag.yml` now explicitly dispatches `publish.yml` after pushing the version tag
- `publish.yml` gains a `workflow_dispatch` entry point with a `tag` input

## Why

GitHub deliberately does not fire `push: tags` workflows when the tag is pushed by `GITHUB_TOKEN`. As a result, every release since `v0.11.0` — `v0.11.1`, `v0.12.0`, `v0.12.1` — was tagged on origin but never reached PyPI. Developers running `pip install aethis-cli` still get v0.11.0, which prompts for browser sign-in on `aethis decide` against public rulesets (the [anonymous-fallback fix](https://github.com/Aethis-ai/aethis-cli/commit/afdca5017465cb929f55b9d35bc59224827e2c07) is in v0.12.0).

`workflow_dispatch` and `repository_dispatch` are the only events `GITHUB_TOKEN` is allowed to trigger, so this is the GitHub-blessed escape hatch.

## To unblock v0.12.1 after merge

```
gh workflow run publish.yml --ref main -f tag=v0.12.1
```

Once that publishes, future releases auto-publish on their own.

## Test plan

- [ ] Merge to main
- [ ] Run the dispatch command above and confirm `v0.12.1` lands on PyPI
- [ ] Verify `aethis decide -b aethis/uk-fsm/child-eligibility -i '{...}'` no longer prompts for auth (against a fresh install of `aethis-cli==0.12.1`)
- [ ] Next version bump: confirm `auto-tag.yml` dispatches `publish.yml` end-to-end without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)