### PR TITLE
feat(publish): --rulebook + --ruleset-name flags (A.9 bridge)

### DIFF
--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -207,6 +207,8 @@ class AethisClient:
         *,
         slug: str | None = None,
         force_unsafe: bool = False,
+        rulebook_id: str | None = None,
+        ruleset_name: str | None = None,
     ) -> dict:
         body: dict = {}
         if slug is not None:
@@ -216,6 +218,16 @@ class AethisClient:
             # publish when stored test cases fail; force_unsafe=True records
             # an audit event and proceeds. Older engines ignore the field.
             body["force_unsafe"] = True
+        # Phase A.9 — publish-into-rulebook bridge. When both set, the
+        # produced ruleset is stamped with rulebook_id + ruleset_name and
+        # lands in state="testing" (instead of status="active"). Promotion
+        # to live then flows via /rulebooks/{id}/rulesets/{name}/promote-
+        # to-live. Requires aethis-core v0.21.0+; older engines either
+        # ignore the fields silently or 422 on the model_validator.
+        if rulebook_id is not None:
+            body["rulebook_id"] = rulebook_id
+        if ruleset_name is not None:
+            body["ruleset_name"] = ruleset_name
         kwargs: dict = {}
         if body:
             kwargs["json"] = body

--- a/aethis_cli/commands/publish_cmd.py
+++ b/aethis_cli/commands/publish_cmd.py
@@ -29,13 +29,44 @@ def publish(
             "namespace is reserved for official rulesets."
         ),
     ),
+    rulebook: Optional[str] = typer.Option(
+        None,
+        "--rulebook",
+        help=(
+            "Rulebook ID or slug to publish this ruleset into "
+            "(converged 2-term model). Requires --ruleset-name. "
+            "The produced ruleset lands in state='testing' rather than "
+            "being flipped to status='active'; promotion to live then "
+            "flows via `aethis rulesets promote-to-live`. Requires "
+            "aethis-core v0.21.0+."
+        ),
+    ),
+    ruleset_name: Optional[str] = typer.Option(
+        None,
+        "--ruleset-name",
+        help=(
+            "Identifier-style name within the parent rulebook (e.g. "
+            "'child_eligibility'). Required when --rulebook is set."
+        ),
+    ),
 ) -> None:
     """Publish the latest generated ruleset (make it active for /decide).
 
     Runs the project's test suite first and refuses to publish if any test
     fails or errors. Use --force to override (for example, when you're
     publishing an intentionally draft ruleset).
+
+    Pass --rulebook + --ruleset-name to publish into a Rulebook (the
+    converged 2-term model). The produced ruleset gets stamped with
+    those FKs and lands in state='testing'; promote it to live with
+    `aethis rulesets promote-to-live <rulebook> <ruleset_name> <rs_id>`.
     """
+    if (rulebook is None) != (ruleset_name is None):
+        console.print(
+            "[red]--rulebook and --ruleset-name must be set together "
+            "(or both omitted for legacy publish-to-active).[/red]"
+        )
+        raise typer.Exit(code=1)
     cfg = load_project_config()
     api_key = resolve_api_key(cfg)
     client = make_authed_client(api_key, cfg.base_url)
@@ -79,7 +110,13 @@ def publish(
         # Older engines ignore the field; newer ones refuse a publish over
         # failing tests unless force_unsafe=True is explicit, in which case
         # they record a publish_force_bypass audit event.
-        result = client.publish(pid, slug=slug, force_unsafe=force)
+        result = client.publish(
+            pid,
+            slug=slug,
+            force_unsafe=force,
+            rulebook_id=rulebook,
+            ruleset_name=ruleset_name,
+        )
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
@@ -88,3 +125,17 @@ def publish(
     if result.get("slug"):
         msg += f" — slug: {result['slug']}"
     success(msg)
+    if result.get("state") == "testing" and result.get("rulebook_id"):
+        # Rulebook-mode publish: surface the next step explicitly so
+        # users don't wonder why /decide doesn't return their ruleset
+        # yet — the ruleset is in `testing`, not `live`.
+        console.print(
+            f"  rulebook: [cyan]{result['rulebook_id']}[/cyan] · "
+            f"ruleset_name: [cyan]{result.get('ruleset_name')}[/cyan] · "
+            f"state: [yellow]testing[/yellow]"
+        )
+        console.print(
+            f"  [dim]promote with: aethis rulesets promote-to-live "
+            f"{result['rulebook_id']} {result.get('ruleset_name')} "
+            f"{result.get('ruleset_id')}[/dim]"
+        )

--- a/tests/test_publish_rulebook_flags.py
+++ b/tests/test_publish_rulebook_flags.py
@@ -1,0 +1,123 @@
+"""Tests for the `aethis publish --rulebook --ruleset-name` flags
+added by Phase A.9 + the small CLI follow-up.
+
+Pattern follows `tests/test_decide_cmd.py`: CliRunner + patch the
+client class.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _runner_invoke(args, env=None):
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    return runner.invoke(app, args, catch_exceptions=False, env=env or {})
+
+
+def _project_dir(tmp_path):
+    """Create the .aethis project config the CLI expects."""
+    aethis_yaml = tmp_path / "aethis.yaml"
+    aethis_yaml.write_text("project: test-project\napi_key_env: AETHIS_API_KEY\n")
+    state = tmp_path / ".aethis"
+    state.mkdir()
+    (state / "state.json").write_text('{"project_id": "proj_test"}')
+
+
+def test_publish_passes_rulebook_flags_to_client(tmp_path, monkeypatch):
+    """`aethis publish --rulebook X --ruleset-name Y` threads both
+    fields through to `client.publish(...)` as kwargs."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    _project_dir(tmp_path)
+
+    client = MagicMock()
+    client.run_tests.return_value = {"passed": 1, "failed": 0, "errors": 0, "total": 1}
+    client.publish.return_value = {
+        "ruleset_id": "rs_x",
+        "rulebook_id": "rb_abc",
+        "ruleset_name": "child_eligibility",
+        "state": "testing",
+    }
+
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "publish",
+                "--rulebook",
+                "aethis/uk-fsm",
+                "--ruleset-name",
+                "child_eligibility",
+            ]
+        )
+
+    assert result.exit_code == 0, result.output
+    _args, kwargs = client.publish.call_args
+    assert kwargs["rulebook_id"] == "aethis/uk-fsm"
+    assert kwargs["ruleset_name"] == "child_eligibility"
+    out = _strip(result.output)
+    assert "rb_abc" in out  # rulebook surfaced
+    assert "testing" in out  # state surfaced
+    assert "promote-to-live" in out  # next-step hint shown
+
+
+def test_publish_without_rulebook_flags_omits_them(tmp_path, monkeypatch):
+    """Legacy publish path: no rulebook flags, no rulebook fields in
+    the client call."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    _project_dir(tmp_path)
+
+    client = MagicMock()
+    client.run_tests.return_value = {"passed": 1, "failed": 0, "errors": 0, "total": 1}
+    client.publish.return_value = {"ruleset_id": "rs_x"}
+
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["publish"])
+
+    assert result.exit_code == 0
+    _args, kwargs = client.publish.call_args
+    assert kwargs.get("rulebook_id") is None
+    assert kwargs.get("ruleset_name") is None
+
+
+def test_publish_rulebook_without_ruleset_name_rejected(tmp_path, monkeypatch):
+    """Partial input must fail loud at the CLI layer with a clear
+    message, before the request is built."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    _project_dir(tmp_path)
+
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["publish", "--rulebook", "aethis/uk-fsm"])
+    assert result.exit_code != 0
+    out = _strip(result.output)
+    assert "must be set together" in out
+    client.publish.assert_not_called()
+
+
+def test_publish_ruleset_name_without_rulebook_rejected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    _project_dir(tmp_path)
+
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["publish", "--ruleset-name", "x"])
+    assert result.exit_code != 0
+    out = _strip(result.output)
+    assert "must be set together" in out
+    client.publish.assert_not_called()


### PR DESCRIPTION
**DRAFT — pending aethis-core v0.21.0 (Phase A.9 endpoint) deploy.**

Wires the Phase A.9 publish-into-rulebook bridge ([Aethis-ai/aethis-core#142](https://github.com/Aethis-ai/aethis-core/pull/142)) through to the CLI. Closes the missing link between legacy project-scoped authoring and the new 2-term Rulebook model.

## What changes

`aethis publish` gains two new flags:

| Flag | Meaning |
|---|---|
| `--rulebook <slug-or-id>` | Target Rulebook to publish into |
| `--ruleset-name <name>` | Identifier-style name within that rulebook |

When both set, the server stamps the produced ruleset with both FKs and lands it in `state="testing"` rather than flipping to `status="active"`. The CLI surfaces the next step explicitly:

```
✓ Published ruleset rs_abc
  rulebook: aethis/uk-fsm · ruleset_name: child_eligibility · state: testing
  promote with: aethis rulesets promote-to-live aethis/uk-fsm child_eligibility rs_abc
```

## End-to-end flow this unlocks

```bash
aethis rulebooks create "UK FSM" --domain uk_fsm --slug aethis/uk-fsm
aethis init
aethis generate --poll
aethis test
aethis publish --rulebook aethis/uk-fsm --ruleset-name child_eligibility
aethis rulesets promote-to-live aethis/uk-fsm child_eligibility <rs_id>
aethis rulebooks decide aethis/uk-fsm -i '{...}'
```

## Discipline

- **Legacy publish unchanged.** No rulebook flags → kwargs default to None → client omits them from the body → server uses the long-standing `status="active"` path. Existing scripts + CI flows are not affected.
- **Partial input fails fast at the CLI layer.** `--rulebook` without `--ruleset-name` (and vice versa) is rejected with a clear message before the request is built. Server-side enforces the same via the `model_validator`, but failing fast in the CLI saves a round-trip.

## Test plan

- [x] 4 new tests in `tests/test_publish_rulebook_flags.py`:
  - Flags thread through to `client.publish()` kwargs
  - Output surfaces next-step hint when `state=testing` returned
  - Legacy publish (no flags) doesn't set the kwargs
  - `--rulebook` without `--ruleset-name` rejected with clear message
  - `--ruleset-name` without `--rulebook` rejected with clear message
- [x] `make lint` clean.

## References

- aethis-core Phase A.9: Aethis-ai/aethis-core#142 (pending merge + v0.21.0 deploy)
- aethis-cli Phase B.1a: #46 (merged in v0.14.0)
- aethis-cli Phase B.1b: #47 (merged in v0.15.0)
- Plan: `~/.claude/plans/ok-i-ve-also-realised-smooth-tome.md`