### PR TITLE
feat(rulesets): ruleset lifecycle commands (Phase B.1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.15.0 (2026-05-21)
+
+- **feat(rulesets): ruleset lifecycle commands scoped to a rulebook.** Phase B.1b of the converged 2-term model. Adds four new sub-commands under `aethis rulesets`:
+  - `aethis rulesets list <rulebook>` — list rulesets in a rulebook (grouped by `ruleset_name` with version counts, live version, and observed states). The legacy `-p <project_id>` and `--public` modes are preserved while the project-scoped authoring pipeline retires in a future phase.
+  - `aethis rulesets create <rulebook> <ruleset_name> [-n "Display name"]` — create a new draft Ruleset inside the rulebook. The display name auto-derives from `ruleset_name` if not provided (`child_eligibility` → `Child Eligibility`).
+  - `aethis rulesets show <rulebook> <ruleset_name>` — full version history for one ruleset name (bundle_id, version, state, created), with live version highlighted.
+  - `aethis rulesets promote-to-live <rulebook> <ruleset_name> <ruleset_id> [--note "..."]` — atomically promote a `testing`-state ruleset version to `live` via the Phase A.4 service. Auto-cuts a new rulebook version; previous live ruleset is archived.
+- feat(client): four new `AethisClient` methods — `create_ruleset_in_rulebook`, `list_rulesets_in_rulebook`, `show_ruleset_in_rulebook`, `promote_ruleset_to_live`.
+- Requires aethis-core v0.20.0+ live on the target API (Phase A.8 endpoints).
+
 ## 0.14.0 (2026-05-21)
 
 - **feat(rulebooks): new `aethis rulebooks` command group.** First user-facing surface for the converged 2-term authoring model (workspace PR #64, aethis-core PRs #133-139). A Rulebook is the whole form — the execution unit — that owns a locked field vocabulary, composition logic, rulebook-level test cases, and an integer version history.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -390,6 +390,57 @@ class AethisClient:
             },
         )
 
+    # -- Ruleset-within-rulebook lifecycle (Phase A.8) --
+
+    def create_ruleset_in_rulebook(
+        self,
+        rulebook_id_or_slug: str,
+        *,
+        ruleset_name: str,
+        name: str,
+        python_source: Optional[str] = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "ruleset_name": ruleset_name,
+            "name": name,
+        }
+        if python_source is not None:
+            body["python_source"] = python_source
+        return self._request(
+            "POST",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/rulesets",
+            json=body,
+        )
+
+    def list_rulesets_in_rulebook(self, rulebook_id_or_slug: str) -> dict:
+        return self._request(
+            "GET",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/rulesets",
+        )
+
+    def show_ruleset_in_rulebook(self, rulebook_id_or_slug: str, ruleset_name: str) -> dict:
+        return self._request(
+            "GET",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/rulesets/{ruleset_name}",
+        )
+
+    def promote_ruleset_to_live(
+        self,
+        rulebook_id_or_slug: str,
+        ruleset_name: str,
+        *,
+        ruleset_id: str,
+        note: Optional[str] = None,
+    ) -> dict:
+        body: dict[str, Any] = {"ruleset_id": ruleset_id}
+        if note is not None:
+            body["note"] = note
+        return self._request(
+            "POST",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/rulesets/{ruleset_name}/promote-to-live",
+            json=body,
+        )
+
     # -- Domain guidance API --
 
     def add_domain_guidance(

--- a/aethis_cli/commands/rulesets_cmd.py
+++ b/aethis_cli/commands/rulesets_cmd.py
@@ -1,4 +1,13 @@
-"""aethis rulesets — list and archive rulesets."""
+"""aethis rulesets — list, create, show, promote, archive rulesets.
+
+In the converged 2-term authoring model (`docs/RULEBOOK_AUTHORING_MODEL.md`
+in the workspace), a Ruleset is the named, versioned part of a Rulebook.
+The lifecycle commands added in Phase B.1b — ``create``, ``show``,
+``promote-to-live`` — scope to a rulebook explicitly (positional first
+argument). The legacy ``-p <project_id>`` and ``--public`` modes of
+``list`` are preserved while the project-scoped authoring pipeline is
+retired in a future phase.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +24,7 @@ from aethis_cli.output import console, error_panel, success, warn
 
 rulesets_app = typer.Typer(
     name="rulesets",
-    help="List and archive rulesets.",
+    help="List, create, show, promote, archive rulesets.",
     no_args_is_help=True,
     pretty_exceptions_enable=False,
 )
@@ -65,8 +74,14 @@ def _list_public(limit: int, offset: int) -> None:
 
 @rulesets_app.command(name="list")
 def list_rulesets(
-    project_id: Optional[str] = typer.Option(None, "--project-id", "-p", help="Project ID"),
-    status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (comma-separated)"),
+    rulebook: Optional[str] = typer.Argument(
+        None,
+        help=("Rulebook ID or slug to list rulesets for. When given, takes precedence over --project-id and --public."),
+    ),
+    project_id: Optional[str] = typer.Option(None, "--project-id", "-p", help="Legacy: list rulesets for a project."),
+    status: Optional[str] = typer.Option(
+        None, "--status", "-s", help="Filter by status (comma-separated; project mode only)."
+    ),
     public: bool = typer.Option(
         False,
         "--public",
@@ -75,15 +90,20 @@ def list_rulesets(
     limit: int = typer.Option(20, "--limit", min=1, max=50, help="Max rulesets to return (public mode)."),
     offset: int = typer.Option(0, "--offset", min=0, help="Pagination offset (public mode)."),
 ) -> None:
-    """List rulesets for a project, or the public showcase catalogue.
+    """List rulesets — by rulebook (new), by project (legacy), or the public showcase.
 
     Examples:
 
-        aethis rulesets list                                  # auto: showcase if no project context
+        aethis rulesets list aethis/uk-fsm                    # rulebook-scoped (new)
+        aethis rulesets list rb_abc123                        # by rulebook_id
         aethis rulesets list --public                         # explicit: anonymous catalogue
-        aethis rulesets list -p proj_i1HyinBtFJniayUC         # tenant-scoped
-        aethis rulesets list -p proj_i1HyinBtFJniayUC -s active,archived
+        aethis rulesets list                                  # auto: showcase if no project context
+        aethis rulesets list -p proj_i1HyinBtFJniayUC         # tenant-scoped (legacy)
     """
+    if rulebook:
+        _list_rulebook_rulesets(rulebook)
+        return
+
     if public:
         _list_public(limit=limit, offset=offset)
         return
@@ -104,7 +124,8 @@ def list_rulesets(
 
     if not pid:
         console.print(
-            "[dim]No project context — showing public showcase rulesets. Pass --project-id <id> to list your own.[/dim]"
+            "[dim]No project context — showing public showcase rulesets. "
+            "Pass <rulebook> or --project-id <id> to list your own.[/dim]"
         )
         _list_public(limit=limit, offset=offset)
         return
@@ -145,6 +166,177 @@ def list_rulesets(
         )
 
     console.print(table)
+
+
+def _list_rulebook_rulesets(rulebook: str) -> None:
+    """List rulesets in a rulebook using the Phase A.8 endpoint."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        resp = client.list_rulesets_in_rulebook(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    rulesets = resp.get("rulesets", [])
+    if not rulesets:
+        console.print(
+            f"[dim]No rulesets in rulebook {rulebook!r} yet. "
+            "Create one with `aethis rulesets create <rulebook> <name>`.[/dim]"
+        )
+        return
+
+    table = Table(title=f"Rulesets in {rulebook}")
+    table.add_column("Ruleset name", style="cyan")
+    table.add_column("Display name")
+    table.add_column("Versions", justify="right")
+    table.add_column("Live version")
+    table.add_column("States seen")
+    for r in rulesets:
+        table.add_row(
+            r.get("ruleset_name", ""),
+            r.get("display_name") or "[dim]—[/dim]",
+            str(r.get("version_count", 0)),
+            r.get("live_version") or "[dim]—[/dim]",
+            ", ".join(r.get("states", [])) or "[dim]—[/dim]",
+        )
+    console.print(table)
+
+
+# ============================================================================
+# Phase B.1b — ruleset lifecycle commands scoped to a rulebook.
+# ============================================================================
+
+
+@rulesets_app.command(name="create")
+def create_ruleset(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug to create the ruleset in."),
+    ruleset_name: str = typer.Argument(..., help="Identifier-style name (lower_snake_case)."),
+    display_name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help=(
+            "Human-readable display name. Defaults to a titlecased version "
+            "of ruleset_name (`child_eligibility` → `Child Eligibility`)."
+        ),
+    ),
+) -> None:
+    """Create a new draft Ruleset within a Rulebook.
+
+    The ruleset starts in `draft` state with no compiled DSL. Authoring
+    (sources, guidance, generate, test) flows through the project-scoped
+    endpoints today; a future phase wires those to the new ruleset path.
+
+    Examples::
+
+        aethis rulesets create aethis/uk-fsm child_eligibility
+        aethis rulesets create rb_abc household_criteria \\
+            -n "Household qualifying criteria"
+    """
+    if display_name is None:
+        display_name = ruleset_name.replace("_", " ").title()
+
+    _cfg, client = load_client_or_fallback()
+    try:
+        rs = client.create_ruleset_in_rulebook(rulebook, ruleset_name=ruleset_name, name=display_name)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    success(
+        f"Created draft ruleset {rs['ruleset_name']!r} (bundle_id: {rs['bundle_id']}) in rulebook {rs['rulebook_id']}"
+    )
+    console.print_json(data=rs)
+
+
+@rulesets_app.command(name="show")
+def show_ruleset(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    ruleset_name: str = typer.Argument(..., help="Ruleset name within the rulebook."),
+) -> None:
+    """Show the version history for one ruleset_name in a rulebook."""
+    _cfg, client = load_client_or_fallback()
+    try:
+        resp = client.show_ruleset_in_rulebook(rulebook, ruleset_name)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    versions = resp.get("versions", [])
+    live_version = resp.get("live_version")
+    display_name = resp.get("display_name")
+    console.print(
+        f"[bold]{ruleset_name}[/bold]  in  [cyan]{rulebook}[/cyan]"
+        + (f"  · [dim]{display_name}[/dim]" if display_name else "")
+    )
+    if live_version:
+        console.print(f"  live version: [green]{live_version}[/green]")
+    else:
+        console.print("  [dim]no live version (never promoted)[/dim]")
+
+    if not versions:
+        return
+
+    table = Table(title="Versions")
+    table.add_column("bundle_id", style="cyan")
+    table.add_column("Version")
+    table.add_column("State")
+    table.add_column("Created")
+    for v in versions:
+        state = v.get("state") or "[dim]—[/dim]"
+        style = "dim" if state == "archived" else None
+        table.add_row(
+            v.get("bundle_id", ""),
+            v.get("version", ""),
+            state,
+            (v.get("created_at") or "")[:10],
+            style=style,
+        )
+    console.print(table)
+
+
+@rulesets_app.command(name="promote-to-live")
+def promote_ruleset(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    ruleset_name: str = typer.Argument(..., help="Ruleset name within the rulebook."),
+    ruleset_id: str = typer.Argument(..., help="Specific ruleset version (bundle_id) to promote."),
+    note: Optional[str] = typer.Option(
+        None,
+        "--note",
+        help="Optional human-readable note recorded on the resulting RulebookVersion.",
+    ),
+) -> None:
+    """Atomically promote a `testing`-state ruleset version to `live`.
+
+    The candidate ruleset must already be in `testing` state. The
+    operation atomically (1) demotes any prior live ruleset of the same
+    name to `archived`, (2) promotes the candidate to `live`,
+    (3) updates the rulebook's live_ruleset_pins, and (4) cuts a new
+    Rulebook version.
+
+    Example::
+
+        aethis rulesets promote-to-live aethis/uk-fsm child_eligibility rs_abc \\
+            --note "post-2026-04 statutory update"
+    """
+    _cfg, client = load_client_or_fallback()
+    try:
+        resp = client.promote_ruleset_to_live(
+            rulebook,
+            ruleset_name,
+            ruleset_id=ruleset_id,
+            note=note,
+        )
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    success(f"Promoted ruleset {ruleset_name!r} version {ruleset_id} → live in rulebook {rulebook}")
+    console.print(f"  new rulebook version: [green]v{resp.get('new_rulebook_version')}[/green]")
+    prior = resp.get("prior_live_archived_id")
+    if prior:
+        console.print(f"  prior live archived: [dim]{prior}[/dim]")
+    console.print(f"  cut reason: [dim]{resp.get('cut_reason')}[/dim]")
 
 
 @rulesets_app.command(name="archive")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.14.0"
+version = "0.15.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rulesets_b1b_lifecycle.py
+++ b/tests/test_rulesets_b1b_lifecycle.py
@@ -1,0 +1,353 @@
+"""Tests for Phase B.1b — ruleset lifecycle commands scoped to a rulebook.
+
+Covers:
+  - `aethis rulesets list <rulebook>` (new rulebook-scoped mode)
+  - `aethis rulesets create <rulebook> <ruleset_name>` (new)
+  - `aethis rulesets show <rulebook> <ruleset_name>` (new)
+  - `aethis rulesets promote-to-live <rulebook> <ruleset_name> <ruleset_id>` (new)
+
+Pattern follows existing `tests/test_rulebooks_cmd.py`: CliRunner + patch
+the AethisClient class so the full command/dispatch path is exercised
+without hitting the network.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _runner_invoke(args, env=None):
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    return runner.invoke(app, args, catch_exceptions=False, env=env or {})
+
+
+# ---------------------------------------------------------------------------
+# rulesets list <rulebook> — new rulebook-scoped mode
+# ---------------------------------------------------------------------------
+
+
+def test_rulesets_list_with_rulebook_arg_uses_rulebook_endpoint(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+
+    client = MagicMock()
+    client.list_rulesets_in_rulebook.return_value = {
+        "rulebook_id": "rb_abc",
+        "rulesets": [
+            {
+                "ruleset_name": "child_eligibility",
+                "display_name": "Child eligibility",
+                "version_count": 3,
+                "live_version": "v2",
+                "states": ["archived", "live", "draft"],
+            },
+            {
+                "ruleset_name": "household_criteria",
+                "display_name": "Household criteria",
+                "version_count": 1,
+                "live_version": None,
+                "states": ["testing"],
+            },
+        ],
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "list", "aethis/uk-fsm"])
+
+    assert result.exit_code == 0, result.output
+    client.list_rulesets_in_rulebook.assert_called_once_with("aethis/uk-fsm")
+    out = _strip(result.output)
+    assert "child_eligibility" in out
+    assert "household_criteria" in out
+    assert "Child eligibility" in out
+    assert "v2" in out
+    # Legacy project endpoint must not be hit.
+    client.list_rulesets.assert_not_called()
+
+
+def test_rulesets_list_with_rulebook_empty_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.list_rulesets_in_rulebook.return_value = {
+        "rulebook_id": "rb_x",
+        "rulesets": [],
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "list", "rb_x"])
+    assert result.exit_code == 0
+    assert "No rulesets in rulebook" in _strip(result.output)
+    assert "aethis rulesets create" in _strip(result.output)
+
+
+def test_rulesets_list_no_args_falls_through_to_showcase(tmp_path, monkeypatch):
+    """Backward compat: no rulebook arg + no project context = public showcase."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    client = MagicMock()
+    client.list_public_rulesets.return_value = []
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "list"])
+    assert result.exit_code == 0
+    client.list_rulesets_in_rulebook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# rulesets create <rulebook> <ruleset_name>
+# ---------------------------------------------------------------------------
+
+
+def test_rulesets_create_uses_default_display_name(tmp_path, monkeypatch):
+    """Without `-n`, display name is auto-derived from ruleset_name."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.create_ruleset_in_rulebook.return_value = {
+        "rulebook_id": "rb_abc",
+        "ruleset_name": "child_eligibility",
+        "bundle_id": "rs_xyz",
+        "state": "draft",
+        "name": "Child Eligibility",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "create", "aethis/uk-fsm", "child_eligibility"])
+    assert result.exit_code == 0, result.output
+    client.create_ruleset_in_rulebook.assert_called_once_with(
+        "aethis/uk-fsm",
+        ruleset_name="child_eligibility",
+        name="Child Eligibility",
+    )
+    assert "rs_xyz" in _strip(result.output)
+
+
+def test_rulesets_create_explicit_display_name(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.create_ruleset_in_rulebook.return_value = {
+        "rulebook_id": "rb_abc",
+        "ruleset_name": "household_criteria",
+        "bundle_id": "rs_a",
+        "state": "draft",
+        "name": "Household qualifying criteria",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulesets",
+                "create",
+                "rb_abc",
+                "household_criteria",
+                "-n",
+                "Household qualifying criteria",
+            ]
+        )
+    assert result.exit_code == 0
+    client.create_ruleset_in_rulebook.assert_called_once_with(
+        "rb_abc",
+        ruleset_name="household_criteria",
+        name="Household qualifying criteria",
+    )
+
+
+# ---------------------------------------------------------------------------
+# rulesets show <rulebook> <ruleset_name>
+# ---------------------------------------------------------------------------
+
+
+def test_rulesets_show_renders_versions(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+    client = MagicMock()
+    client.show_ruleset_in_rulebook.return_value = {
+        "rulebook_id": "rb_abc",
+        "ruleset_name": "child_eligibility",
+        "display_name": "Child eligibility (FSM, England)",
+        "versions": [
+            {
+                "bundle_id": "rs_v1",
+                "version": "v1",
+                "state": "archived",
+                "created_at": "2026-04-08T12:00:00Z",
+            },
+            {
+                "bundle_id": "rs_v2",
+                "version": "v2",
+                "state": "live",
+                "created_at": "2026-05-15T12:00:00Z",
+            },
+            {
+                "bundle_id": "rs_v3",
+                "version": "v3",
+                "state": "draft",
+                "created_at": "2026-05-21T12:00:00Z",
+            },
+        ],
+        "live_version": "v2",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "show", "aethis/uk-fsm", "child_eligibility"])
+    assert result.exit_code == 0, result.output
+    client.show_ruleset_in_rulebook.assert_called_once_with("aethis/uk-fsm", "child_eligibility")
+    out = _strip(result.output)
+    assert "child_eligibility" in out
+    assert "live version: v2" in out
+    assert "rs_v1" in out and "rs_v2" in out and "rs_v3" in out
+    assert "archived" in out and "live" in out and "draft" in out
+
+
+def test_rulesets_show_no_live_version(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.show_ruleset_in_rulebook.return_value = {
+        "rulebook_id": "rb_abc",
+        "ruleset_name": "english_language",
+        "display_name": None,
+        "versions": [
+            {"bundle_id": "rs_a", "version": "v1", "state": "testing", "created_at": ""},
+        ],
+        "live_version": None,
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "show", "rb_abc", "english_language"])
+    assert result.exit_code == 0
+    out = _strip(result.output)
+    assert "no live version" in out
+    assert "rs_a" in out
+
+
+# ---------------------------------------------------------------------------
+# rulesets promote-to-live <rulebook> <ruleset_name> <ruleset_id>
+# ---------------------------------------------------------------------------
+
+
+def test_promote_to_live_happy_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.promote_ruleset_to_live.return_value = {
+        "rulebook_id": "rb_abc",
+        "ruleset_name": "child_eligibility",
+        "promoted_ruleset_id": "rs_v3",
+        "new_rulebook_version": 7,
+        "prior_live_archived_id": "rs_v2",
+        "cut_reason": "auto_on_promote",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulesets",
+                "promote-to-live",
+                "aethis/uk-fsm",
+                "child_eligibility",
+                "rs_v3",
+            ]
+        )
+    assert result.exit_code == 0, result.output
+    client.promote_ruleset_to_live.assert_called_once_with(
+        "aethis/uk-fsm",
+        "child_eligibility",
+        ruleset_id="rs_v3",
+        note=None,
+    )
+    out = _strip(result.output)
+    assert "Promoted" in out
+    assert "v7" in out
+    assert "rs_v2" in out  # prior live archived
+    assert "auto_on_promote" in out
+
+
+def test_promote_to_live_with_note(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.promote_ruleset_to_live.return_value = {
+        "rulebook_id": "rb_x",
+        "ruleset_name": "rs",
+        "promoted_ruleset_id": "rs_a",
+        "new_rulebook_version": 2,
+        "prior_live_archived_id": None,
+        "cut_reason": "auto_on_promote",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulesets",
+                "promote-to-live",
+                "rb_x",
+                "rs",
+                "rs_a",
+                "--note",
+                "post-2026-04 statutory update",
+            ]
+        )
+    assert result.exit_code == 0
+    client.promote_ruleset_to_live.assert_called_once_with(
+        "rb_x",
+        "rs",
+        ruleset_id="rs_a",
+        note="post-2026-04 statutory update",
+    )
+
+
+def test_promote_to_live_first_promotion_has_no_prior_live(tmp_path, monkeypatch):
+    """When a ruleset has never been live before, prior_live_archived_id is null."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.promote_ruleset_to_live.return_value = {
+        "rulebook_id": "rb_x",
+        "ruleset_name": "rs",
+        "promoted_ruleset_id": "rs_a",
+        "new_rulebook_version": 1,
+        "prior_live_archived_id": None,
+        "cut_reason": "auto_on_promote",
+    }
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "promote-to-live", "rb_x", "rs", "rs_a"])
+    assert result.exit_code == 0
+    out = _strip(result.output)
+    assert "v1" in out
+    # No "prior live archived" line should appear.
+    assert "prior live archived" not in out
+
+
+# ---------------------------------------------------------------------------
+# API error propagation
+# ---------------------------------------------------------------------------
+
+
+def test_promote_to_live_surfaces_422(tmp_path, monkeypatch):
+    """Engine 422 (e.g. ruleset not in testing state) propagates as exit 1."""
+    from aethis_cli.errors import AethisAPIError
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.promote_ruleset_to_live.side_effect = AethisAPIError(
+        status_code=422,
+        detail={
+            "error": "validation_error",
+            "reason_code": "ruleset_not_promotable",
+            "message": "ruleset 'rs_x' must be in 'testing' state",
+        },
+    )
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulesets", "promote-to-live", "rb_x", "child_eligibility", "rs_x"])
+    assert result.exit_code == 1
+    out = _strip(result.output)
+    assert "testing" in out or "ruleset_not_promotable" in out


### PR DESCRIPTION
**DRAFT — pending aethis-core v0.20.0 deploy to `api.aethis.ai`.**

Per submodule-discipline rule 6, this PR holds as a draft until the [Phase A.8 endpoints](https://github.com/Aethis-ai/aethis-core/pull/141) are live on production. The endpoints have been merged on aethis-core main and tagged v0.20.0; Cloud Build is rolling them out now.

---

## Summary

Phase B.1b completes the converged 2-term authoring model on the CLI. Four new sub-commands under `aethis rulesets`:

| Command | Purpose |
|---|---|
| `aethis rulesets list <rulebook>` | List rulesets in a rulebook — grouped by `ruleset_name`, with version_count / live_version / states. The legacy `-p <project_id>` and `--public` modes are preserved while the project-scoped authoring pipeline retires in a future phase. |
| `aethis rulesets create <rulebook> <ruleset_name> [-n "Display name"]` | Create a new draft Ruleset. Display name auto-derives if not given (`child_eligibility` → `Child Eligibility`). |
| `aethis rulesets show <rulebook> <ruleset_name>` | Full version history. Live version highlighted; clear empty-state message when never promoted. |
| `aethis rulesets promote-to-live <rulebook> <ruleset_name> <ruleset_id> [--note]` | Atomically promote a `testing`-state version to `live`. Wraps the Phase A.4 service via the Phase A.8 REST endpoint. Surfaces new rulebook version + prior live archived + cut reason. |

Four new `AethisClient` methods covering the Phase A.8 endpoints with explicit keyword args matching the request models.

## Discipline

- **Backward-compat preserved on `list`.** The legacy `-p` and `--public` modes still work; positional `<rulebook>` takes precedence when present.
- **Greenfield migration path.** The `aethis projects` / top-level `aethis generate` / `aethis test` / `aethis publish` commands are unchanged in this release. Removal lands in a future phase once the authoring pipeline is reworked.
- **No client-side parser duplication.** Composition expressions stay on the Phase A.5 server-side parser; `set-logic` will land when the request model accepts the string form (small follow-up).

## Test plan

- [x] 11 new tests in `tests/test_rulesets_b1b_lifecycle.py`:
  - list with rulebook arg (table + empty-state + endpoint correctness; legacy endpoint not hit)
  - list without args falls through to showcase (backward compat)
  - create with default display name (auto-derive)
  - create with explicit display name (`-n`)
  - show renders versions + live version highlighted
  - show with no live version
  - promote-to-live happy path
  - promote-to-live with `--note`
  - promote-to-live first promotion (no prior live)
  - promote-to-live propagates 422 (ruleset not in testing state)
  - regression: list with rulebook arg never calls `client.list_rulesets` (legacy project endpoint)
- [x] `make lint` clean (after `ruff format`).
- [x] Full suite: **215 passed, 6 pre-existing failures unchanged** (Rich ANSI coloring issue on main, same as in v0.14.0 release).
- [ ] Integration smoke against staging — **blocked on aethis-core v0.20.0 rolling out**.

## What this PR deliberately does NOT do

- No `aethis rulesets generate / test` commands yet — those wrap the authoring pipeline which still flows through project endpoints. Coming when the authoring pipeline is reworked.
- No removal of `aethis projects` command group, `aethis generate`, `aethis test`, `aethis publish`. Still in place; will retire when authoring pipeline migration completes.
- No `aethis rulebooks set-logic` — needs server-side acceptance of string DSL on `PATCH /rulebooks/{id}` or client-side parser duplication. Small follow-up.

## References

- aethis-core Phase A.8: Aethis-ai/aethis-core#141 (merged, deploying as v0.20.0)
- Phase B.1a (rulebooks command group): #46 (merged in v0.14.0)
- Workspace assessment + resolution: Aethis-ai/aethis-workspace#64
- Plan: `~/.claude/plans/ok-i-ve-also-realised-smooth-tome.md`

Bumps version 0.14.0 → 0.15.0 + CHANGELOG roll.