### PR TITLE
feat(rulesets): show section name column in 'rulesets list' output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.1 (2026-05-20)
+
+- feat(rulesets): show the human-readable section `name` column in `aethis rulesets list` output (both the public showcase and project-scoped tables). Surfaces the new field from aethis-core v0.18.0.
+
 ## 0.13.0 (2026-05-20)
 
 - feat: pluggable auth providers. Profiles now carry an optional `auth_mode` (default `"api_key"`) and `audience` field. The new `aethis_cli.auth_providers` module exposes a process-local registry; plugins (e.g. `aethis-cli-internal`) can `register_provider("gcloud_id_token", ...)` to add staff/internal auth schemes without touching the published package. `AethisClient` accepts an optional `auth_provider` callable, and `make_authed_client(...)` picks the right provider based on the active profile's mode.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/aethis_cli/commands/rulesets_cmd.py
+++ b/aethis_cli/commands/rulesets_cmd.py
@@ -25,6 +25,7 @@ def _print_public_table(rulesets: list[dict]) -> None:
     table = Table(title="Public showcase rulesets")
     table.add_column("Slug", style="cyan")
     table.add_column("Ruleset ID", style="dim")
+    table.add_column("Name")
     table.add_column("Description")
     table.add_column("Fields", justify="right")
     table.add_column("Rules", justify="right")
@@ -33,6 +34,7 @@ def _print_public_table(rulesets: list[dict]) -> None:
         table.add_row(
             r.get("slug") or "[dim]—[/dim]",
             r.get("ruleset_id", ""),
+            r.get("name") or "[dim]—[/dim]",
             r.get("description", "") or "[dim]—[/dim]",
             str(r.get("field_count", 0)),
             str(r.get("rule_count", 0)),
@@ -121,6 +123,7 @@ def list_rulesets(
 
     table = Table(title=f"Rulesets — {pid}")
     table.add_column("Ruleset ID", style="cyan")
+    table.add_column("Name")
     table.add_column("Status")
     table.add_column("Fields", justify="right")
     table.add_column("Rules", justify="right")
@@ -132,6 +135,7 @@ def list_rulesets(
         style = "dim" if s == "archived" else None
         table.add_row(
             b["ruleset_id"],
+            b.get("name") or "[dim]—[/dim]",
             s,
             str(b.get("total_fields", 0)),
             str(b.get("total_rules", 0)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.13.0"
+version = "0.13.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Render the new ruleset `name` field in both tables produced by
`aethis rulesets list` — the cross-tenant public showcase and the
project-scoped tenant view.

## Why

`aethis-core` PRs #130–132 added `name: Optional[str]` to
`RulesetSummary` (public catalogue) and `RulesetListItem` (project
scoped). The new field is live on `api.aethis.ai` in engine
**v0.18.0**, but the CLI was dropping it on the floor — users had no
way to see the human-readable section name without hitting
`/explain`.

## Changes

- `aethis_cli/commands/rulesets_cmd.py`:
  - `_print_public_table`: insert a `Name` column between `Ruleset ID`
    and `Description`.
  - Project-scoped table: insert a `Name` column after `Ruleset ID`.
  - Both columns render `[dim]—[/dim]` when the field is absent so
    older engines (and pre-rename rulesets) still display cleanly.
- Patch bump `0.13.0` → `0.13.1` (`pyproject.toml` + `_version.py`).
- `CHANGELOG.md` entry under the new version heading.

## Test plan

- [x] `uv run pytest` — 179 passed; 6 pre-existing failures unrelated
  to this change (ANSI-colour matchers in `test_account_cmd`,
  `test_guidance_cli`, `test_id_utils`, `test_status_cmd`; confirmed
  by stashing the edits and re-running on clean `main`).
- [x] `uv run --with ruff ruff check aethis_cli/commands/rulesets_cmd.py`
  — all checks passed.
- [ ] Manual: `aethis rulesets list --public` against `api.aethis.ai`
  shows the new `Name` column populated for v0.18.0-era rulesets.
- [ ] Manual: `aethis rulesets list -p <project_id>` for a tenant
  with named rulesets shows the column populated.

Engine dependency: live on `api.aethis.ai` as of v0.18.0.