### PR TITLE
fix(login): use correct OAuth client_id for clerk.aethis.ai (v0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.2 (2026-05-19)
+
+- fix(login): default `AETHIS_CLERK_CLIENT_ID` to the OAuth Application registered on the `clerk.aethis.ai` Clerk instance. The previous default belonged to a different Clerk app, so `aethis login` returned `invalid_client` against the dev-tools domain set in 0.12.1.
+- fix(account): default `AETHIS_CLERK_DOMAIN` to `clerk.aethis.ai` for `aethis account generate` (matching the 0.12.1 change to `aethis login`); previously still pointed at the immigration domain.
+
 ## 0.12.1 (2026-05-12)
 
 - fix: default Clerk domain changed from `clerk.aethis.legal` to `clerk.aethis.ai` so developer portal users can authenticate via `aethis login` (closes aethis-cli#40)

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"

--- a/aethis_cli/commands/account_cmd.py
+++ b/aethis_cli/commands/account_cmd.py
@@ -14,8 +14,8 @@ from aethis_cli.config import DEFAULT_BASE_URL
 from aethis_cli.errors import AuthenticationError
 from aethis_cli.output import console, info, success
 
-CLERK_DOMAIN = os.environ.get("AETHIS_CLERK_DOMAIN", "clerk.aethis.legal")
-CLERK_CLIENT_ID = os.environ.get("AETHIS_CLERK_CLIENT_ID", "cwH009p1vPtyy1EG")
+CLERK_DOMAIN = os.environ.get("AETHIS_CLERK_DOMAIN", "clerk.aethis.ai")
+CLERK_CLIENT_ID = os.environ.get("AETHIS_CLERK_CLIENT_ID", "gEiHOxoeLgZJifjf")
 
 VALID_SCOPES = {
     "decide",

--- a/aethis_cli/commands/login_cmd.py
+++ b/aethis_cli/commands/login_cmd.py
@@ -86,7 +86,7 @@ def run_browser_login(base_url: str, timeout: int = 120, *, profile: Optional[st
     from aethis_cli.errors import AuthenticationError
 
     clerk_domain = os.environ.get("AETHIS_CLERK_DOMAIN", "clerk.aethis.ai")
-    clerk_client_id = os.environ.get("AETHIS_CLERK_CLIENT_ID", "cwH009p1vPtyy1EG")
+    clerk_client_id = os.environ.get("AETHIS_CLERK_CLIENT_ID", "gEiHOxoeLgZJifjf")
 
     info("Opening browser for sign-in...")
     console.print(f"Waiting for authentication ({timeout}s timeout)...\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.12.1"
+version = "0.12.2"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Default `AETHIS_CLERK_CLIENT_ID` is now `gEiHOxoeLgZJifjf`, the OAuth Application registered on the `clerk.aethis.ai` Clerk instance (the developer-portal app). 0.12.1 flipped the domain default to `clerk.aethis.ai` but left the client_id pointing at the previous Clerk app, so `aethis login` returned `{"error":"invalid_client", ...}` against the new domain.
- `account_cmd.py` also still defaulted `AETHIS_CLERK_DOMAIN` to the old domain (the 0.12.1 fix only touched `login_cmd.py`); aligned both files on `clerk.aethis.ai`.
- Created a public PKCE OAuth Application on `clerk.aethis.ai` via the Clerk Backend API with redirect_uri `http://127.0.0.1:9876/callback` (matches the CLI's fixed callback port in `auth.py`). Verified the new client_id resolves on `clerk.aethis.ai/oauth/token` with `invalid_grant` (i.e. client exists, code expected) instead of the old `invalid_client`.
- Bumps version 0.12.1 → 0.12.2 + CHANGELOG per public-repos.md.

## Reproduction (before this PR)

```
$ aethis login
{"error":"invalid_client","error_description":"Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The requested OAuth 2.0 Client does not exist."}
```

## Follow-up (not in this PR)

`aethis-admin/aethis_admin/commands/iam_cmd.py:20` carries the same hardcoded `cwH009p1vPtyy1EG` client_id pattern. Staff-only tool, so blast radius is smaller, but the same fix should land there separately (different repo).

## Test plan

- [ ] `pip install --upgrade aethis-cli` and run `aethis login` — browser opens to `clerk.aethis.ai/oauth/authorize?...`, user signs in, an API key is minted and stored.
- [ ] `aethis account generate --scope decide` against the new default — same domain, same client_id, same outcome.
- [ ] `AETHIS_CLERK_DOMAIN=clerk.aethis.legal AETHIS_CLERK_CLIENT_ID=cwH009p1vPtyy1EG aethis login` — env overrides still honoured for anyone with an account on the legacy domain.