### PR TITLE
feat(rulebooks): set-logic — set composition expression via CLI (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.16.0 (2026-05-21)
+
+- **feat(rulebooks): `aethis rulebooks set-logic` — set the composition expression on a rulebook.** The composition expression (server field `outcome_logic`) is an Expr AST that combines per-ruleset outcomes into the rulebook's final decision. Previously settable only via raw PATCH; now exposed via the CLI for multi-ruleset rulebooks (e.g. UK FSM's `child_eligibility AND (household_criteria OR universal_infant)`).
+  - `aethis rulebooks set-logic <id> -f logic.yaml` — load from YAML/JSON file
+  - `aethis rulebooks set-logic <id> --logic '<json>'` — inline JSON
+  - Exactly one of `--file` / `--logic` is required; both forms reject non-object payloads at the client side so server validation isn't the first line of defence.
+
 ## 0.15.0 (2026-05-21)
 
 - **feat(rulesets): ruleset lifecycle commands scoped to a rulebook.** Phase B.1b of the converged 2-term model. Adds four new sub-commands under `aethis rulesets`:

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -14,6 +14,7 @@ This command group covers the rulebook lifecycle and configuration:
     aethis rulebooks set-fields <id> -f fields.yaml
     aethis rulebooks lock-fields <id>
     aethis rulebooks unlock-fields <id>
+    aethis rulebooks set-logic <id> -f logic.yaml
     aethis rulebooks tests add <id> -f scenario.yaml
     aethis rulebooks tests list <id>
     aethis rulebooks tests delete <id> <tc_id>
@@ -298,6 +299,83 @@ def get_fields(
             f.get("description") or "[dim]—[/dim]",
         )
     console.print(table)
+
+
+# ============================================================================
+# rulebooks set-logic
+# ============================================================================
+
+
+@rulebooks_app.command(name="set-logic")
+def set_logic(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    file: Optional[Path] = typer.Option(
+        None,
+        "--file",
+        "-f",
+        exists=True,
+        readable=True,
+        help="Path to a YAML or JSON file containing the outcome_logic Expr AST.",
+    ),
+    logic: Optional[str] = typer.Option(
+        None,
+        "--logic",
+        "-l",
+        help="Inline JSON Expr AST. Mutually exclusive with --file.",
+    ),
+) -> None:
+    """Set the rulebook's composition expression (``outcome_logic``).
+
+    The composition expression is an Expr AST that combines per-ruleset
+    outcomes into the rulebook's final decision. The smallest example::
+
+        {"type": "field_ref", "key": "single_ruleset_name"}
+
+    A typical multi-ruleset composition, e.g. ``A AND (B OR C)``::
+
+        {
+          "type": "op", "operator": "and",
+          "args": [
+            {"type": "field_ref", "key": "A"},
+            {"type": "op", "operator": "or", "args": [
+              {"type": "field_ref", "key": "B"},
+              {"type": "field_ref", "key": "C"}
+            ]}
+          ]
+        }
+
+    ``field_ref.key`` values are ruleset names within the rulebook. Pass
+    the expression as either a file (``--file logic.yaml``) or inline
+    JSON (``--logic '{...}'``). Exactly one of the two is required.
+    """
+    if (file is None) == (logic is None):
+        # Either both supplied or both missing — neither is valid.
+        raise typer.BadParameter(
+            "Provide exactly one of --file/-f or --logic/-l."
+        )
+
+    if file is not None:
+        payload = _load_yaml_or_json(file)
+    else:
+        try:
+            payload = json.loads(logic or "")
+        except json.JSONDecodeError as exc:
+            raise typer.BadParameter(f"--logic is not valid JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise typer.BadParameter(
+            "outcome_logic must be a JSON object (Expr AST), not a list or scalar."
+        )
+
+    _cfg, client = load_client_or_fallback()
+    try:
+        client.update_rulebook(rulebook, outcome_logic=payload)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    op = payload.get("operator") or payload.get("type")
+    success(f"Set outcome_logic on rulebook {rulebook} (top-level: {op})")
 
 
 # ============================================================================

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -350,9 +350,7 @@ def set_logic(
     """
     if (file is None) == (logic is None):
         # Either both supplied or both missing — neither is valid.
-        raise typer.BadParameter(
-            "Provide exactly one of --file/-f or --logic/-l."
-        )
+        raise typer.BadParameter("Provide exactly one of --file/-f or --logic/-l.")
 
     if file is not None:
         payload = _load_yaml_or_json(file)
@@ -363,9 +361,7 @@ def set_logic(
             raise typer.BadParameter(f"--logic is not valid JSON: {exc}") from exc
 
     if not isinstance(payload, dict):
-        raise typer.BadParameter(
-            "outcome_logic must be a JSON object (Expr AST), not a list or scalar."
-        )
+        raise typer.BadParameter("outcome_logic must be a JSON object (Expr AST), not a list or scalar.")
 
     _cfg, client = load_client_or_fallback()
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.15.0"
+version = "0.16.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -349,9 +349,7 @@ def test_set_logic_from_json_file(tmp_path, monkeypatch):
     }
 
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-logic", "rb_x", "--file", str(logic_path)]
-        )
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "--file", str(logic_path)])
 
     assert result.exit_code == 0, result.output
     client.update_rulebook.assert_called_once()
@@ -393,9 +391,7 @@ def test_set_logic_from_yaml_file(tmp_path, monkeypatch):
     client = MagicMock()
     client.update_rulebook.return_value = {"rulebook_id": "rb_x"}
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-logic", "rb_x", "-f", str(logic_path)]
-        )
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "-f", str(logic_path)])
 
     assert result.exit_code == 0, result.output
     sent = client.update_rulebook.call_args.kwargs["outcome_logic"]
@@ -460,9 +456,7 @@ def test_set_logic_rejects_non_object_payload(tmp_path, monkeypatch):
     bad_path.write_text(json.dumps(["not", "an", "expr"]))
     client = MagicMock()
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-logic", "rb_x", "-f", str(bad_path)]
-        )
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "-f", str(bad_path)])
     assert result.exit_code != 0
     client.update_rulebook.assert_not_called()
 
@@ -472,9 +466,7 @@ def test_set_logic_inline_json_invalid(tmp_path, monkeypatch):
     monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
     client = MagicMock()
     with patch("aethis_cli.client.AethisClient", return_value=client):
-        result = _runner_invoke(
-            ["rulebooks", "set-logic", "rb_x", "--logic", "{not-json}"]
-        )
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "--logic", "{not-json}"])
     assert result.exit_code != 0
     client.update_rulebook.assert_not_called()
 

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -308,6 +308,178 @@ def test_get_fields_empty_state(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# rulebooks set-logic
+# ---------------------------------------------------------------------------
+
+
+def _logic_expr() -> dict:
+    """The composition expression that the UK FSM example uses.
+
+    Plain English: ``child_eligibility AND (household_criteria OR universal_infant)``.
+    The shape is the Expr AST the server validates against.
+    """
+    return {
+        "type": "op",
+        "operator": "and",
+        "args": [
+            {"type": "field_ref", "key": "child_eligibility"},
+            {
+                "type": "op",
+                "operator": "or",
+                "args": [
+                    {"type": "field_ref", "key": "household_criteria"},
+                    {"type": "field_ref", "key": "universal_infant"},
+                ],
+            },
+        ],
+    }
+
+
+def test_set_logic_from_json_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+
+    logic_path = tmp_path / "logic.json"
+    logic_path.write_text(json.dumps(_logic_expr()))
+
+    client = MagicMock()
+    client.update_rulebook.return_value = {
+        "rulebook_id": "rb_x",
+        "outcome_logic": _logic_expr(),
+    }
+
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-logic", "rb_x", "--file", str(logic_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    client.update_rulebook.assert_called_once()
+    _args, kwargs = client.update_rulebook.call_args
+    assert kwargs["outcome_logic"] == _logic_expr()
+    # Only outcome_logic should have been sent — no accidental name/slug edits.
+    for k in ("name", "description", "ruleset_refs", "slug"):
+        assert kwargs.get(k) is None, f"unexpected {k} sent on set-logic"
+    out = _strip(result.output)
+    assert "rb_x" in out
+
+
+def test_set_logic_from_yaml_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    import importlib.util
+
+    if importlib.util.find_spec("yaml") is None:
+        import pytest
+
+        pytest.skip("PyYAML not installed")
+
+    logic_path = tmp_path / "logic.yaml"
+    logic_path.write_text(
+        "type: op\n"
+        "operator: and\n"
+        "args:\n"
+        "  - type: field_ref\n"
+        "    key: child_eligibility\n"
+        "  - type: op\n"
+        "    operator: or\n"
+        "    args:\n"
+        "      - type: field_ref\n"
+        "        key: household_criteria\n"
+        "      - type: field_ref\n"
+        "        key: universal_infant\n"
+    )
+
+    client = MagicMock()
+    client.update_rulebook.return_value = {"rulebook_id": "rb_x"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-logic", "rb_x", "-f", str(logic_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    sent = client.update_rulebook.call_args.kwargs["outcome_logic"]
+    assert sent == _logic_expr()
+
+
+def test_set_logic_inline_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+
+    client = MagicMock()
+    client.update_rulebook.return_value = {"rulebook_id": "rb_x"}
+    inline = json.dumps(_logic_expr())
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "--logic", inline])
+
+    assert result.exit_code == 0, result.output
+    sent = client.update_rulebook.call_args.kwargs["outcome_logic"]
+    assert sent == _logic_expr()
+
+
+def test_set_logic_requires_one_of_file_or_logic(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x"])
+    assert result.exit_code != 0
+    out = _strip(result.output).lower()
+    assert "--file" in out or "--logic" in out
+    client.update_rulebook.assert_not_called()
+
+
+def test_set_logic_rejects_both_file_and_inline(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    logic_path = tmp_path / "logic.json"
+    logic_path.write_text(json.dumps(_logic_expr()))
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            [
+                "rulebooks",
+                "set-logic",
+                "rb_x",
+                "--file",
+                str(logic_path),
+                "--logic",
+                json.dumps(_logic_expr()),
+            ]
+        )
+    assert result.exit_code != 0
+    client.update_rulebook.assert_not_called()
+
+
+def test_set_logic_rejects_non_object_payload(tmp_path, monkeypatch):
+    """The Expr AST must be a JSON object (dict). Lists, scalars, etc. are
+    rejected at the client side so the server doesn't have to."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    bad_path = tmp_path / "logic.json"
+    bad_path.write_text(json.dumps(["not", "an", "expr"]))
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-logic", "rb_x", "-f", str(bad_path)]
+        )
+    assert result.exit_code != 0
+    client.update_rulebook.assert_not_called()
+
+
+def test_set_logic_inline_json_invalid(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "set-logic", "rb_x", "--logic", "{not-json}"]
+        )
+    assert result.exit_code != 0
+    client.update_rulebook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # rulebooks archive
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `aethis rulebooks set-logic <id> [-f file | --logic '<json>']` to set the composition expression (server field `outcome_logic`) on a rulebook from the CLI.
- Previously settable only via raw PATCH. Tolerable for single-ruleset rulebooks (spacecraft) but a worse UX than the rest of the converged 2-term flow for multi-ruleset rulebooks like the UK FSM example, which needs `A AND (B OR C)`.
- Wire call reuses the existing PATCH `outcome_logic` support in `update_rulebook`. Engine PATCH endpoint accepting `outcome_logic` has been live since Phase A.7 — no aethis-core change required.

## Behaviour

- Exactly one of `--file` / `--logic` is required (BadParameter if both or neither).
- Both forms reject non-object payloads at the client side so a typo doesn't round-trip to the server.
- File form accepts `.yaml`, `.yml`, or `.json` (PyYAML lazy-imported).

## Tests

- 7 new tests in `tests/test_rulebooks_cmd.py` cover: JSON file, YAML file, inline JSON, missing/conflicting options, non-object payload, malformed JSON. All pass.
- Full `test_rulebooks_cmd.py`: 32 passed.

## Test plan

- [ ] CI green
- [ ] `aethis rulebooks set-logic --help` prints the usage block with both flag variants
- [ ] Manual: against a draft rulebook, `set-logic -f logic.yaml` returns 0 and a subsequent `aethis rulebooks show` reflects the new composition