### PR TITLE
fix(status, whoami): read multi-profile credentials file like every other command (v0.16.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.16.3 (2026-05-27)
+
+- **fix(status, whoami): read the multi-profile credentials file the same way every other command does.** `aethis login --api-key ...` writes `profiles.<name>.api_key` to `~/.config/aethis/credentials` (the multi-profile schema introduced in v0.10), but `aethis status` and `aethis whoami` had stale local resolvers that only looked for a flat top-level `api_key` (and `whoami` was looking at the wrong filename, `credentials.yaml`). Result: after a fresh `aethis login`, `aethis status` reported `no API key` and `aethis whoami` reported `No Aethis API key configured`, even though the same key worked for `aethis projects list`, `aethis generate`, and every other authoring command.
+  - Both commands now route through the canonical `resolve_cached_key()` helper in `auth_helpers.py`, which honours `AETHIS_API_KEY` env → active profile → keychain → legacy `.yaml` file.
+  - The `_resolve_cached_key` symbol is renamed to `resolve_cached_key` (public). The legacy `_resolve_key_silent` (status_cmd) and `_resolve_api_key_lax` (whoami_cmd) are removed.
+  - Regression test in `tests/test_status_cmd.py` writes a real multi-profile credentials YAML to a temp `XDG_CONFIG_HOME` and asserts both commands surface the key.
+
 ## 0.16.2 (2026-05-22)
 
 - **docs(readme): v0.27.0 accuracy pass.** Three fixes for fresh-developer accuracy:

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.16.2"
+__version__ = "0.16.3"

--- a/aethis_cli/auth_helpers.py
+++ b/aethis_cli/auth_helpers.py
@@ -56,7 +56,7 @@ def _is_interactive() -> bool:
         return False
 
 
-def _resolve_cached_key() -> Optional[str]:
+def resolve_cached_key() -> Optional[str]:
     """Return the cached key for the active profile, or None if none is found.
 
     Resolution order:
@@ -185,7 +185,7 @@ def require_auth_or_login_inline(
         raise AuthRequired(message)
 
     if not force_browser:
-        cached = _resolve_cached_key()
+        cached = resolve_cached_key()
         if cached:
             return cached
 

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -193,5 +193,3 @@ def _print_generation_section(project_id: str) -> None:
     bid = result.get("latest_ruleset_id")
     if bid:
         console.print(f"  Ruleset:  {bid}")
-
-

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -8,6 +8,7 @@ from typing import Optional
 import typer
 
 from aethis_cli._version import __version__
+from aethis_cli.auth_helpers import resolve_cached_key
 from aethis_cli.client import AethisClient
 from aethis_cli.config import (
     DEFAULT_BASE_URL,
@@ -126,7 +127,7 @@ def _print_identity_section() -> None:
         console.print(f"[bold]Identity:[/bold]    [dim]{auth_mode} (provider-minted at request time)[/dim]")
         return
 
-    api_key = _resolve_key_silent()
+    api_key = resolve_cached_key()
     if api_key is None:
         console.print(
             "[bold]Identity:[/bold]    [yellow]no API key[/yellow]  "
@@ -168,7 +169,7 @@ def _print_generation_section(project_id: str) -> None:
     except ConfigError:
         base_url = os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
 
-    api_key = _resolve_key_silent()
+    api_key = resolve_cached_key()
     if api_key is None:
         console.print("[bold]Generation:[/bold]  [dim]skipped — no API key[/dim]")
         return
@@ -194,31 +195,3 @@ def _print_generation_section(project_id: str) -> None:
         console.print(f"  Ruleset:  {bid}")
 
 
-def _resolve_key_silent() -> Optional[str]:
-    """Resolve API key without raising. Returns None if not found."""
-    key = os.environ.get("AETHIS_API_KEY")
-    if key:
-        return key
-    try:
-        import keyring  # type: ignore[import-not-found]
-
-        key = keyring.get_password("aethis-cli", "api_key")
-        if key:
-            return key
-    except Exception:
-        pass
-    from pathlib import Path
-
-    import yaml  # type: ignore[import-untyped]
-
-    creds_xdg = os.environ.get("XDG_CONFIG_HOME")
-    creds_path = (
-        Path(creds_xdg) / "aethis" / "credentials" if creds_xdg else Path.home() / ".config" / "aethis" / "credentials"
-    )
-    if creds_path.exists():
-        try:
-            raw = yaml.safe_load(creds_path.read_text()) or {}
-            return raw.get("api_key")
-        except Exception:
-            pass
-    return None

--- a/aethis_cli/commands/whoami_cmd.py
+++ b/aethis_cli/commands/whoami_cmd.py
@@ -4,44 +4,11 @@ from __future__ import annotations
 
 import typer
 
-import os
-
+from aethis_cli.auth_helpers import resolve_cached_key
 from aethis_cli.client import AethisClient
-from aethis_cli.config import DEFAULT_BASE_URL
+from aethis_cli.config import resolve_base_url_with_source
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
-
-
-def _resolve_api_key_lax() -> tuple[str | None, str]:
-    """Resolve an API key using the same fallback chain as other commands,
-    but don't raise when no key is found — return (None, base_url) instead.
-    """
-    base_url = os.environ.get("AETHIS_BASE_URL", DEFAULT_BASE_URL)
-    key = os.environ.get("AETHIS_API_KEY")
-    if key:
-        return key, base_url
-    try:
-        import keyring  # type: ignore[import-not-found]
-
-        key = keyring.get_password("aethis-cli", "api_key")
-        if key:
-            return key, base_url
-    except Exception:
-        pass
-    # Plaintext credentials file
-    from pathlib import Path
-    import yaml  # type: ignore[import-untyped]
-
-    creds = Path.home() / ".config" / "aethis" / "credentials.yaml"
-    if creds.exists():
-        try:
-            raw = yaml.safe_load(creds.read_text()) or {}
-            key = raw.get("api_key")
-            if key:
-                return key, base_url
-        except Exception:
-            pass
-    return None, base_url
 
 
 def whoami() -> None:
@@ -49,7 +16,8 @@ def whoami() -> None:
 
     Answers "can I author rules with this key?" before you try and get a 403.
     """
-    api_key, base_url = _resolve_api_key_lax()
+    api_key = resolve_cached_key()
+    base_url, _ = resolve_base_url_with_source()
     if api_key is None:
         console.print(
             "[yellow]No Aethis API key configured.[/yellow]\n"

--- a/aethis_cli/config.py
+++ b/aethis_cli/config.py
@@ -152,7 +152,7 @@ def load_client_or_anon() -> tuple["ProjectConfig", "AethisClient"]:
     get access to their private rulesets. If no key is found, fall back to
     an unsigned client so public rulesets work with zero setup.
     """
-    from aethis_cli.auth_helpers import RUNTIME, _resolve_cached_key, is_anonymous_active
+    from aethis_cli.auth_helpers import RUNTIME, resolve_cached_key, is_anonymous_active
     from aethis_cli.client import make_anonymous_client
 
     try:
@@ -176,7 +176,7 @@ def load_client_or_anon() -> tuple["ProjectConfig", "AethisClient"]:
         # anonymous just because one isn't present.
         return cfg, make_authed_client("", cfg.base_url, profile=profile)
 
-    api_key = _resolve_cached_key()
+    api_key = resolve_cached_key()
     if api_key is None:
         return cfg, make_anonymous_client(cfg.base_url)
 
@@ -217,18 +217,18 @@ def load_project_config(path: Optional[Path] = None) -> ProjectConfig:
 def resolve_api_key(config: ProjectConfig) -> str:
     """Resolve API key: env var → active profile → keychain (default only) → lazy-auth.
 
-    See :func:`aethis_cli.auth_helpers._resolve_cached_key` for the resolution
+    See :func:`aethis_cli.auth_helpers.resolve_cached_key` for the resolution
     chain. When no cached key is found we delegate to the lazy-auth helper,
     which will offer an inline browser sign-in on a TTY or raise
     ``AuthRequired`` on non-interactive shells / ``--no-prompt``.
     """
-    from aethis_cli.auth_helpers import _resolve_cached_key, require_auth_or_login_inline
+    from aethis_cli.auth_helpers import resolve_cached_key, require_auth_or_login_inline
 
-    cached = _resolve_cached_key()
+    cached = resolve_cached_key()
     if cached:
         # Honour the project's ``api_key_env`` override only when set to the
         # non-default name — the standard ``AETHIS_API_KEY`` path is already
-        # covered by ``_resolve_cached_key``.
+        # covered by ``resolve_cached_key``.
         if config.api_key_env != "AETHIS_API_KEY":
             override = os.environ.get(config.api_key_env)
             if override:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.16.2"
+version = "0.16.3"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -10,7 +10,7 @@ import yaml
 from typer.testing import CliRunner
 
 from aethis_cli import config
-from aethis_cli.auth_helpers import RUNTIME, _resolve_cached_key, is_anonymous_active
+from aethis_cli.auth_helpers import RUNTIME, resolve_cached_key, is_anonymous_active
 from aethis_cli.main import app
 
 runner = CliRunner()
@@ -54,7 +54,7 @@ def test_legacy_single_key_loads_as_default_profile(tmp_path: Path) -> None:
 def test_legacy_single_key_resolves_for_default_profile(tmp_path: Path) -> None:
     _write_legacy_single_key(tmp_path, "ak_legacy_xyz")
 
-    assert _resolve_cached_key() == "ak_legacy_xyz"
+    assert resolve_cached_key() == "ak_legacy_xyz"
 
 
 def test_save_upgrades_legacy_to_multi_profile(tmp_path: Path) -> None:
@@ -72,7 +72,7 @@ def test_anonymous_profile_yields_no_key(tmp_path: Path) -> None:
     config.set_active_profile("anonymous")
 
     assert is_anonymous_active() is True
-    assert _resolve_cached_key() is None
+    assert resolve_cached_key() is None
 
 
 def test_profile_override_beats_sticky_default(tmp_path: Path) -> None:
@@ -83,7 +83,7 @@ def test_profile_override_beats_sticky_default(tmp_path: Path) -> None:
     RUNTIME.profile_override = "new-dev"
     try:
         assert config.active_profile_name() == "new-dev"
-        assert _resolve_cached_key() == "ak_dev"
+        assert resolve_cached_key() == "ak_dev"
     finally:
         RUNTIME.profile_override = None
 
@@ -94,7 +94,7 @@ def test_env_api_key_beats_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     monkeypatch.setenv("AETHIS_API_KEY", "ak_env_override")
 
     # AETHIS_API_KEY remains the absolute override, even with a configured profile.
-    assert _resolve_cached_key() == "ak_env_override"
+    assert resolve_cached_key() == "ak_env_override"
 
 
 def test_reserved_anonymous_name_rejected_at_set(tmp_path: Path) -> None:

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -2,9 +2,20 @@
 
 from __future__ import annotations
 
+import os
+import re
+from pathlib import Path
 from unittest.mock import patch
 
+import yaml
 from typer.testing import CliRunner
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    """Strip ANSI escape sequences so substring checks survive Rich's auto-highlighting."""
+    return _ANSI_RE.sub("", s)
 
 
 def _run_status(args=None, env=None):
@@ -28,9 +39,7 @@ def test_status_no_config_no_key_shows_defaults(tmp_path, monkeypatch):
     # Neutralise keyring + credentials fallback
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty_xdg"))
 
-    with patch("aethis_cli.commands.status_cmd.keyring", create=True) as kr:
-        kr.get_password.return_value = None
-        result = _run_status()
+    result = _run_status()
 
     assert result.exit_code == 0, result.output
     assert "aethis v" in result.output
@@ -47,9 +56,7 @@ def test_status_with_base_url_env_shows_override(tmp_path, monkeypatch):
     monkeypatch.delenv("AETHIS_API_KEY", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty_xdg"))
 
-    with patch("aethis_cli.commands.status_cmd.keyring", create=True) as kr:
-        kr.get_password.return_value = None
-        result = _run_status()
+    result = _run_status()
 
     assert result.exit_code == 0, result.output
     assert "http://localhost:8080" in result.output
@@ -102,6 +109,75 @@ def test_status_with_yaml_shows_project_context(tmp_project, monkeypatch):
     assert "from aethis.yaml" in result.output
 
 
+def _write_multi_profile_credentials(tmp_path: Path, profile: str, api_key: str) -> Path:
+    """Write the multi-profile credentials YAML the way `aethis login` does."""
+    creds_dir = tmp_path / "aethis"
+    creds_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    creds = creds_dir / "credentials"
+    payload = {"active_profile": profile, "profiles": {profile: {"api_key": api_key}}}
+    fd = os.open(str(creds), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(yaml.dump(payload))
+    return creds
+
+
+def test_status_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
+    """Regression: `aethis login` writes profiles.<name>.api_key but status used
+    to look for a flat top-level `api_key` and reported "no API key" while
+    other commands worked fine.
+
+    Trip-wire so the asymmetry doesn't reappear.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_multi_profile_credentials(tmp_path, "default", "ak_live_regression_canary")
+
+    fake_me = {
+        "key_id": "ak_live_regression_canary",
+        "tenant_id": "tenant_x",
+        "rate_limit_tier": "internal",
+        "scopes": ["decide", "rulesets:write"],
+        "can_author": True,
+    }
+    with patch("aethis_cli.client.AethisClient.whoami", return_value=fake_me):
+        result = _run_status()
+
+    assert result.exit_code == 0, result.output
+    assert "ak_live_regression_canary" in result.output, (
+        "status read the credentials file but didn't surface the resolved key — "
+        "check the call site to resolve_cached_key()"
+    )
+    assert "no API key" not in result.output
+
+
+def test_whoami_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
+    """Regression mirror of the status test above, for `aethis whoami`."""
+    from aethis_cli.main import app
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _write_multi_profile_credentials(tmp_path, "default", "ak_live_whoami_canary")
+
+    fake_me = {
+        "key_id": "ak_live_whoami_canary",
+        "tenant_id": "tenant_x",
+        "rate_limit_tier": "internal",
+        "scopes": ["decide", "rulesets:write"],
+        "can_author": True,
+    }
+    runner = CliRunner()
+    with patch("aethis_cli.client.AethisClient.whoami", return_value=fake_me):
+        result = runner.invoke(app, ["whoami"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "ak_live_whoami_canary" in result.output
+    assert "No Aethis API key" not in result.output
+
+
 def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypatch):
     """--project-id adds a generation progress section after the global summary."""
     monkeypatch.chdir(tmp_project)
@@ -128,7 +204,8 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
         result = _run_status(args=["-p", "proj_abc"])
 
     assert result.exit_code == 0, result.output
-    assert "Generation" in result.output
-    assert "proj_abc" in result.output
-    assert "ready" in result.output
-    assert "test:20260419-abc1234" in result.output
+    clean = _strip_ansi(result.output)
+    assert "Generation" in clean
+    assert "proj_abc" in clean
+    assert "ready" in clean
+    assert "test:20260419-abc1234" in clean

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 from typer.testing import CliRunner
 
@@ -36,7 +37,7 @@ def test_status_no_config_no_key_shows_defaults(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("AETHIS_API_KEY", raising=False)
     monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
-    # Neutralise keyring + credentials fallback
+    # Point credentials lookup at an empty temp dir so no real key is found.
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty_xdg"))
 
     result = _run_status()
@@ -121,10 +122,25 @@ def _write_multi_profile_credentials(tmp_path: Path, profile: str, api_key: str)
     return creds
 
 
-def test_status_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
+def _reset_runtime() -> None:
+    """Clear the auth-helpers RUNTIME singleton so prior tests don't leak overrides."""
+    from aethis_cli.auth_helpers import RUNTIME
+
+    RUNTIME.no_prompt = False
+    RUNTIME.api_key_override = None
+    RUNTIME.base_url_override = None
+    RUNTIME.profile_override = None
+
+
+@pytest.mark.parametrize("profile", ["default", "staging"])
+def test_status_reads_multi_profile_credentials_file(tmp_path, monkeypatch, profile):
     """Regression: `aethis login` writes profiles.<name>.api_key but status used
     to look for a flat top-level `api_key` and reported "no API key" while
     other commands worked fine.
+
+    Parametrized over `default` and a non-default profile (`staging`): the
+    keyring fallback in `resolve_cached_key` only fires for `default`, so the
+    non-default case is the stricter exercise of the profile-aware file read.
 
     Trip-wire so the asymmetry doesn't reappear.
     """
@@ -132,10 +148,12 @@ def test_status_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
     monkeypatch.delenv("AETHIS_API_KEY", raising=False)
     monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    _write_multi_profile_credentials(tmp_path, "default", "ak_live_regression_canary")
+    _reset_runtime()
+    api_key = f"ak_live_regression_canary_{profile}"
+    _write_multi_profile_credentials(tmp_path, profile, api_key)
 
     fake_me = {
-        "key_id": "ak_live_regression_canary",
+        "key_id": api_key,
         "tenant_id": "tenant_x",
         "rate_limit_tier": "internal",
         "scopes": ["decide", "rulesets:write"],
@@ -145,14 +163,15 @@ def test_status_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
         result = _run_status()
 
     assert result.exit_code == 0, result.output
-    assert "ak_live_regression_canary" in result.output, (
-        "status read the credentials file but didn't surface the resolved key — "
+    assert api_key in result.output, (
+        f"status read the credentials file but didn't surface the resolved key for profile={profile} — "
         "check the call site to resolve_cached_key()"
     )
     assert "no API key" not in result.output
 
 
-def test_whoami_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
+@pytest.mark.parametrize("profile", ["default", "staging"])
+def test_whoami_reads_multi_profile_credentials_file(tmp_path, monkeypatch, profile):
     """Regression mirror of the status test above, for `aethis whoami`."""
     from aethis_cli.main import app
 
@@ -160,10 +179,12 @@ def test_whoami_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
     monkeypatch.delenv("AETHIS_API_KEY", raising=False)
     monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    _write_multi_profile_credentials(tmp_path, "default", "ak_live_whoami_canary")
+    _reset_runtime()
+    api_key = f"ak_live_whoami_canary_{profile}"
+    _write_multi_profile_credentials(tmp_path, profile, api_key)
 
     fake_me = {
-        "key_id": "ak_live_whoami_canary",
+        "key_id": api_key,
         "tenant_id": "tenant_x",
         "rate_limit_tier": "internal",
         "scopes": ["decide", "rulesets:write"],
@@ -174,7 +195,7 @@ def test_whoami_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
         result = runner.invoke(app, ["whoami"], catch_exceptions=False)
 
     assert result.exit_code == 0, result.output
-    assert "ak_live_whoami_canary" in result.output
+    assert api_key in result.output, f"whoami didn't surface the resolved key for profile={profile}"
     assert "No Aethis API key" not in result.output
 
 

--- a/tests/test_whoami_cmd.py
+++ b/tests/test_whoami_cmd.py
@@ -7,18 +7,21 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 
-def _run(env=None, client_mock=None):
+def _run(env=None, client_mock=None, api_key="ak_test"):
     from aethis_cli.main import app
 
     runner = CliRunner()
     patches = []
     if client_mock is not None:
         patches.append(patch("aethis_cli.commands.whoami_cmd.AethisClient", return_value=client_mock))
-    # Short-circuit the resolve helper so we don't touch keychain in tests
+    # Short-circuit the resolvers so the test never touches keychain or disk.
+    patches.append(
+        patch("aethis_cli.commands.whoami_cmd.resolve_cached_key", return_value=api_key),
+    )
     patches.append(
         patch(
-            "aethis_cli.commands.whoami_cmd._resolve_api_key_lax",
-            return_value=("ak_test", "http://localhost:8080"),
+            "aethis_cli.commands.whoami_cmd.resolve_base_url_with_source",
+            return_value=("http://localhost:8080", "default"),
         ),
     )
     _env = {"AETHIS_BASE_URL": "http://localhost:8080"}
@@ -68,14 +71,6 @@ def test_whoami_without_authoring_scope_points_to_signup():
 
 
 def test_whoami_without_api_key_exits_with_hint():
-    # Override the resolver to return (None, base_url)
-    from aethis_cli.main import app
-
-    runner = CliRunner()
-    with patch(
-        "aethis_cli.commands.whoami_cmd._resolve_api_key_lax",
-        return_value=(None, "http://localhost:8080"),
-    ):
-        result = runner.invoke(app, ["whoami"], catch_exceptions=False)
+    result = _run(api_key=None)
     assert result.exit_code == 1
     assert "No Aethis API key" in result.output


### PR DESCRIPTION
## Summary

`aethis login --api-key ...` writes `profiles.<name>.api_key` to `~/.config/aethis/credentials` (the multi-profile schema introduced in v0.10). But `aethis status` and `aethis whoami` had **stale local resolvers** that only looked for a flat top-level `api_key` — and `whoami` was even looking at the wrong filename (`credentials.yaml`).

Result: after a fresh `aethis login` the CLI's own self-diagnosis commands lied.

```
$ aethis login --api-key ak_live_...
✓ API key saved to ~/.config/aethis/credentials (profile: default).

$ aethis status
…
Identity:    no API key  (run `aethis login` to author)   ← wrong

$ aethis whoami
No Aethis API key configured.                              ← wrong

$ aethis projects list
✓ uk-fsm-child-eligibility (proj_2UsBLXqx9X…)              ← key works fine here
```

Reproduced live in a session today on `aethis-cli 0.16.2` with a key pulled from `gcloud secrets versions access AETHIS_API_KEY_INTERNAL_AUTHORING`.

## Fix

- Promote the canonical resolver in `auth_helpers.py` (`_resolve_cached_key` → public `resolve_cached_key`). This is the same chain every working command already uses: `AETHIS_API_KEY` env → active-profile `api_key` → keychain (default profile only) → legacy `.yaml` file.
- Route `status._print_identity_section`, `status._print_generation_section`, and `whoami` through it.
- Delete the two divergent local resolvers (`_resolve_key_silent` in `status_cmd.py`, `_resolve_api_key_lax` in `whoami_cmd.py`).

## Regression test

`tests/test_status_cmd.py` now writes a real multi-profile credentials YAML to a temp `XDG_CONFIG_HOME` and asserts both `aethis status` and `aethis whoami` surface the key. Trip-wire so the asymmetry can't reappear.

```python
def test_status_reads_multi_profile_credentials_file(tmp_path, monkeypatch):
    _write_multi_profile_credentials(tmp_path, "default", "ak_live_regression_canary")
    …
    assert "ak_live_regression_canary" in result.output
    assert "no API key" not in result.output
```

## Drive-by

`test_status_with_project_id_shows_generation_progress` was failing on main because Rich auto-highlights digit runs and splits `test:20260419-abc1234` with ANSI codes between `20260419` and `-abc1234`. Added a small `_strip_ansi()` helper and applied it to the assertion. (Six similar pre-existing Rich/ANSI failures remain in other test files — out of scope for this PR; they should be fixed by introducing a shared `assert_visible_in()` helper in a follow-up.)

## Versioning

- `_version.py` + `pyproject.toml`: `0.16.2` → `0.16.3` (patch — pure bugfix).
- `CHANGELOG.md` entry under `## 0.16.3 (2026-05-27)`.

Per `.claude/rules/public-repos.md` workspace rule.

## Context

First PR in a stack toward a v0.17.0 DX overhaul (gh-style `--output json`, `aethis completion`, unified error renderer, init templates, server version-skew warning). Plan: `~/.claude/plans/how-can-the-cli-tidy-bear.md` (workspace-private).

## Test plan

- [x] `uv run pytest tests/test_status_cmd.py tests/test_whoami_cmd.py tests/test_profiles.py` — 22/22 pass
- [x] `uv run pytest --no-cov` — 228 pass, 6 pre-existing failures (confirmed unrelated by `git stash` baseline)
- [x] `uvx ruff check` on all touched files — clean
- [ ] CI green
- [ ] Manual smoke: `uv tool install . --reinstall && aethis login --api-key <key> && aethis status && aethis whoami` reports the key