### PR TITLE
docs(readme): v0.27.0 accuracy pass — rulebooks surface + pip→uv + v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.16.2 (2026-05-22)
+
+- **docs(readme): v0.27.0 accuracy pass.** Three fixes for fresh-developer accuracy:
+  - Install block: removed the `pip install` fallback (uv and pipx are the recommended forms per workspace policy). Development section: `pip install -e ".[dev]"` → `uv pip install -e ".[dev]"`.
+  - Added **Rulebooks** command-group section documenting the converged 2-term model surface shipped in v0.14.0–v0.16.1 (`aethis rulebooks` + `aethis rulesets` promote-to-live).
+  - Updated engine_version example to `aethis-core@0.27.0` (was absent; clarified to current production version).
+
 ## 0.16.1 (2026-05-22)
 
 - **docs(rulebooks set-logic):** the docstring example for `field_ref.key` now matches engine behaviour. Phase A.16 (aethis-core v0.26.0+) added per-section aggregate group synthesis, so `field_ref.key = <ruleset_name>` resolves to the AND of that ruleset's groups. The unscoped group-name and scoped `<ruleset_name>.<group>` forms remain available for advanced compositions. Requires aethis-core v0.26.0+ live on the target API.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ uv tool install aethis-cli
 
 # Or, with pipx:
 pipx install aethis-cli
-
-# Or in a venv:
-python -m venv .venv && source .venv/bin/activate
-pip install aethis-cli
 ```
 
 ## Quick start
@@ -161,6 +157,25 @@ Project guidance lives in `.aethis/guidance/hints.yaml` and is uploaded by `aeth
 | `aethis projects archive <project_id>` | Archive a project |
 | `aethis rulesets list` | List published rulesets |
 | `aethis rulesets archive <ruleset_id>` | Archive a ruleset |
+
+### Rulebooks (the converged 2-term model, login required)
+
+A Rulebook is the whole form — the unit `/decide` evaluates against. It owns a locked field vocabulary, an `outcome_logic` composition expression, rulebook-level test cases, and an integer version history. Rulesets are named, versioned members of a Rulebook.
+
+| Command | Description |
+|---------|-------------|
+| `aethis rulebooks list` | List your tenant's rulebooks |
+| `aethis rulebooks show <id-or-slug>` | Full configuration including outcome_logic |
+| `aethis rulebooks create <name> --domain <d> [--slug ...]` | Create a draft rulebook |
+| `aethis rulebooks set-fields <id> -f fields.yaml` | Replace the locked field vocabulary |
+| `aethis rulebooks lock-fields <id>` / `unlock-fields <id>` / `get-fields <id>` | Manage the field-lock state |
+| `aethis rulebooks set-logic <id> -f logic.yaml` | Set the composition expression (Expr AST) |
+| `aethis rulebooks decide <id-or-slug> -i '<json>'` | Evaluate the composed rulebook (requires API key) |
+| `aethis rulebooks activate <id>` / `archive <id>` | Lifecycle |
+| `aethis rulesets create <rulebook> <ruleset_name>` | Create a draft ruleset inside a rulebook |
+| `aethis rulesets list <rulebook>` | List rulesets in a rulebook |
+| `aethis rulesets show <rulebook> <ruleset_name>` | Full version history for one ruleset name |
+| `aethis rulesets promote-to-live <rulebook> <ruleset_name> <ruleset_id>` | Atomic promotion: demote prior live → archived, promote candidate, cut new Rulebook version |
 
 ### Account
 
@@ -320,7 +335,7 @@ Staff-only tools (DSL source viewer, IAM registry, domain-guidance management, `
 ```bash
 git clone https://github.com/aethis-ai/aethis-cli.git
 cd aethis-cli
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 pytest tests/ -v
 ```
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.16.1"
+version = "0.16.2"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Fresh-developer audit identified three concrete gaps in the CLI README against the v0.27.0 platform state:

- **pip→uv**: removed the `pip install aethis-cli` fallback from the Install block and the `pip install -e ".[dev]"` from the Development section. Replaced with `uv pip install -e ".[dev]"` per workspace `.claude/rules/no-pip.md`.
- **Missing rulebooks section**: the Commands section had no documentation of the `aethis rulebooks` and `aethis rulesets` surface shipped in v0.14.0–v0.16.1 (the converged 2-term model). Added a new **Rulebooks** subsection with a full command table.
- **Version bump**: 0.16.1 → 0.16.2 so PyPI users pulling the README refresh get the updated content.

## Related

- aethis-core#150 (v0.27.0 rulebook surface)
- aethis-cli#51 (set-logic docstring, prior readme accuracy pass)

## Test plan

- [ ] `uv run pytest -q` — 226 passed, 6 pre-existing failures (unrelated to README; confirmed identical on `main`)
- [ ] Install block contains no `pip install` reference
- [ ] Rulebooks section renders correctly in GitHub markdown preview
- [ ] `pyproject.toml` and `_version.py` both show `0.16.2`