### PR TITLE
feat(auth): pluggable auth providers + profile auth_mode/audience (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0 (2026-05-20)
+
+- feat: pluggable auth providers. Profiles now carry an optional `auth_mode` (default `"api_key"`) and `audience` field. The new `aethis_cli.auth_providers` module exposes a process-local registry; plugins (e.g. `aethis-cli-internal`) can `register_provider("gcloud_id_token", ...)` to add staff/internal auth schemes without touching the published package. `AethisClient` accepts an optional `auth_provider` callable, and `make_authed_client(...)` picks the right provider based on the active profile's mode.
+- feat: `aethis status` now prints the active profile name + auth mode (plus audience when set). For non-`api_key` modes it shows "provider-minted at request time" instead of calling `/me`, which is X-API-Key-only.
+- chore: un-hide the `--base-url` global flag in `aethis --help` (it was already implemented, just `hidden=True`).
+
 ## 0.12.3 (2026-05-19)
 
 - fix(decide): `aethis decide --explain` no longer crashes with `AttributeError: 'str' object has no attribute 'get'`. The CLI previously treated the engine's `explanation` field as a flat `list[dict]`, but the public decide route returns a layered `{decision, decision_path?, groups: [{group, status, criteria: [{title, status, supporting_facts?, ...}]}], unused_facts}` shape. The "Rules" block now walks the actual structure and renders each group + criterion with PASS/FAIL marks, supporting fact field/value pairs underneath satisfied criteria, and a final list of unused fields (provided answers that no satisfied criterion referenced — useful for catching field-name typos).

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.12.3"
+__version__ = "0.13.0"

--- a/aethis_cli/auth_providers.py
+++ b/aethis_cli/auth_providers.py
@@ -1,0 +1,92 @@
+"""Pluggable auth providers for ``AethisClient``.
+
+Each profile carries an ``auth_mode`` (default ``"api_key"``) that selects how
+the client builds its outbound request headers. A provider is a callable that
+takes a :class:`ProviderContext` and returns the headers to attach.
+
+Built-in modes:
+
+* ``api_key`` — ``X-API-Key: <api_key>`` (current default behaviour).
+* ``none`` — anonymous (no auth header). Equivalent to ``unsigned=True``.
+
+Plugins (e.g. ``aethis-cli-internal``) register additional modes at startup
+via :func:`register_provider`. The registry is process-local; the public
+package ships no Cloud Run URLs or gcloud logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+@dataclass(frozen=True)
+class ProviderContext:
+    """Inputs available to an auth provider when building request headers.
+
+    ``base_url`` is the already-resolved API host; providers that mint
+    audience-scoped tokens (e.g. GCP ID tokens for IAM-gated Cloud Run) should
+    use ``profile.get("audience") or base_url``.
+    """
+
+    api_key: Optional[str]
+    base_url: str
+    profile: dict
+
+
+AuthProvider = Callable[[ProviderContext], dict[str, str]]
+
+
+class UnknownAuthMode(ValueError):
+    """Raised when a profile selects an ``auth_mode`` that no plugin registered."""
+
+
+_PROVIDERS: dict[str, AuthProvider] = {}
+
+
+def register_provider(name: str, provider: AuthProvider) -> None:
+    """Register an auth provider under ``name``.
+
+    Re-registration replaces the previous provider — plugins can override
+    built-ins if they need to (rare).
+    """
+    _PROVIDERS[name] = provider
+
+
+def get_provider(name: str) -> AuthProvider:
+    """Return the provider registered under ``name`` or raise :class:`UnknownAuthMode`.
+
+    The error message lists the modes that *are* available, which is what a
+    misconfigured profile most needs to see.
+    """
+    try:
+        return _PROVIDERS[name]
+    except KeyError:
+        known = ", ".join(sorted(_PROVIDERS)) or "(none registered)"
+        raise UnknownAuthMode(
+            f"Unknown auth_mode '{name}'. Available modes: {known}. "
+            "If this is a staff mode (e.g. 'gcloud_id_token'), install "
+            "aethis-cli-internal."
+        )
+
+
+def known_modes() -> list[str]:
+    """Return the names of every currently-registered provider."""
+    return sorted(_PROVIDERS)
+
+
+# -- Built-in providers ------------------------------------------------------
+
+
+def _api_key_provider(ctx: ProviderContext) -> dict[str, str]:
+    if not ctx.api_key:
+        return {}
+    return {"X-API-Key": ctx.api_key}
+
+
+def _none_provider(ctx: ProviderContext) -> dict[str, str]:
+    return {}
+
+
+register_provider("api_key", _api_key_provider)
+register_provider("none", _none_provider)

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Optional
 
 import httpx
 
+from aethis_cli.auth_providers import AuthProvider, ProviderContext, get_provider
 from aethis_cli.errors import AethisAPIError
 
 # Callback signature for the lazy-auth refresh hook. Receives ``force_browser``
@@ -26,14 +27,26 @@ class AethisClient:
         on_auth_required: Optional[KeyRefreshCallback] = None,
         *,
         unsigned: bool = False,
+        auth_provider: Optional[AuthProvider] = None,
+        profile: Optional[dict] = None,
     ) -> None:
-        # ``unsigned=True`` skips the X-API-Key header so anonymous endpoints
-        # (e.g. the public ruleset catalogue) can be hit from the same client.
-        headers: dict[str, str] = {}
-        if api_key and not unsigned:
-            headers["X-API-Key"] = api_key
+        # Auth resolution: an explicit ``auth_provider`` wins (the staff plugin
+        # passes its gcloud-ID-token provider this way). Otherwise we keep
+        # legacy behaviour: ``unsigned=True`` => no auth header; api_key
+        # present => ``X-API-Key`` header. Every existing call site that just
+        # passes ``(api_key, base_url)`` keeps working unchanged.
+        if auth_provider is None:
+            auth_provider = get_provider("none" if unsigned else "api_key")
+        ctx = ProviderContext(
+            api_key=None if unsigned else api_key,
+            base_url=base_url,
+            profile=profile or {},
+        )
+        headers: dict[str, str] = dict(auth_provider(ctx))
         if anthropic_key:
             headers["X-Anthropic-Key"] = anthropic_key
+        self._auth_provider = auth_provider
+        self._auth_ctx = ctx
         self._client = httpx.Client(
             base_url=base_url,
             headers=headers,

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -123,9 +123,7 @@ def _print_identity_section() -> None:
         # ``/me`` is an X-API-Key endpoint; non-api_key modes don't have a
         # tenant identity to show. The provider mints its credential at
         # request time, so "Identity" here just confirms the scheme.
-        console.print(
-            f"[bold]Identity:[/bold]    [dim]{auth_mode} (provider-minted at request time)[/dim]"
-        )
+        console.print(f"[bold]Identity:[/bold]    [dim]{auth_mode} (provider-minted at request time)[/dim]")
         return
 
     api_key = _resolve_key_silent()

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -11,6 +11,8 @@ from aethis_cli._version import __version__
 from aethis_cli.client import AethisClient
 from aethis_cli.config import (
     DEFAULT_BASE_URL,
+    active_profile_name,
+    get_profile,
     load_project_config,
     read_state,
     resolve_base_url_with_source,
@@ -69,12 +71,21 @@ def _print_server_section() -> None:
     base_url, source = resolve_base_url_with_source()
     if source == "default":
         console.print(f"[bold]Server:[/bold]      {base_url}")
-        return
-    source_label = {
-        "env": "from AETHIS_BASE_URL env var",
-        "yaml": "from aethis.yaml",
-    }[source]
-    console.print(f"[bold]Server:[/bold]      [green]●[/green] {base_url}  [dim]({source_label})[/dim]")
+    else:
+        source_label = {
+            "env": "from AETHIS_BASE_URL env var",
+            "yaml": "from aethis.yaml",
+            "profile": "from active profile",
+        }.get(source, source)
+        console.print(f"[bold]Server:[/bold]      [green]●[/green] {base_url}  [dim]({source_label})[/dim]")
+
+    profile_name = active_profile_name()
+    profile = get_profile(profile_name)
+    auth_mode = profile.get("auth_mode") or "api_key"
+    audience = profile.get("audience")
+    aud_suffix = f"  [dim](audience: {audience})[/dim]" if audience else ""
+    console.print(f"[bold]Profile:[/bold]     {profile_name}")
+    console.print(f"[bold]Auth mode:[/bold]   {auth_mode}{aud_suffix}")
 
 
 def _print_project_section() -> tuple[Optional[object], Optional[str]]:
@@ -105,6 +116,17 @@ def _print_identity_section() -> None:
         base_url = cfg.base_url
     except ConfigError:
         pass
+
+    profile = get_profile(active_profile_name())
+    auth_mode = profile.get("auth_mode") or "api_key"
+    if auth_mode != "api_key":
+        # ``/me`` is an X-API-Key endpoint; non-api_key modes don't have a
+        # tenant identity to show. The provider mints its credential at
+        # request time, so "Identity" here just confirms the scheme.
+        console.print(
+            f"[bold]Identity:[/bold]    [dim]{auth_mode} (provider-minted at request time)[/dim]"
+        )
+        return
 
     api_key = _resolve_key_silent()
     if api_key is None:

--- a/aethis_cli/config.py
+++ b/aethis_cli/config.py
@@ -70,20 +70,38 @@ def make_authed_client(
     base_url: str,
     *,
     anthropic_key: Optional[str] = None,
+    profile: Optional[dict] = None,
 ) -> "AethisClient":
-    """Build an :class:`AethisClient` wired with the lazy-auth refresh hook.
+    """Build an :class:`AethisClient` for the active profile's auth mode.
 
-    Use this in place of constructing ``AethisClient`` directly so a 401 from
-    the server transparently triggers the inline browser sign-in flow once
-    before failing.
+    For the default ``api_key`` mode this wires the lazy-auth refresh hook so
+    a 401 from the server transparently triggers the inline browser sign-in
+    flow once before failing. For any other mode (e.g. ``gcloud_id_token``
+    contributed by ``aethis-cli-internal``) the corresponding provider is
+    selected from the registry and the refresh hook is left unset — those
+    providers handle their own token lifetime.
     """
     from aethis_cli.auth_helpers import require_auth_or_login_inline
+    from aethis_cli.auth_providers import get_provider
     from aethis_cli.client import AethisClient
 
-    def _refresh(force_browser: bool = True) -> str:
-        return require_auth_or_login_inline(base_url, force_browser=force_browser)
+    auth_mode = (profile or {}).get("auth_mode", "api_key")
+    auth_provider = get_provider(auth_mode)
 
-    return AethisClient(api_key, base_url, anthropic_key=anthropic_key, on_auth_required=_refresh)
+    on_auth_required = None
+    if auth_mode == "api_key":
+        def _refresh(force_browser: bool = True) -> str:
+            return require_auth_or_login_inline(base_url, force_browser=force_browser)
+        on_auth_required = _refresh
+
+    return AethisClient(
+        api_key,
+        base_url,
+        anthropic_key=anthropic_key,
+        on_auth_required=on_auth_required,
+        auth_provider=auth_provider,
+        profile=profile,
+    )
 
 
 def load_client_or_fallback() -> tuple["ProjectConfig", "AethisClient"]:
@@ -114,8 +132,14 @@ def load_client_or_fallback() -> tuple["ProjectConfig", "AethisClient"]:
     if is_anonymous_active():
         return cfg, make_anonymous_client(cfg.base_url)
 
-    api_key = require_auth_or_login_inline(cfg.base_url)
-    return cfg, make_authed_client(api_key, cfg.base_url)
+    profile = get_profile(active_profile_name())
+    if (profile.get("auth_mode") or "api_key") == "api_key":
+        api_key = require_auth_or_login_inline(cfg.base_url)
+    else:
+        # Non-api_key modes (e.g. gcloud_id_token) don't need a cached key —
+        # the provider mints its own credential at request time.
+        api_key = ""
+    return cfg, make_authed_client(api_key, cfg.base_url, profile=profile)
 
 
 def load_client_or_anon() -> tuple["ProjectConfig", "AethisClient"]:
@@ -141,11 +165,20 @@ def load_client_or_anon() -> tuple["ProjectConfig", "AethisClient"]:
     if is_anonymous_active():
         return cfg, make_anonymous_client(cfg.base_url)
 
+    profile = get_profile(active_profile_name())
+    auth_mode = profile.get("auth_mode") or "api_key"
+    if auth_mode != "api_key":
+        # Profile selects a non-api_key auth scheme (e.g. gcloud_id_token).
+        # The provider is responsible for minting its own credential; we
+        # don't need a cached API key, and we shouldn't fall back to
+        # anonymous just because one isn't present.
+        return cfg, make_authed_client("", cfg.base_url, profile=profile)
+
     api_key = _resolve_cached_key()
     if api_key is None:
         return cfg, make_anonymous_client(cfg.base_url)
 
-    return cfg, make_authed_client(api_key, cfg.base_url)
+    return cfg, make_authed_client(api_key, cfg.base_url, profile=profile)
 
 
 def load_project_config(path: Optional[Path] = None) -> ProjectConfig:
@@ -272,7 +305,18 @@ def credentials_path() -> Path:
 #         base_url: https://api.aethis.ai
 #       new-dev:
 #         api_key: ak_test_...
+#       internal-staging:                     # staff-only (aethis-cli-internal)
+#         base_url: https://aethis-core-internal-staging-...run.app
+#         auth_mode: gcloud_id_token
+#         audience: https://aethis-core-internal-staging-...run.app
 #       anonymous: {}
+#
+# Optional per-profile fields:
+#   * ``api_key`` — the ``X-API-Key`` header value (default ``auth_mode``).
+#   * ``base_url`` — overrides the global default for this profile.
+#   * ``auth_mode`` — name of an auth provider registered via
+#     :mod:`aethis_cli.auth_providers`. Defaults to ``"api_key"``.
+#   * ``audience`` — used by audience-scoped providers (e.g. GCP ID tokens).
 #
 # The reserved name ``anonymous`` is recognised even when not present in the
 # file: selecting it yields no API key (and the client runs in unsigned mode).
@@ -354,10 +398,20 @@ def get_profile(name: str) -> dict:
     return dict(creds["profiles"].get(name, {}))
 
 
-def set_profile(name: str, *, api_key: Optional[str] = None, base_url: Optional[str] = None) -> None:
+def set_profile(
+    name: str,
+    *,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    auth_mode: Optional[str] = None,
+    audience: Optional[str] = None,
+) -> None:
     """Create or update a named profile in the credentials file.
 
     Only fields passed as non-None are written; existing fields are preserved.
+    ``auth_mode`` selects an auth provider registered via
+    :mod:`aethis_cli.auth_providers` (default ``"api_key"``); ``audience`` is
+    consumed by audience-scoped providers like ``gcloud_id_token``.
     """
     if name == ANONYMOUS_PROFILE:
         raise ConfigError(
@@ -370,6 +424,10 @@ def set_profile(name: str, *, api_key: Optional[str] = None, base_url: Optional[
         profile["api_key"] = api_key
     if base_url is not None:
         profile["base_url"] = base_url
+    if auth_mode is not None:
+        profile["auth_mode"] = auth_mode
+    if audience is not None:
+        profile["audience"] = audience
     creds["profiles"][name] = profile
     save_credentials(creds)
 

--- a/aethis_cli/config.py
+++ b/aethis_cli/config.py
@@ -90,8 +90,10 @@ def make_authed_client(
 
     on_auth_required = None
     if auth_mode == "api_key":
+
         def _refresh(force_browser: bool = True) -> str:
             return require_auth_or_login_inline(base_url, force_browser=force_browser)
+
         on_auth_required = _refresh
 
     return AethisClient(

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -100,8 +100,11 @@ def main(
     base_url: Optional[str] = typer.Option(
         None,
         "--base-url",
-        help="Override the API base URL (defaults to AETHIS_BASE_URL or https://api.aethis.ai).",
-        hidden=True,
+        help=(
+            "Override the API base URL for this command (e.g. local dev, "
+            "staging). Equivalent to setting AETHIS_BASE_URL. Defaults to the "
+            "active profile's base_url, or https://api.aethis.ai."
+        ),
     ),
     profile: Optional[str] = typer.Option(
         None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.12.3"
+version = "0.13.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -1,0 +1,73 @@
+"""Tests for the auth-provider registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from aethis_cli.auth_providers import (
+    ProviderContext,
+    UnknownAuthMode,
+    get_provider,
+    known_modes,
+    register_provider,
+)
+
+
+def _ctx(api_key: str | None = None, audience: str | None = None) -> ProviderContext:
+    profile: dict = {}
+    if audience:
+        profile["audience"] = audience
+    return ProviderContext(api_key=api_key, base_url="https://api.aethis.ai", profile=profile)
+
+
+def test_api_key_provider_emits_x_api_key_header() -> None:
+    headers = get_provider("api_key")(_ctx(api_key="ak_live_abc"))
+    assert headers == {"X-API-Key": "ak_live_abc"}
+
+
+def test_api_key_provider_returns_empty_when_key_missing() -> None:
+    # Anonymous decision endpoints still go through this provider when no
+    # cached key is present — the absence is expected, not an error.
+    headers = get_provider("api_key")(_ctx(api_key=None))
+    assert headers == {}
+
+
+def test_none_provider_always_empty() -> None:
+    assert get_provider("none")(_ctx(api_key="ak_live_abc")) == {}
+    assert get_provider("none")(_ctx(api_key=None)) == {}
+
+
+def test_unknown_mode_raises_with_helpful_message() -> None:
+    with pytest.raises(UnknownAuthMode) as exc_info:
+        get_provider("gcloud_id_token")
+    msg = str(exc_info.value)
+    assert "gcloud_id_token" in msg
+    assert "api_key" in msg  # lists registered modes
+    assert "aethis-cli-internal" in msg
+
+
+def test_register_and_lookup_plugin_provider() -> None:
+    def stub_provider(ctx: ProviderContext) -> dict[str, str]:
+        return {"Authorization": f"Bearer fake-token-for-{ctx.profile.get('audience')}"}
+
+    register_provider("test_provider", stub_provider)
+    try:
+        assert "test_provider" in known_modes()
+        headers = get_provider("test_provider")(_ctx(audience="aud-1"))
+        assert headers == {"Authorization": "Bearer fake-token-for-aud-1"}
+    finally:
+        # Don't leak the test provider into other test modules.
+        from aethis_cli import auth_providers
+
+        auth_providers._PROVIDERS.pop("test_provider", None)
+
+
+def test_re_register_replaces_provider() -> None:
+    from aethis_cli import auth_providers
+
+    original = auth_providers._PROVIDERS["api_key"]
+    try:
+        register_provider("api_key", lambda ctx: {"X-Other": "x"})
+        assert get_provider("api_key")(_ctx()) == {"X-Other": "x"}
+    finally:
+        auth_providers._PROVIDERS["api_key"] = original

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,6 +55,28 @@ def test_decide_401_raises_api_error(respx_mock):
 
 
 @respx.mock(base_url=BASE)
+def test_custom_auth_provider_overrides_x_api_key(respx_mock):
+    route = respx_mock.post("/api/v1/public/decide").mock(
+        return_value=httpx.Response(200, json={"decision": "eligible"})
+    )
+
+    def gcloud_provider(ctx):
+        return {"Authorization": f"Bearer fake-id-token-for-{ctx.profile.get('audience')}"}
+
+    client = AethisClient(
+        api_key=None,
+        base_url=BASE,
+        auth_provider=gcloud_provider,
+        profile={"audience": "https://internal.example/aud"},
+    )
+    client.decide("b:1", {})
+    sent = route.calls[0].request.headers
+    assert sent["authorization"] == "Bearer fake-id-token-for-https://internal.example/aud"
+    # The custom provider replaces the default — no X-API-Key leaks out.
+    assert "x-api-key" not in sent
+
+
+@respx.mock(base_url=BASE)
 def test_get_schema(respx_mock):
     respx_mock.get("/api/v1/public/rulesets/b:1/schema").mock(
         return_value=httpx.Response(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -110,6 +110,38 @@ def test_remove_profile_resets_active_when_active(tmp_path: Path) -> None:
     assert config.active_profile_name() == "default"
 
 
+def test_set_profile_writes_auth_mode_and_audience(tmp_path: Path) -> None:
+    config.set_profile(
+        "internal-staging",
+        base_url="https://aethis-core-internal-staging.run.app",
+        auth_mode="gcloud_id_token",
+        audience="https://aethis-core-internal-staging.run.app",
+    )
+    creds = config.load_credentials()
+    profile = creds["profiles"]["internal-staging"]
+    assert profile["base_url"] == "https://aethis-core-internal-staging.run.app"
+    assert profile["auth_mode"] == "gcloud_id_token"
+    assert profile["audience"] == "https://aethis-core-internal-staging.run.app"
+    # Crucially, no api_key was written — that's the whole point.
+    assert "api_key" not in profile
+
+
+def test_set_profile_preserves_existing_auth_mode_when_unspecified(tmp_path: Path) -> None:
+    config.set_profile("staff", base_url="https://foo", auth_mode="gcloud_id_token")
+    # Now update only the base_url; auth_mode should stick.
+    config.set_profile("staff", base_url="https://bar")
+    profile = config.get_profile("staff")
+    assert profile["auth_mode"] == "gcloud_id_token"
+    assert profile["base_url"] == "https://bar"
+
+
+def test_legacy_profile_without_auth_mode_defaults_to_api_key(tmp_path: Path) -> None:
+    _write_legacy_single_key(tmp_path, "ak_legacy")
+    profile = config.get_profile("default")
+    # ``auth_mode`` is implicit — readers default to ``"api_key"`` when absent.
+    assert profile.get("auth_mode") in (None, "api_key")
+
+
 def test_profile_list_command_marks_active(tmp_path: Path) -> None:
     config.set_profile("admin", api_key="ak_admin_with_long_suffix_xyz")
     config.set_active_profile("admin")


### PR DESCRIPTION
## Summary

- Adds `aethis_cli.auth_providers` — a tiny registry that plugins can extend with new auth schemes. Built-ins: `api_key` (existing `X-API-Key`) and `none` (anonymous).
- Profiles in `~/.config/aethis/credentials` now carry optional `auth_mode` (default `"api_key"`) and `audience` fields. Schema is fully backwards-compatible.
- `AethisClient` accepts an optional `auth_provider` callable + `profile` dict. Existing call sites (`AethisClient(api_key, base_url)`) are unchanged.
- `make_authed_client()` resolves the provider from the active profile's mode and only wires the lazy-auth refresh hook for `api_key` mode.
- `aethis status` shows Profile + Auth mode lines; skips `/me` for non-api_key modes.
- `--base-url` un-hidden in `--help`.

## Why

A staff user trying to evaluate a ruleset on the IAM-gated `aethis-core-internal-*` Cloud Run services had to (a) self-grant `roles/run.invoker`, (b) spin up `gcloud run services proxy`, (c) hand-set `AETHIS_BASE_URL`. Even then, the CLI's only auth scheme was `X-API-Key`, not the Google ID token the service expects. This PR is the platform half of the fix; the staff plugin (`aethis-cli-internal#…`) registers `gcloud_id_token` and seeds the four canonical staff profiles.

Captured DX context + the bigger deferred server-side fix in workspace ADR [`2026-05-19-aethis-core-host-consolidation.md`](https://github.com/Aethis-ai/aethis-workspace/blob/main/docs/adrs/2026-05-19-aethis-core-host-consolidation.md).

## Test plan

- [x] New `tests/test_auth_providers.py` (6 tests) — registry behaviour, default providers, unknown-mode error message
- [x] `tests/test_profiles.py` (+3) — `auth_mode`/`audience` round-trip, partial updates preserve fields, legacy profiles default to `api_key`
- [x] `tests/test_client.py` (+1) — custom provider overrides default and replaces (not augments) the auth header
- [x] All 20 targeted tests pass; pre-existing 6 failures on `main` (rich-console ANSI escapes in unrelated tests) unchanged
- [x] Smoke: `aethis --help` shows `--base-url`; `aethis status` shows Profile + Auth mode lines

## Compatibility

- Existing single-key legacy credentials files load unchanged.
- Profiles without `auth_mode` default to `api_key` at read time.
- Every `AethisClient(...)` call site keeps working with positional/keyword args as before.