### PR TITLE
feat(rulebooks): aethis rulebooks command group (Phase B.1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.14.0 (2026-05-21)
+
+- **feat(rulebooks): new `aethis rulebooks` command group.** First user-facing surface for the converged 2-term authoring model (workspace PR #64, aethis-core PRs #133-139). A Rulebook is the whole form — the execution unit — that owns a locked field vocabulary, composition logic, rulebook-level test cases, and an integer version history.
+  - `aethis rulebooks list` — list tenant rulebooks
+  - `aethis rulebooks show <id-or-slug>` — full configuration
+  - `aethis rulebooks create <name> --domain <d> [--slug ...]` — create draft
+  - `aethis rulebooks set-fields <id> -f fields.yaml` — replace locked vocabulary
+  - `aethis rulebooks lock-fields <id>` / `unlock-fields <id>` / `get-fields <id>`
+  - `aethis rulebooks tests add <id> -f scenario.yaml` — embed full-form test case
+  - `aethis rulebooks tests list <id>` / `delete <id> <tc_id>`
+  - `aethis rulebooks activate <id>` / `archive <id>` — lifecycle
+  - `aethis rulebooks decide <id> -i '{...}' [--explain]` — evaluate composed rulebook
+  - `aethis rulebooks schema <id>` / `explain <id>` — combined schema + explanations
+- feat(client): new `AethisClient` methods for every rulebook REST endpoint (create / list / show / update / activate / archive / set-fields / lock-fields / unlock-fields / get-fields / add-test / list-tests / delete-test / decide-rulebook / get-rulebook-schema / explain-rulebook).
+- Requires aethis-core v0.19.0+ live on the target API (the Phase A.6 endpoints).
+- The legacy `aethis projects` / `aethis generate` / `aethis test` / `aethis publish` command tree is unchanged in this release — replacement lands in the next minor (Phase B.1b: ruleset lifecycle + project retirement). No backward-compat shims are planned past public release.
+
 ## 0.13.1 (2026-05-20)
 
 - feat(rulesets): show the human-readable section `name` column in `aethis rulesets list` output (both the public showcase and project-scoped tables). Surfaces the new field from aethis-core v0.18.0.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -279,9 +279,7 @@ class AethisClient:
         return self._request("GET", "/api/v1/public/rulebooks/")
 
     def get_rulebook(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}"
-        )
+        return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}")
 
     def update_rulebook(
         self,
@@ -311,30 +309,20 @@ class AethisClient:
         )
 
     def activate_rulebook(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "POST", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/activate"
-        )
+        return self._request("POST", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/activate")
 
     def archive_rulebook(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "POST", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/archive"
-        )
+        return self._request("POST", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/archive")
 
     def get_rulebook_schema(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/schema"
-        )
+        return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/schema")
 
     def explain_rulebook(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/explain"
-        )
+        return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/explain")
 
     # -- Rulebook fields (Phase A.6) --
 
-    def set_rulebook_fields(
-        self, rulebook_id_or_slug: str, fields: list[dict]
-    ) -> dict:
+    def set_rulebook_fields(self, rulebook_id_or_slug: str, fields: list[dict]) -> dict:
         return self._request(
             "POST",
             f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields",
@@ -354,9 +342,7 @@ class AethisClient:
         )
 
     def get_rulebook_fields(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields"
-        )
+        return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields")
 
     # -- Rulebook-level test cases (Phase A.6) --
 
@@ -379,21 +365,15 @@ class AethisClient:
         )
 
     def list_rulebook_test_cases(self, rulebook_id_or_slug: str) -> dict:
-        return self._request(
-            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/tests"
-        )
+        return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/tests")
 
-    def delete_rulebook_test_case(
-        self, rulebook_id_or_slug: str, tc_id: str
-    ) -> None:
+    def delete_rulebook_test_case(self, rulebook_id_or_slug: str, tc_id: str) -> None:
         self._request(
             "DELETE",
             f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/tests/{tc_id}",
         )
 
-    def decide_rulebook(
-        self, rulebook_id_or_slug: str, field_values: dict, **opts: Any
-    ) -> dict:
+    def decide_rulebook(self, rulebook_id_or_slug: str, field_values: dict, **opts: Any) -> dict:
         """Evaluate a rulebook against field_values.
 
         Same endpoint as :py:meth:`decide` but passes ``rulebook_id`` instead

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -250,6 +250,166 @@ class AethisClient:
     def archive_ruleset(self, ruleset_id: str) -> dict:
         return self._request("POST", f"/api/v1/public/rulesets/{ruleset_id}/archive")
 
+    # -- Rulebooks API (Phase B.1 — converged 2-term model) --
+
+    def create_rulebook(
+        self,
+        name: str,
+        *,
+        domain: str = "",
+        description: Optional[str] = None,
+        slug: Optional[str] = None,
+        ruleset_refs: Optional[list[dict]] = None,
+        outcome_logic: Optional[dict] = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "name": name,
+            "domain": domain,
+            "ruleset_refs": ruleset_refs or [],
+        }
+        if description is not None:
+            body["description"] = description
+        if slug is not None:
+            body["slug"] = slug
+        if outcome_logic is not None:
+            body["outcome_logic"] = outcome_logic
+        return self._request("POST", "/api/v1/public/rulebooks/", json=body)
+
+    def list_rulebooks(self) -> list[dict]:
+        return self._request("GET", "/api/v1/public/rulebooks/")
+
+    def get_rulebook(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}"
+        )
+
+    def update_rulebook(
+        self,
+        rulebook_id_or_slug: str,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        ruleset_refs: Optional[list[dict]] = None,
+        outcome_logic: Optional[dict] = None,
+        slug: Optional[str] = None,
+    ) -> dict:
+        body: dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if ruleset_refs is not None:
+            body["ruleset_refs"] = ruleset_refs
+        if outcome_logic is not None:
+            body["outcome_logic"] = outcome_logic
+        if slug is not None:
+            body["slug"] = slug
+        return self._request(
+            "PATCH",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}",
+            json=body,
+        )
+
+    def activate_rulebook(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "POST", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/activate"
+        )
+
+    def archive_rulebook(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "POST", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/archive"
+        )
+
+    def get_rulebook_schema(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/schema"
+        )
+
+    def explain_rulebook(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/explain"
+        )
+
+    # -- Rulebook fields (Phase A.6) --
+
+    def set_rulebook_fields(
+        self, rulebook_id_or_slug: str, fields: list[dict]
+    ) -> dict:
+        return self._request(
+            "POST",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields",
+            json={"fields": fields},
+        )
+
+    def lock_rulebook_fields(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "POST",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields/lock",
+        )
+
+    def unlock_rulebook_fields(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "POST",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields/unlock",
+        )
+
+    def get_rulebook_fields(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/fields"
+        )
+
+    # -- Rulebook-level test cases (Phase A.6) --
+
+    def add_rulebook_test_case(
+        self,
+        rulebook_id_or_slug: str,
+        *,
+        name: str,
+        field_values: dict,
+        expected_outcome: str,
+    ) -> dict:
+        return self._request(
+            "POST",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/tests",
+            json={
+                "name": name,
+                "field_values": field_values,
+                "expected_outcome": expected_outcome,
+            },
+        )
+
+    def list_rulebook_test_cases(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/tests"
+        )
+
+    def delete_rulebook_test_case(
+        self, rulebook_id_or_slug: str, tc_id: str
+    ) -> None:
+        self._request(
+            "DELETE",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/tests/{tc_id}",
+        )
+
+    def decide_rulebook(
+        self, rulebook_id_or_slug: str, field_values: dict, **opts: Any
+    ) -> dict:
+        """Evaluate a rulebook against field_values.
+
+        Same endpoint as :py:meth:`decide` but passes ``rulebook_id`` instead
+        of ``ruleset_id``. The engine resolves the rulebook's live ruleset
+        pins and runs the composed evaluation.
+        """
+        return self._request(
+            "POST",
+            "/api/v1/public/decide",
+            json={
+                "rulebook_id": rulebook_id_or_slug,
+                "field_values": field_values,
+                **opts,
+            },
+        )
+
     # -- Domain guidance API --
 
     def add_domain_guidance(

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -61,8 +61,7 @@ def _load_yaml_or_json(path: Path) -> Any:
             import yaml  # type: ignore[import-untyped]
         except ImportError as exc:
             raise typer.BadParameter(
-                f"YAML input requires PyYAML; install it or pass a .json "
-                f"file instead. ({exc})"
+                f"YAML input requires PyYAML; install it or pass a .json file instead. ({exc})"
             ) from exc
         return yaml.safe_load(text)
     return json.loads(text)
@@ -89,9 +88,7 @@ def list_rulebooks() -> None:
         raise typer.Exit(code=1)
 
     if not rulebooks:
-        console.print(
-            "[dim]No rulebooks yet. Create one with `aethis rulebooks create`.[/dim]"
-        )
+        console.print("[dim]No rulebooks yet. Create one with `aethis rulebooks create`.[/dim]")
         return
 
     table = Table(title="Rulebooks")
@@ -157,9 +154,7 @@ def create_rulebook(
             "intend to reference from outside the CLI."
         ),
     ),
-    description: Optional[str] = typer.Option(
-        None, "--description", help="Optional description."
-    ),
+    description: Optional[str] = typer.Option(None, "--description", help="Optional description."),
 ) -> None:
     """Create a new Rulebook.
 
@@ -182,10 +177,7 @@ def create_rulebook(
         error_panel(e)
         raise typer.Exit(code=1)
 
-    success(
-        f"Created rulebook {rb['rulebook_id']}"
-        + (f" (slug: {rb['slug']})" if rb.get("slug") else "")
-    )
+    success(f"Created rulebook {rb['rulebook_id']}" + (f" (slug: {rb['slug']})" if rb.get("slug") else ""))
     console.print_json(data=rb)
 
 
@@ -203,7 +195,7 @@ def set_fields(
         "-f",
         exists=True,
         readable=True,
-        help='Path to fields.yaml or fields.json (list of {key, sort, ...}).',
+        help="Path to fields.yaml or fields.json (list of {key, sort, ...}).",
     ),
 ) -> None:
     """Replace the rulebook's locked field vocabulary.
@@ -225,9 +217,7 @@ def set_fields(
     else:
         fields = payload
     if not isinstance(fields, list) or not fields:
-        raise typer.BadParameter(
-            f"{file} must contain a non-empty list of field specs."
-        )
+        raise typer.BadParameter(f"{file} must contain a non-empty list of field specs.")
 
     _cfg, client = load_client_or_fallback()
     try:
@@ -262,9 +252,7 @@ def lock_fields(
         error_panel(e)
         raise typer.Exit(code=1)
     success(f"Locked field vocabulary on rulebook {rulebook}")
-    console.print(
-        f"Locked field count: [cyan]{len(result.get('fields', []))}[/cyan]"
-    )
+    console.print(f"Locked field count: [cyan]{len(result.get('fields', []))}[/cyan]")
 
 
 @rulebooks_app.command(name="unlock-fields")
@@ -292,9 +280,7 @@ def get_fields(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
-    console.print(
-        f"Lock state: [cyan]{result['field_lock_state']}[/cyan]"
-    )
+    console.print(f"Lock state: [cyan]{result['field_lock_state']}[/cyan]")
     fields = result.get("fields", [])
     if not fields:
         console.print("[dim]No fields locked yet.[/dim]")
@@ -364,10 +350,7 @@ def decide_rulebook(
         None,
         "--inputs",
         "-i",
-        help=(
-            'Field values as JSON inline (e.g. \'{"age": 21}\') or @path.json '
-            "to load from disk."
-        ),
+        help=("Field values as JSON inline (e.g. '{\"age\": 21}') or @path.json to load from disk."),
     ),
     input_file: Optional[Path] = typer.Option(
         None,
@@ -376,9 +359,7 @@ def decide_rulebook(
         readable=True,
         help="YAML or JSON file with field values (alternative to --inputs).",
     ),
-    explain: bool = typer.Option(
-        False, "--explain", help="Include a human-readable explanation."
-    ),
+    explain: bool = typer.Option(False, "--explain", help="Include a human-readable explanation."),
 ) -> None:
     """Evaluate a rulebook against a set of field values.
 
@@ -388,13 +369,9 @@ def decide_rulebook(
         aethis rulebooks decide aethis/uk-fsm --input-file persona.yaml --explain
     """
     if inputs is None and input_file is None:
-        raise typer.BadParameter(
-            "Provide field values via --inputs / -i or --input-file."
-        )
+        raise typer.BadParameter("Provide field values via --inputs / -i or --input-file.")
     if inputs and input_file:
-        raise typer.BadParameter(
-            "Pass either --inputs or --input-file, not both."
-        )
+        raise typer.BadParameter("Pass either --inputs or --input-file, not both.")
 
     if input_file is not None:
         field_values = _load_yaml_or_json(input_file)
@@ -406,14 +383,10 @@ def decide_rulebook(
             try:
                 field_values = json.loads(inputs or "{}")
             except json.JSONDecodeError as exc:
-                raise typer.BadParameter(
-                    f"--inputs must be valid JSON: {exc}"
-                ) from exc
+                raise typer.BadParameter(f"--inputs must be valid JSON: {exc}") from exc
 
     if not isinstance(field_values, dict):
-        raise typer.BadParameter(
-            "Field values must be a JSON object / YAML mapping."
-        )
+        raise typer.BadParameter("Field values must be a JSON object / YAML mapping.")
 
     _cfg, client = load_client_or_fallback()
     try:
@@ -498,17 +471,13 @@ def tests_add(
     elif isinstance(payload, list):
         cases = payload
     else:
-        raise typer.BadParameter(
-            f"{file} must contain a test-case object or a list of them."
-        )
+        raise typer.BadParameter(f"{file} must contain a test-case object or a list of them.")
 
     _cfg, client = load_client_or_fallback()
     added: list[dict[str, Any]] = []
     for tc in cases:
         if not isinstance(tc, dict):
-            raise typer.BadParameter(
-                f"Each test case must be a mapping; got {type(tc).__name__}."
-            )
+            raise typer.BadParameter(f"Each test case must be a mapping; got {type(tc).__name__}.")
         try:
             result = client.add_rulebook_test_case(
                 rulebook,
@@ -517,9 +486,7 @@ def tests_add(
                 expected_outcome=tc["expected_outcome"],
             )
         except KeyError as exc:
-            raise typer.BadParameter(
-                f"Test case missing required key: {exc}"
-            ) from exc
+            raise typer.BadParameter(f"Test case missing required key: {exc}") from exc
         except AethisAPIError as e:
             error_panel(e)
             raise typer.Exit(code=1)
@@ -568,9 +535,7 @@ def tests_delete(
 ) -> None:
     """Delete a rulebook-level test case by tc_id."""
     if not yes:
-        confirmed = typer.confirm(
-            f"Delete test case {tc_id} from rulebook {rulebook}?"
-        )
+        confirmed = typer.confirm(f"Delete test case {tc_id} from rulebook {rulebook}?")
         if not confirmed:
             raise typer.Abort()
     _cfg, client = load_client_or_fallback()

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -1,0 +1,585 @@
+"""aethis rulebooks — author, configure, and evaluate Rulebooks.
+
+In the converged 2-term authoring model (`docs/RULEBOOK_AUTHORING_MODEL.md`
+in the workspace), a **Rulebook** is the whole form — the execution unit.
+It owns the locked field vocabulary, the composition expression, rulebook-
+level test cases, and an integer version history. Rulesets (the parts of a
+rulebook) are managed via `aethis rulesets …` (separate command group).
+
+This command group covers the rulebook lifecycle and configuration:
+
+    aethis rulebooks list
+    aethis rulebooks show <id-or-slug>
+    aethis rulebooks create <name> --domain <d> [--slug ...]
+    aethis rulebooks set-fields <id> -f fields.yaml
+    aethis rulebooks lock-fields <id>
+    aethis rulebooks unlock-fields <id>
+    aethis rulebooks tests add <id> -f scenario.yaml
+    aethis rulebooks tests list <id>
+    aethis rulebooks tests delete <id> <tc_id>
+    aethis rulebooks activate <id>
+    aethis rulebooks archive <id>
+    aethis rulebooks decide <id> -i '{"field":"value"}'
+    aethis rulebooks schema <id>
+    aethis rulebooks explain <id>
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import typer
+from rich.table import Table
+
+from aethis_cli.config import load_client_or_fallback
+from aethis_cli.errors import AethisAPIError
+from aethis_cli.output import console, error_panel, success
+
+rulebooks_app = typer.Typer(
+    name="rulebooks",
+    help="Author, configure, and evaluate Rulebooks.",
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,
+)
+
+tests_app = typer.Typer(
+    name="tests",
+    help="Manage rulebook-level test cases.",
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,
+)
+
+
+def _load_yaml_or_json(path: Path) -> Any:
+    """Load a YAML or JSON file based on extension. YAML support is lazy
+    so callers without PyYAML can still use JSON inputs."""
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in (".yaml", ".yml"):
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise typer.BadParameter(
+                f"YAML input requires PyYAML; install it or pass a .json "
+                f"file instead. ({exc})"
+            ) from exc
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+# ============================================================================
+# rulebooks list
+# ============================================================================
+
+
+@rulebooks_app.command(name="list")
+def list_rulebooks() -> None:
+    """List rulebooks visible to the current tenant.
+
+    Example::
+
+        aethis rulebooks list
+    """
+    _cfg, client = load_client_or_fallback()
+    try:
+        rulebooks = client.list_rulebooks()
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    if not rulebooks:
+        console.print(
+            "[dim]No rulebooks yet. Create one with `aethis rulebooks create`.[/dim]"
+        )
+        return
+
+    table = Table(title="Rulebooks")
+    table.add_column("Slug", style="cyan")
+    table.add_column("Rulebook ID", style="dim")
+    table.add_column("Name")
+    table.add_column("Domain")
+    table.add_column("Status")
+    table.add_column("Rulesets", justify="right")
+
+    for rb in rulebooks:
+        table.add_row(
+            rb.get("slug") or "[dim]—[/dim]",
+            rb.get("rulebook_id", ""),
+            rb.get("name") or "[dim]—[/dim]",
+            rb.get("domain") or "[dim]—[/dim]",
+            rb.get("status", ""),
+            str(len(rb.get("ruleset_refs", []) or [])),
+        )
+    console.print(table)
+
+
+# ============================================================================
+# rulebooks show
+# ============================================================================
+
+
+@rulebooks_app.command(name="show")
+def show_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Show a single rulebook's full configuration."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        rb = client.get_rulebook(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    console.print_json(data=rb)
+
+
+# ============================================================================
+# rulebooks create
+# ============================================================================
+
+
+@rulebooks_app.command(name="create")
+def create_rulebook(
+    name: str = typer.Argument(..., help='Human-readable name (e.g. "UK FSM").'),
+    domain: str = typer.Option(
+        "",
+        "--domain",
+        "-d",
+        help='Domain hint, lower-snake (e.g. "uk_fsm").',
+    ),
+    slug: Optional[str] = typer.Option(
+        None,
+        "--slug",
+        help=(
+            "Stable human-readable alias (e.g. aethis/uk-fsm). "
+            "Globally unique when set; recommended for any rulebook you "
+            "intend to reference from outside the CLI."
+        ),
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", help="Optional description."
+    ),
+) -> None:
+    """Create a new Rulebook.
+
+    The new rulebook is created with no rulesets, no field vocabulary, no
+    tests, and ``status="draft"``. Populate it with::
+
+        aethis rulebooks set-fields <id> -f fields.yaml
+        aethis rulebooks tests add <id> -f scenario.yaml
+        aethis rulesets create <rulebook> <ruleset_name>   # (Phase B.1b)
+    """
+    _cfg, client = load_client_or_fallback()
+    try:
+        rb = client.create_rulebook(
+            name=name,
+            domain=domain,
+            slug=slug,
+            description=description,
+        )
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    success(
+        f"Created rulebook {rb['rulebook_id']}"
+        + (f" (slug: {rb['slug']})" if rb.get("slug") else "")
+    )
+    console.print_json(data=rb)
+
+
+# ============================================================================
+# rulebooks set-fields
+# ============================================================================
+
+
+@rulebooks_app.command(name="set-fields")
+def set_fields(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        exists=True,
+        readable=True,
+        help='Path to fields.yaml or fields.json (list of {key, sort, ...}).',
+    ),
+) -> None:
+    """Replace the rulebook's locked field vocabulary.
+
+    Refused if currently locked — call ``unlock-fields`` first.
+
+    The file is a list of field specs, e.g.::
+
+        - key: applicant.age
+          sort: Int
+        - key: child.year_group
+          sort: Enum
+          enum_values: [reception, year_1, year_2]
+    """
+    payload = _load_yaml_or_json(file)
+    if isinstance(payload, dict) and "fields" in payload:
+        # Allow either a top-level list or a {fields: [...]} object.
+        fields = payload["fields"]
+    else:
+        fields = payload
+    if not isinstance(fields, list) or not fields:
+        raise typer.BadParameter(
+            f"{file} must contain a non-empty list of field specs."
+        )
+
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.set_rulebook_fields(rulebook, fields)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    success(f"Set {len(result['fields'])} field(s) on rulebook {rulebook}")
+    console.print(f"Lock state: [cyan]{result['field_lock_state']}[/cyan]")
+
+
+# ============================================================================
+# rulebooks lock-fields / unlock-fields / get-fields
+# ============================================================================
+
+
+@rulebooks_app.command(name="lock-fields")
+def lock_fields(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Lock the rulebook's field vocabulary.
+
+    After locking, rulesets cannot introduce new field names. Call
+    ``unlock-fields`` to make changes (will cut a new rulebook version
+    in a later phase).
+    """
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.lock_rulebook_fields(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    success(f"Locked field vocabulary on rulebook {rulebook}")
+    console.print(
+        f"Locked field count: [cyan]{len(result.get('fields', []))}[/cyan]"
+    )
+
+
+@rulebooks_app.command(name="unlock-fields")
+def unlock_fields(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Unlock the rulebook's field vocabulary so it can be modified."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        client.unlock_rulebook_fields(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    success(f"Unlocked field vocabulary on rulebook {rulebook}")
+
+
+@rulebooks_app.command(name="get-fields")
+def get_fields(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Print the rulebook's locked field vocabulary."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.get_rulebook_fields(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    console.print(
+        f"Lock state: [cyan]{result['field_lock_state']}[/cyan]"
+    )
+    fields = result.get("fields", [])
+    if not fields:
+        console.print("[dim]No fields locked yet.[/dim]")
+        return
+    table = Table(title=f"Fields — {rulebook}")
+    table.add_column("Key", style="cyan")
+    table.add_column("Sort")
+    table.add_column("Enum values")
+    table.add_column("Description")
+    for f in fields:
+        table.add_row(
+            f.get("key", ""),
+            f.get("sort", ""),
+            ", ".join(f.get("enum_values") or []) or "[dim]—[/dim]",
+            f.get("description") or "[dim]—[/dim]",
+        )
+    console.print(table)
+
+
+# ============================================================================
+# rulebooks activate / archive
+# ============================================================================
+
+
+@rulebooks_app.command(name="activate")
+def activate_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Mark a rulebook as active. Refused on archived rulebooks."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.activate_rulebook(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    success(f"Activated rulebook {rulebook} (status: {result.get('status')})")
+
+
+@rulebooks_app.command(name="archive")
+def archive_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
+) -> None:
+    """Archive a rulebook (soft-delete; data preserved)."""
+    if not yes:
+        confirmed = typer.confirm(f"Archive rulebook {rulebook}? Cannot be undone")
+        if not confirmed:
+            raise typer.Abort()
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.archive_rulebook(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    success(f"Archived rulebook {rulebook} (status: {result.get('status')})")
+
+
+# ============================================================================
+# rulebooks decide
+# ============================================================================
+
+
+@rulebooks_app.command(name="decide")
+def decide_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    inputs: Optional[str] = typer.Option(
+        None,
+        "--inputs",
+        "-i",
+        help=(
+            'Field values as JSON inline (e.g. \'{"age": 21}\') or @path.json '
+            "to load from disk."
+        ),
+    ),
+    input_file: Optional[Path] = typer.Option(
+        None,
+        "--input-file",
+        exists=True,
+        readable=True,
+        help="YAML or JSON file with field values (alternative to --inputs).",
+    ),
+    explain: bool = typer.Option(
+        False, "--explain", help="Include a human-readable explanation."
+    ),
+) -> None:
+    """Evaluate a rulebook against a set of field values.
+
+    Examples::
+
+        aethis rulebooks decide aethis/uk-fsm -i '{"applicant.age": 6}'
+        aethis rulebooks decide aethis/uk-fsm --input-file persona.yaml --explain
+    """
+    if inputs is None and input_file is None:
+        raise typer.BadParameter(
+            "Provide field values via --inputs / -i or --input-file."
+        )
+    if inputs and input_file:
+        raise typer.BadParameter(
+            "Pass either --inputs or --input-file, not both."
+        )
+
+    if input_file is not None:
+        field_values = _load_yaml_or_json(input_file)
+    else:
+        # `inputs` may be inline JSON or @path syntax.
+        if inputs and inputs.startswith("@"):
+            field_values = _load_yaml_or_json(Path(inputs[1:]))
+        else:
+            try:
+                field_values = json.loads(inputs or "{}")
+            except json.JSONDecodeError as exc:
+                raise typer.BadParameter(
+                    f"--inputs must be valid JSON: {exc}"
+                ) from exc
+
+    if not isinstance(field_values, dict):
+        raise typer.BadParameter(
+            "Field values must be a JSON object / YAML mapping."
+        )
+
+    _cfg, client = load_client_or_fallback()
+    try:
+        opts: dict[str, Any] = {}
+        if explain:
+            opts["include_explanation"] = True
+        result = client.decide_rulebook(rulebook, field_values, **opts)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    console.print_json(data=result)
+
+
+# ============================================================================
+# rulebooks schema / explain
+# ============================================================================
+
+
+@rulebooks_app.command(name="schema")
+def schema_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Print the combined field schema across all live rulesets."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.get_rulebook_schema(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    console.print_json(data=result)
+
+
+@rulebooks_app.command(name="explain")
+def explain_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """Print human-readable rule explanations for the rulebook."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.explain_rulebook(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    console.print_json(data=result)
+
+
+# ============================================================================
+# rulebooks tests {add,list,delete}
+# ============================================================================
+
+
+@tests_app.command(name="add")
+def tests_add(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    file: Path = typer.Option(
+        ...,
+        "--file",
+        "-f",
+        exists=True,
+        readable=True,
+        help=(
+            "YAML or JSON file with {name, field_values, expected_outcome}. "
+            "May also be a list to add multiple test cases at once."
+        ),
+    ),
+) -> None:
+    """Add one or more rulebook-level (full-form) test cases.
+
+    A test case carries::
+
+        name: "Reception, low income"
+        field_values:
+          applicant.age: 5
+          household.income: 8000
+        expected_outcome: eligible   # or not_eligible / undetermined
+    """
+    payload = _load_yaml_or_json(file)
+    cases: list[dict[str, Any]]
+    if isinstance(payload, dict):
+        cases = [payload]
+    elif isinstance(payload, list):
+        cases = payload
+    else:
+        raise typer.BadParameter(
+            f"{file} must contain a test-case object or a list of them."
+        )
+
+    _cfg, client = load_client_or_fallback()
+    added: list[dict[str, Any]] = []
+    for tc in cases:
+        if not isinstance(tc, dict):
+            raise typer.BadParameter(
+                f"Each test case must be a mapping; got {type(tc).__name__}."
+            )
+        try:
+            result = client.add_rulebook_test_case(
+                rulebook,
+                name=tc["name"],
+                field_values=tc["field_values"],
+                expected_outcome=tc["expected_outcome"],
+            )
+        except KeyError as exc:
+            raise typer.BadParameter(
+                f"Test case missing required key: {exc}"
+            ) from exc
+        except AethisAPIError as e:
+            error_panel(e)
+            raise typer.Exit(code=1)
+        added.append(result)
+
+    success(f"Added {len(added)} test case(s) to rulebook {rulebook}")
+    for tc in added:
+        console.print(f"  {tc['tc_id']}  {tc['name']}  → {tc['expected_outcome']}")
+
+
+@tests_app.command(name="list")
+def tests_list(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+) -> None:
+    """List rulebook-level test cases."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.list_rulebook_test_cases(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    cases = result.get("test_cases", [])
+    if not cases:
+        console.print("[dim]No test cases yet.[/dim]")
+        return
+    table = Table(title=f"Rulebook test cases — {rulebook}")
+    table.add_column("tc_id", style="cyan")
+    table.add_column("Name")
+    table.add_column("Expected outcome")
+    table.add_column("Fields", justify="right")
+    for tc in cases:
+        table.add_row(
+            tc.get("tc_id", ""),
+            tc.get("name", ""),
+            tc.get("expected_outcome", ""),
+            str(len(tc.get("field_values", {}) or {})),
+        )
+    console.print(table)
+
+
+@tests_app.command(name="delete")
+def tests_delete(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    tc_id: str = typer.Argument(..., help="Test case ID (tc_*)."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
+) -> None:
+    """Delete a rulebook-level test case by tc_id."""
+    if not yes:
+        confirmed = typer.confirm(
+            f"Delete test case {tc_id} from rulebook {rulebook}?"
+        )
+        if not confirmed:
+            raise typer.Abort()
+    _cfg, client = load_client_or_fallback()
+    try:
+        client.delete_rulebook_test_case(rulebook, tc_id)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    success(f"Deleted test case {tc_id} from rulebook {rulebook}")
+
+
+rulebooks_app.add_typer(tests_app, name="tests")

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -14,6 +14,7 @@ from aethis_cli.auth_helpers import RUNTIME
 from aethis_cli.errors import AethisAPIError, AuthenticationError, AuthRequired, ConfigError
 from aethis_cli.output import console
 from aethis_cli.commands.account_cmd import account_app
+from aethis_cli.commands.rulebooks_cmd import rulebooks_app
 from aethis_cli.commands.rulesets_cmd import rulesets_app
 from aethis_cli.commands.guidance_cmd import guidance_app
 from aethis_cli.commands.mcp_cmd import mcp_app
@@ -135,6 +136,7 @@ def main(
 
 
 app.add_typer(account_app, name="account")
+app.add_typer(rulebooks_app, name="rulebooks")
 app.add_typer(rulesets_app, name="rulesets")
 app.add_typer(guidance_app, name="guidance")
 app.add_typer(mcp_app, name="mcp")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.13.1"
+version = "0.14.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -153,9 +153,7 @@ def test_rulebooks_create_minimal(tmp_path, monkeypatch):
     with patch("aethis_cli.client.AethisClient", return_value=client):
         result = _runner_invoke(["rulebooks", "create", "Bare bones"])
     assert result.exit_code == 0
-    client.create_rulebook.assert_called_once_with(
-        name="Bare bones", domain="", slug=None, description=None
-    )
+    client.create_rulebook.assert_called_once_with(name="Bare bones", domain="", slug=None, description=None)
 
 
 # ---------------------------------------------------------------------------
@@ -195,9 +193,7 @@ def test_set_fields_from_json_top_level_list(tmp_path, monkeypatch):
         "field_lock_state": "unlocked",
     }
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)]
-        )
+        result = _runner_invoke(["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)])
 
     assert result.exit_code == 0, result.output
     args, _kwargs = client.set_rulebook_fields.call_args
@@ -213,18 +209,14 @@ def test_set_fields_from_json_wrapped_object(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
     fields_path = tmp_path / "fields.json"
-    fields_path.write_text(
-        json.dumps({"fields": [{"key": "x", "sort": "Bool"}]})
-    )
+    fields_path.write_text(json.dumps({"fields": [{"key": "x", "sort": "Bool"}]}))
     client = MagicMock()
     client.set_rulebook_fields.return_value = {
         "fields": [{"key": "x", "sort": "Bool"}],
         "field_lock_state": "unlocked",
     }
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)]
-        )
+        result = _runner_invoke(["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)])
     assert result.exit_code == 0
     sent = client.set_rulebook_fields.call_args[0][1]
     assert sent == [{"key": "x", "sort": "Bool"}]
@@ -237,9 +229,7 @@ def test_set_fields_rejects_empty_list(tmp_path, monkeypatch):
     fields_path.write_text("[]")
     client = MagicMock()
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)]
-        )
+        result = _runner_invoke(["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)])
     assert result.exit_code != 0
     assert "non-empty" in _strip(result.output).lower()
 
@@ -435,9 +425,7 @@ def test_decide_rejects_non_object_inputs(tmp_path, monkeypatch):
     monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
     client = MagicMock()
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "decide", "rb_x", "-i", "[1, 2, 3]"]
-        )
+        result = _runner_invoke(["rulebooks", "decide", "rb_x", "-i", "[1, 2, 3]"])
     assert result.exit_code != 0
     assert "object" in _strip(result.output).lower() or "mapping" in _strip(result.output).lower()
 
@@ -467,9 +455,7 @@ def test_tests_add_single_case(tmp_path, monkeypatch):
         "expected_outcome": "eligible",
     }
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "tests", "add", "rb_x", "-f", str(case_path)]
-        )
+        result = _runner_invoke(["rulebooks", "tests", "add", "rb_x", "-f", str(case_path)])
     assert result.exit_code == 0, result.output
     client.add_rulebook_test_case.assert_called_once()
     _args, kwargs = client.add_rulebook_test_case.call_args
@@ -504,9 +490,7 @@ def test_tests_add_multiple_cases(tmp_path, monkeypatch):
         {"tc_id": "tc_b", "name": "B", "expected_outcome": "not_eligible"},
     ]
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "tests", "add", "rb_x", "-f", str(cases_path)]
-        )
+        result = _runner_invoke(["rulebooks", "tests", "add", "rb_x", "-f", str(cases_path)])
     assert result.exit_code == 0, result.output
     assert client.add_rulebook_test_case.call_count == 2
     out = _strip(result.output)
@@ -518,14 +502,10 @@ def test_tests_add_missing_required_key(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
     bad = tmp_path / "bad.json"
-    bad.write_text(
-        json.dumps({"name": "No outcome", "field_values": {}})
-    )  # missing expected_outcome
+    bad.write_text(json.dumps({"name": "No outcome", "field_values": {}}))  # missing expected_outcome
     client = MagicMock()
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "tests", "add", "rb_x", "-f", str(bad)]
-        )
+        result = _runner_invoke(["rulebooks", "tests", "add", "rb_x", "-f", str(bad)])
     assert result.exit_code != 0
     client.add_rulebook_test_case.assert_not_called()
 
@@ -579,8 +559,6 @@ def test_tests_delete_with_yes(tmp_path, monkeypatch):
     client = MagicMock()
     client.delete_rulebook_test_case.return_value = None
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "tests", "delete", "rb_x", "tc_abc", "--yes"]
-        )
+        result = _runner_invoke(["rulebooks", "tests", "delete", "rb_x", "tc_abc", "--yes"])
     assert result.exit_code == 0, result.output
     client.delete_rulebook_test_case.assert_called_once_with("rb_x", "tc_abc")

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -1,0 +1,586 @@
+"""Tests for `aethis rulebooks` — the converged 2-term authoring model's
+top-level command group.
+
+Pattern follows existing `tests/test_decide_cmd.py`: CliRunner + patch the
+AethisClient class so we exercise the full command/dispatch path without
+hitting the network.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _runner_invoke(args, env=None):
+    """Boilerplate: import the app, patch the client, run."""
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    return runner.invoke(app, args, catch_exceptions=False, env=env or {})
+
+
+# ---------------------------------------------------------------------------
+# rulebooks list
+# ---------------------------------------------------------------------------
+
+
+def test_rulebooks_list_renders_table(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+
+    client = MagicMock()
+    client.list_rulebooks.return_value = [
+        {
+            "rulebook_id": "rb_abc",
+            "slug": "aethis/uk-fsm",
+            "name": "UK Free School Meals",
+            "domain": "uk_fsm",
+            "status": "active",
+            "ruleset_refs": [{"section_id": "a"}, {"section_id": "b"}],
+        },
+        {
+            "rulebook_id": "rb_def",
+            "slug": None,
+            "name": "Spacecraft Crew",
+            "domain": "",
+            "status": "draft",
+            "ruleset_refs": [],
+        },
+    ]
+
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "list"])
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "rb_abc" in out
+    assert "aethis/uk-fsm" in out
+    assert "UK Free School Meals" in out
+    assert "Spacecraft Crew" in out
+
+
+def test_rulebooks_list_empty_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.list_rulebooks.return_value = []
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "list"])
+    assert result.exit_code == 0
+    assert "No rulebooks yet" in _strip(result.output)
+
+
+# ---------------------------------------------------------------------------
+# rulebooks show
+# ---------------------------------------------------------------------------
+
+
+def test_rulebooks_show_prints_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.get_rulebook.return_value = {
+        "rulebook_id": "rb_abc",
+        "name": "UK FSM",
+        "ruleset_refs": [],
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "show", "rb_abc"])
+    assert result.exit_code == 0, result.output
+    client.get_rulebook.assert_called_once_with("rb_abc")
+    assert '"rulebook_id"' in result.output
+    assert "rb_abc" in result.output
+
+
+# ---------------------------------------------------------------------------
+# rulebooks create
+# ---------------------------------------------------------------------------
+
+
+def test_rulebooks_create_with_all_options(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+
+    client = MagicMock()
+    client.create_rulebook.return_value = {
+        "rulebook_id": "rb_new",
+        "slug": "aethis/uk-fsm",
+        "name": "UK FSM",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulebooks",
+                "create",
+                "UK FSM",
+                "--domain",
+                "uk_fsm",
+                "--slug",
+                "aethis/uk-fsm",
+                "--description",
+                "Free school meals eligibility",
+            ]
+        )
+
+    assert result.exit_code == 0, result.output
+    client.create_rulebook.assert_called_once_with(
+        name="UK FSM",
+        domain="uk_fsm",
+        slug="aethis/uk-fsm",
+        description="Free school meals eligibility",
+    )
+    assert "rb_new" in _strip(result.output)
+    assert "aethis/uk-fsm" in _strip(result.output)
+
+
+def test_rulebooks_create_minimal(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.create_rulebook.return_value = {"rulebook_id": "rb_min"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "Bare bones"])
+    assert result.exit_code == 0
+    client.create_rulebook.assert_called_once_with(
+        name="Bare bones", domain="", slug=None, description=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# rulebooks set-fields
+# ---------------------------------------------------------------------------
+
+
+def test_set_fields_from_json_top_level_list(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+
+    fields_path = tmp_path / "fields.json"
+    fields_path.write_text(
+        json.dumps(
+            [
+                {"key": "applicant.age", "sort": "Int"},
+                {
+                    "key": "child.year_group",
+                    "sort": "Enum",
+                    "enum_values": ["reception", "year_1"],
+                },
+            ]
+        )
+    )
+
+    client = MagicMock()
+    client.set_rulebook_fields.return_value = {
+        "rulebook_id": "rb_x",
+        "fields": [
+            {"key": "applicant.age", "sort": "Int"},
+            {
+                "key": "child.year_group",
+                "sort": "Enum",
+                "enum_values": ["reception", "year_1"],
+            },
+        ],
+        "field_lock_state": "unlocked",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    args, _kwargs = client.set_rulebook_fields.call_args
+    assert args[0] == "rb_x"
+    sent_fields = args[1]
+    assert isinstance(sent_fields, list)
+    assert len(sent_fields) == 2
+    assert sent_fields[0]["key"] == "applicant.age"
+
+
+def test_set_fields_from_json_wrapped_object(tmp_path, monkeypatch):
+    """Accept both a top-level list and {fields: [...]}."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    fields_path = tmp_path / "fields.json"
+    fields_path.write_text(
+        json.dumps({"fields": [{"key": "x", "sort": "Bool"}]})
+    )
+    client = MagicMock()
+    client.set_rulebook_fields.return_value = {
+        "fields": [{"key": "x", "sort": "Bool"}],
+        "field_lock_state": "unlocked",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)]
+        )
+    assert result.exit_code == 0
+    sent = client.set_rulebook_fields.call_args[0][1]
+    assert sent == [{"key": "x", "sort": "Bool"}]
+
+
+def test_set_fields_rejects_empty_list(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    fields_path = tmp_path / "fields.json"
+    fields_path.write_text("[]")
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-fields", "rb_x", "-f", str(fields_path)]
+        )
+    assert result.exit_code != 0
+    assert "non-empty" in _strip(result.output).lower()
+
+
+# ---------------------------------------------------------------------------
+# rulebooks lock-fields / unlock-fields / get-fields
+# ---------------------------------------------------------------------------
+
+
+def test_lock_fields(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.lock_rulebook_fields.return_value = {
+        "field_lock_state": "locked",
+        "fields": [{"key": "x", "sort": "Bool"}, {"key": "y", "sort": "Int"}],
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "lock-fields", "rb_x"])
+    assert result.exit_code == 0, result.output
+    client.lock_rulebook_fields.assert_called_once_with("rb_x")
+    assert "Locked" in _strip(result.output)
+
+
+def test_unlock_fields(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.unlock_rulebook_fields.return_value = {"field_lock_state": "unlocked"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "unlock-fields", "rb_x"])
+    assert result.exit_code == 0
+    client.unlock_rulebook_fields.assert_called_once_with("rb_x")
+
+
+def test_get_fields_renders_table(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+    client = MagicMock()
+    client.get_rulebook_fields.return_value = {
+        "field_lock_state": "locked",
+        "fields": [
+            {"key": "applicant.age", "sort": "Int"},
+            {
+                "key": "child.year_group",
+                "sort": "Enum",
+                "enum_values": ["reception", "year_1"],
+            },
+        ],
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "get-fields", "rb_x"])
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "applicant.age" in out
+    assert "Int" in out
+    assert "child.year_group" in out
+    assert "Enum" in out
+    assert "reception" in out
+    assert "locked" in out.lower()
+
+
+def test_get_fields_empty_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.get_rulebook_fields.return_value = {
+        "field_lock_state": "unlocked",
+        "fields": [],
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "get-fields", "rb_x"])
+    assert result.exit_code == 0
+    assert "No fields locked yet" in _strip(result.output)
+
+
+# ---------------------------------------------------------------------------
+# rulebooks archive
+# ---------------------------------------------------------------------------
+
+
+def test_archive_rulebook_with_yes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.archive_rulebook.return_value = {"status": "archived"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "archive", "rb_x", "--yes"])
+    assert result.exit_code == 0
+    client.archive_rulebook.assert_called_once_with("rb_x")
+
+
+def test_archive_rulebook_aborts_without_confirmation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        # Decline the confirmation prompt by feeding "n\n" on stdin.
+        from aethis_cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["rulebooks", "archive", "rb_x"],
+            input="n\n",
+            catch_exceptions=False,
+        )
+    assert result.exit_code != 0
+    client.archive_rulebook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# rulebooks activate
+# ---------------------------------------------------------------------------
+
+
+def test_activate_rulebook(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.activate_rulebook.return_value = {"status": "active"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "activate", "rb_x"])
+    assert result.exit_code == 0
+    client.activate_rulebook.assert_called_once_with("rb_x")
+    assert "active" in _strip(result.output)
+
+
+# ---------------------------------------------------------------------------
+# rulebooks decide
+# ---------------------------------------------------------------------------
+
+
+def test_decide_with_inline_inputs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.decide_rulebook.return_value = {"decision": "eligible"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulebooks",
+                "decide",
+                "aethis/uk-fsm",
+                "-i",
+                '{"applicant.age": 6}',
+            ]
+        )
+    assert result.exit_code == 0, result.output
+    args, kwargs = client.decide_rulebook.call_args
+    assert args[0] == "aethis/uk-fsm"
+    assert args[1] == {"applicant.age": 6}
+    assert "eligible" in result.output
+
+
+def test_decide_with_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    persona = tmp_path / "persona.json"
+    persona.write_text(json.dumps({"applicant.age": 7}))
+    client = MagicMock()
+    client.decide_rulebook.return_value = {"decision": "not_eligible"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulebooks",
+                "decide",
+                "aethis/uk-fsm",
+                "--input-file",
+                str(persona),
+                "--explain",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+    args, kwargs = client.decide_rulebook.call_args
+    assert args[1] == {"applicant.age": 7}
+    assert kwargs.get("include_explanation") is True
+
+
+def test_decide_requires_input(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "decide", "rb_x"])
+    assert result.exit_code != 0
+    assert "field values" in _strip(result.output).lower() or "inputs" in _strip(result.output).lower()
+
+
+def test_decide_rejects_non_object_inputs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "decide", "rb_x", "-i", "[1, 2, 3]"]
+        )
+    assert result.exit_code != 0
+    assert "object" in _strip(result.output).lower() or "mapping" in _strip(result.output).lower()
+
+
+# ---------------------------------------------------------------------------
+# rulebooks tests add / list / delete
+# ---------------------------------------------------------------------------
+
+
+def test_tests_add_single_case(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    case_path = tmp_path / "case.json"
+    case_path.write_text(
+        json.dumps(
+            {
+                "name": "Reception, low income",
+                "field_values": {"applicant.age": 5, "household.income": 8000},
+                "expected_outcome": "eligible",
+            }
+        )
+    )
+    client = MagicMock()
+    client.add_rulebook_test_case.return_value = {
+        "tc_id": "tc_abc",
+        "name": "Reception, low income",
+        "expected_outcome": "eligible",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "tests", "add", "rb_x", "-f", str(case_path)]
+        )
+    assert result.exit_code == 0, result.output
+    client.add_rulebook_test_case.assert_called_once()
+    _args, kwargs = client.add_rulebook_test_case.call_args
+    assert kwargs["name"] == "Reception, low income"
+    assert kwargs["expected_outcome"] == "eligible"
+    assert "tc_abc" in _strip(result.output)
+
+
+def test_tests_add_multiple_cases(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "A",
+                    "field_values": {"x": 1},
+                    "expected_outcome": "eligible",
+                },
+                {
+                    "name": "B",
+                    "field_values": {"x": 2},
+                    "expected_outcome": "not_eligible",
+                },
+            ]
+        )
+    )
+    client = MagicMock()
+    client.add_rulebook_test_case.side_effect = [
+        {"tc_id": "tc_a", "name": "A", "expected_outcome": "eligible"},
+        {"tc_id": "tc_b", "name": "B", "expected_outcome": "not_eligible"},
+    ]
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "tests", "add", "rb_x", "-f", str(cases_path)]
+        )
+    assert result.exit_code == 0, result.output
+    assert client.add_rulebook_test_case.call_count == 2
+    out = _strip(result.output)
+    assert "Added 2 test case" in out
+    assert "tc_a" in out and "tc_b" in out
+
+
+def test_tests_add_missing_required_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    bad = tmp_path / "bad.json"
+    bad.write_text(
+        json.dumps({"name": "No outcome", "field_values": {}})
+    )  # missing expected_outcome
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "tests", "add", "rb_x", "-f", str(bad)]
+        )
+    assert result.exit_code != 0
+    client.add_rulebook_test_case.assert_not_called()
+
+
+def test_tests_list_renders_table(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+    client = MagicMock()
+    client.list_rulebook_test_cases.return_value = {
+        "test_cases": [
+            {
+                "tc_id": "tc_a",
+                "name": "Reception",
+                "expected_outcome": "eligible",
+                "field_values": {"x": 1, "y": 2},
+            },
+            {
+                "tc_id": "tc_b",
+                "name": "Year 6, high income",
+                "expected_outcome": "not_eligible",
+                "field_values": {"x": 3},
+            },
+        ]
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "tests", "list", "rb_x"])
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "tc_a" in out
+    assert "Reception" in out
+    assert "eligible" in out
+    assert "tc_b" in out
+    assert "Year 6" in out
+
+
+def test_tests_list_empty_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.list_rulebook_test_cases.return_value = {"test_cases": []}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "tests", "list", "rb_x"])
+    assert result.exit_code == 0
+    assert "No test cases yet" in _strip(result.output)
+
+
+def test_tests_delete_with_yes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.delete_rulebook_test_case.return_value = None
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "tests", "delete", "rb_x", "tc_abc", "--yes"]
+        )
+    assert result.exit_code == 0, result.output
+    client.delete_rulebook_test_case.assert_called_once_with("rb_x", "tc_abc")


### PR DESCRIPTION
**DRAFT — do not merge until aethis-core's Phase A is live on `api.aethis.ai`.**

Per `.claude/rules/submodule-discipline.md` rule 6, this PR can't open as ready-for-review until aethis-core PRs #133-139 merge, a version bump lands, and `./scripts/deploy-production.sh` rolls out v0.19.0+ (the Phase A.6 endpoints this PR consumes).

---

## Summary

First user-facing surface for the [converged 2-term authoring model](https://github.com/Aethis-ai/aethis-workspace/pull/64) — `Rulebook` as the whole form / execution unit, with locked field vocabulary, composition logic, rulebook-level test cases, and integer version history.

## New commands (15)

| Command | Endpoint |
|---|---|
| `aethis rulebooks list` | `GET /api/v1/public/rulebooks/` |
| `aethis rulebooks show <id-or-slug>` | `GET /api/v1/public/rulebooks/{id}` |
| `aethis rulebooks create <name> --domain <d> [--slug ...]` | `POST /api/v1/public/rulebooks/` |
| `aethis rulebooks set-fields <id> -f fields.yaml` | `POST /api/v1/public/rulebooks/{id}/fields` |
| `aethis rulebooks lock-fields <id>` | `POST .../fields/lock` |
| `aethis rulebooks unlock-fields <id>` | `POST .../fields/unlock` |
| `aethis rulebooks get-fields <id>` | `GET .../fields` |
| `aethis rulebooks tests add <id> -f scenario.yaml` | `POST .../tests` |
| `aethis rulebooks tests list <id>` | `GET .../tests` |
| `aethis rulebooks tests delete <id> <tc_id>` | `DELETE .../tests/{tc_id}` |
| `aethis rulebooks activate <id>` | `POST .../activate` |
| `aethis rulebooks archive <id>` | `POST .../archive` |
| `aethis rulebooks decide <id> -i '{...}' [--explain]` | `POST /api/v1/public/decide` (with `rulebook_id`) |
| `aethis rulebooks schema <id>` | `GET .../schema` |
| `aethis rulebooks explain <id>` | `GET .../explain` |

15 commands, 12 new `AethisClient` methods.

## Test plan

- [x] 25 new tests in `tests/test_rulebooks_cmd.py` using the existing CliRunner + `patch("aethis_cli.client.AethisClient")` pattern.
- [x] Coverage: 68% overall (gate 45%); the new module covers 72% via its dedicated tests.
- [x] `uv run ruff check` clean.
- [x] 6 pre-existing test failures on main (ANSI/Rich coloring issue in account/guidance/id_utils/status tests) are unchanged — verified by re-running on the parent commit before this PR.
- [ ] Integration smoke test against staging — **blocked on aethis-core Phase A deploy**. Will run as part of B.2.1 (spacecraft example rewrite).

## What this PR deliberately does NOT do

- **No backward-compat shims.** Green field until public release per user direction.
- **No removal** of the legacy `aethis projects` / top-level `aethis generate` / `aethis test` / `aethis publish` tree. Replacement + removal lands in the next minor (Phase B.1b: ruleset lifecycle + project retirement).
- **No `set-logic`** command for composition — needs client-side parser or server-side string-DSL acceptance on `PATCH /rulebooks/{id}`. Small follow-up.
- **No `promote-to-live`** — service exists in aethis-core A.4 but no REST endpoint yet. Needs an A.8 aethis-core PR exposing it before this CLI command can be added.
- **No `versions` / `cut`** — endpoints don't exist yet on aethis-core (deferred follow-up).

## References

- Workspace assessment + resolution: Aethis-ai/aethis-workspace#64
- aethis-core Phase A stack: Aethis-ai/aethis-core#133-139
- Plan: `~/.claude/plans/ok-i-ve-also-realised-smooth-tome.md`