### PR TITLE
docs(set-logic): clarify post-A.16 ruleset-name composition + v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.1 (2026-05-22)
+
+- **docs(rulebooks set-logic):** the docstring example for `field_ref.key` now matches engine behaviour. Phase A.16 (aethis-core v0.26.0+) added per-section aggregate group synthesis, so `field_ref.key = <ruleset_name>` resolves to the AND of that ruleset's groups. The unscoped group-name and scoped `<ruleset_name>.<group>` forms remain available for advanced compositions. Requires aethis-core v0.26.0+ live on the target API.
+
 ## 0.16.0 (2026-05-21)
 
 - **feat(rulebooks): `aethis rulebooks set-logic` — set the composition expression on a rulebook.** The composition expression (server field `outcome_logic`) is an Expr AST that combines per-ruleset outcomes into the rulebook's final decision. Previously settable only via raw PATCH; now exposed via the CLI for multi-ruleset rulebooks (e.g. UK FSM's `child_eligibility AND (household_criteria OR universal_infant)`).

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -344,9 +344,14 @@ def set_logic(
           ]
         }
 
-    ``field_ref.key`` values are ruleset names within the rulebook. Pass
-    the expression as either a file (``--file logic.yaml``) or inline
-    JSON (``--logic '{...}'``). Exactly one of the two is required.
+    ``field_ref.key`` values are ruleset names within the rulebook (e.g.
+    ``"child_eligibility"``); the engine resolves each name to the AND of
+    that ruleset's compiled groups (requires aethis-core v0.26.0+). For
+    advanced compositions you may also use an unscoped group name or the
+    scoped ``<ruleset_name>.<group>`` form — both remain accepted for
+    backwards compatibility. Pass the expression as either a file
+    (``--file logic.yaml``) or inline JSON (``--logic '{...}'``). Exactly
+    one of the two is required.
     """
     if (file is None) == (logic is None):
         # Either both supplied or both missing — neither is valid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.16.0"
+version = "0.16.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Enhances the `set_logic` docstring to clarify that `field_ref.key` resolves to the AND of a ruleset's compiled groups — the forward-looking claim that existed since v0.16.0 is now accurate once aethis-core v0.26.0+ (Phase A.16) is live.
- Documents the backwards-compatible unscoped group-name and scoped `<ruleset_name>.<group>` forms for advanced compositions.
- Bumps version to 0.16.1 (patch — docs-only change).

## References

- Engine PR: Aethis-ai/aethis-core#155 (Phase A.16 — per-section aggregate group synthesis)
- Epic: Aethis-ai/aethis-core#150

## Test plan

- [x] `uv run aethis rulebooks set-logic --help` renders cleanly with the new paragraph
- [x] No functional code changes — existing tests unchanged