### PR TITLE
fix(decide): render layered explanation without crashing (v0.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.3 (2026-05-19)
+
+- fix(decide): `aethis decide --explain` no longer crashes with `AttributeError: 'str' object has no attribute 'get'`. The CLI previously treated the engine's `explanation` field as a flat `list[dict]`, but the public decide route returns a layered `{decision, decision_path?, groups: [{group, status, criteria: [{title, status, supporting_facts?, ...}]}], unused_facts}` shape. The "Rules" block now walks the actual structure and renders each group + criterion with PASS/FAIL marks, supporting fact field/value pairs underneath satisfied criteria, and a final list of unused fields (provided answers that no satisfied criterion referenced — useful for catching field-name typos).
+
 ## 0.12.2 (2026-05-19)
 
 - fix(login): default `AETHIS_CLERK_CLIENT_ID` to the OAuth Application registered on the `clerk.aethis.ai` Clerk instance. The previous default belonged to a different Clerk app, so `aethis login` returned `invalid_client` against the dev-tools domain set in 0.12.1.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"

--- a/aethis_cli/commands/decide_cmd.py
+++ b/aethis_cli/commands/decide_cmd.py
@@ -192,15 +192,10 @@ def _print_explanation(explanation: dict) -> None:
             console.print(f"    {cicon} {title}{suffix}")
             for fact in crit.get("supporting_facts", []) or []:
                 if isinstance(fact, dict):
-                    console.print(
-                        f"        [dim]{fact.get('field', '')} = {fact.get('value', '')}[/dim]"
-                    )
+                    console.print(f"        [dim]{fact.get('field', '')} = {fact.get('value', '')}[/dim]")
 
     unused = explanation.get("unused_facts") or []
     if unused:
-        console.print(
-            "\n  [dim]Unused fields (provided but not referenced by any "
-            "satisfied criterion):[/dim]"
-        )
+        console.print("\n  [dim]Unused fields (provided but not referenced by any satisfied criterion):[/dim]")
         for field in unused:
             console.print(f"    [dim]- {field}[/dim]")

--- a/aethis_cli/commands/decide_cmd.py
+++ b/aethis_cli/commands/decide_cmd.py
@@ -6,7 +6,6 @@ import json
 from typing import Optional
 
 import typer
-from rich.table import Table
 
 from aethis_cli.commands._id_utils import require_ruleset_id
 from aethis_cli.config import load_client_or_anon, read_state
@@ -158,19 +157,50 @@ def _print_trace(trace: dict) -> None:
                 console.print(f"    [red]\u2717[/red] {fr}")
 
 
-def _print_explanation(explanation: list) -> None:
-    """Print human-readable rule text in a table."""
+_CRITERION_ICONS = {
+    "satisfied": "[green]✓[/green]",
+    "not_satisfied": "[red]✗[/red]",
+    "pending": "[yellow]?[/yellow]",
+}
+
+
+def _print_explanation(explanation: dict) -> None:
+    """Print the layered decision explanation.
+
+    Shape (see aethis-core public decide route): `{decision, decision_path?,
+    groups: [{group, status, criteria: [{criterion_id, title, status,
+    supporting_facts?, source_refs?}]}], unused_facts}`.
+    """
     console.print("\n[bold]Rules[/bold]")
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Group")
-    table.add_column("Rule")
-    table.add_column("Requirement")
 
-    for rule in explanation:
-        table.add_row(
-            rule.get("group", ""),
-            rule.get("title", ""),
-            rule.get("rule_text", ""),
+    path = explanation.get("decision_path")
+    if path:
+        console.print(f"  Satisfied by: [green]{path}[/green]")
+
+    for group in explanation.get("groups", []) or []:
+        name = group.get("group", "")
+        status = group.get("status", "")
+        icon = _STATUS_ICONS.get(status, f"[yellow]{status}[/yellow]")
+        console.print(f"\n  [bold]{name}[/bold] {icon}")
+
+        for crit in group.get("criteria", []) or []:
+            cstatus = crit.get("status", "")
+            cicon = _CRITERION_ICONS.get(cstatus, "[yellow]?[/yellow]")
+            title = crit.get("title") or crit.get("criterion_id", "")
+            cid = crit.get("criterion_id", "")
+            suffix = f" [dim]({cid})[/dim]" if cid and cid != title else ""
+            console.print(f"    {cicon} {title}{suffix}")
+            for fact in crit.get("supporting_facts", []) or []:
+                if isinstance(fact, dict):
+                    console.print(
+                        f"        [dim]{fact.get('field', '')} = {fact.get('value', '')}[/dim]"
+                    )
+
+    unused = explanation.get("unused_facts") or []
+    if unused:
+        console.print(
+            "\n  [dim]Unused fields (provided but not referenced by any "
+            "satisfied criterion):[/dim]"
         )
-
-    console.print(table)
+        for field in unused:
+            console.print(f"    [dim]- {field}[/dim]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.12.2"
+version = "0.12.3"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_decide_cmd.py
+++ b/tests/test_decide_cmd.py
@@ -1,0 +1,191 @@
+"""Tests for `aethis decide` — in particular the --explain rendering, which
+crashed in 0.12.2 because `_print_explanation` assumed a flat list of dicts
+but the engine returns a nested `{groups: [{criteria: [...]}, ...]}` shape.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(s: str) -> str:
+    """Strip ANSI escape sequences so substring asserts aren't fooled by
+    Rich's per-token number highlighting (e.g. `1000+` → `<ESC>1000<ESC>+`)."""
+    return _ANSI_RE.sub("", s)
+
+
+# Captured from a real api.aethis.ai response against
+# `aethis/spacecraft-crew-certification` (trimmed to two groups with mixed
+# criterion statuses + a non-empty `unused_facts`). Mirrors the contract in
+# aethis-core/aethis_core/public/routes/decide.py:312-324.
+_REAL_EXPLANATION = {
+    "decision": "eligible",
+    "decision_path": "species_eligible",
+    "groups": [
+        {
+            "group": "species_eligibility",
+            "status": "satisfied",
+            "criteria": [
+                {
+                    "criterion_id": "species_eligible",
+                    "title": "Applicant is of an eligible species",
+                    "status": "satisfied",
+                    "supporting_facts": [
+                        {"field": "space.crew.species", "value": "human"}
+                    ],
+                }
+            ],
+        },
+        {
+            "group": "flight_readiness",
+            "status": "satisfied",
+            "criteria": [
+                {
+                    "criterion_id": "flight_readiness_exempt_1000hrs",
+                    "title": "Exempt from flight readiness — 1000+ flight hours",
+                    "status": "satisfied",
+                    "supporting_facts": [
+                        {"field": "space.crew.flight_hours", "value": 1000},
+                    ],
+                },
+                {
+                    "criterion_id": "flight_readiness_exempt_age",
+                    "title": "Exempt from flight readiness — age 60+",
+                    "status": "not_satisfied",
+                },
+            ],
+        },
+    ],
+    "unused_facts": ["space.crew.has_radiation_cert"],
+}
+
+
+def _decide_result(explanation):
+    return {
+        "decision": "eligible",
+        "ruleset_id": "spacecraft-crew-certification:20260517-c59647a5",
+        "fields_evaluated": 16,
+        "fields_provided": 11,
+        "missing_fields": [],
+        "field_errors": None,
+        "next_question": None,
+        "optimal_path": None,
+        "trace": None,
+        "explanation": explanation,
+    }
+
+
+def test_decide_explain_renders_nested_explanation(tmp_path, monkeypatch):
+    """Regression: --explain must walk the dict shape returned by the engine
+    without raising AttributeError, and must surface group statuses,
+    criterion titles, supporting facts, and unused fields."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+
+    client = MagicMock()
+    client.decide.return_value = _decide_result(_REAL_EXPLANATION)
+
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        from aethis_cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "decide",
+                "-b",
+                "aethis/spacecraft-crew-certification",
+                "-i",
+                '{"space.crew.species":"Human"}',
+                "--explain",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "Traceback" not in out
+    assert "AttributeError" not in out
+
+    # Group headers must appear with their names.
+    assert "species_eligibility" in out
+    assert "flight_readiness" in out
+
+    # Criterion titles must appear (both satisfied and not_satisfied paths).
+    assert "Applicant is of an eligible species" in out
+    assert "1000+ flight hours" in out
+    assert "age 60+" in out
+
+    # Supporting facts must appear under satisfied criteria.
+    assert "space.crew.species = human" in out
+    assert "space.crew.flight_hours = 1000" in out
+
+    # Decision path is surfaced.
+    assert "species_eligible" in out
+
+    # Unused-facts block is rendered with its explanatory header.
+    assert "Unused fields" in out
+    assert "space.crew.has_radiation_cert" in out
+
+
+def test_decide_explain_handles_missing_decision_path(tmp_path, monkeypatch):
+    """not_eligible decisions omit decision_path per the engine contract;
+    the CLI must render without crashing and without a 'Satisfied by:' line."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+
+    explanation = {
+        "decision": "not_eligible",
+        "groups": [
+            {
+                "group": "towel_compliance",
+                "status": "not_satisfied",
+                "criteria": [
+                    {
+                        "criterion_id": "towel_compliance",
+                        "title": "Applicant carries a towel",
+                        "status": "not_satisfied",
+                    }
+                ],
+            }
+        ],
+        "unused_facts": [],
+    }
+
+    client = MagicMock()
+    client.decide.return_value = {**_decide_result(explanation), "decision": "not_eligible"}
+
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        from aethis_cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "decide",
+                "-b",
+                "aethis/spacecraft-crew-certification",
+                "-i",
+                '{"space.crew.has_towel":false}',
+                "--explain",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "Traceback" not in out
+    assert "Satisfied by:" not in out
+    assert "Applicant carries a towel" in out
+    # No unused-facts block when the list is empty.
+    assert "Unused fields" not in out

--- a/tests/test_decide_cmd.py
+++ b/tests/test_decide_cmd.py
@@ -36,9 +36,7 @@ _REAL_EXPLANATION = {
                     "criterion_id": "species_eligible",
                     "title": "Applicant is of an eligible species",
                     "status": "satisfied",
-                    "supporting_facts": [
-                        {"field": "space.crew.species", "value": "human"}
-                    ],
+                    "supporting_facts": [{"field": "space.crew.species", "value": "human"}],
                 }
             ],
         },


### PR DESCRIPTION
## Summary

- `aethis decide --explain` crashed with `AttributeError: 'str' object has no attribute 'get'` against any public ruleset (reproduced on 0.12.2 with `aethis/spacecraft-crew-certification`).
- Root cause: `_print_explanation` iterated `explanation` as a flat `list[dict]`, but the engine returns a nested dict — `{decision, decision_path?, groups: [{group, status, criteria: [{title, status, supporting_facts?, source_refs?}]}], unused_facts}`. Iterating that dict yielded its keys (strings), so `.get` raised. The shape mismatch dates back to the `--explain` feature commit (980deb6, 2026-03-30) — looks like the renderer was modelled on `aethis explain`'s flat `criteria` shape without noticing decide's `explanation` field is layered.
- Rewrote `_print_explanation` to walk the actual structure: per-group PASS/FAIL header, per-criterion check/cross + title, supporting facts indented underneath satisfied criteria, and a final list of unused fields (which the API contract calls out as useful for catching field-name typos).
- Added `tests/test_decide_cmd.py` with fixtures captured from the live API: one eligible case with supporting facts + unused_facts, one not_eligible case with `decision_path` omitted.
- Bumped to 0.12.3 + CHANGELOG entry per the published-package version-bump rule.

## Test plan

- [x] `uv run pytest tests/test_decide_cmd.py -v --no-cov` — 2 passed
- [x] `aethis decide -b aethis/spacecraft-crew-certification -i '{...eligible inputs...}' --explain` against `api.aethis.ai` — exit 0, layered Rules block renders with check/cross marks, supporting facts, and unused-fields footer
- [x] Same command with `space.crew.has_towel:false` — not_eligible path renders the ✗ under `towel_compliance` and correctly omits the `Satisfied by:` line (engine omits `decision_path` for not_eligible decisions)
- [x] Confirmed the 6 pre-existing failing tests in this repo (Rich console-width artifacts in `test_id_utils`, `test_status_cmd`, `test_account_cmd`, `test_guidance_cli`) are present on `main` and unrelated to this change.