### PR TITLE
feat(output): gh-style JSON output (--output / --json / --jq) — v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 - **feat(output): gh-style machine-readable output mode (`--output json`, `--json fields`, `--jq`).** Every list/show command (and the decision commands) now emit structured JSON on demand, so `aethis rulesets list --output json | jq '.[0].slug'` just works instead of trying to scrape ANSI-coloured Rich tables.
   - `--output table|json` — pick the format. Default: `table` on a TTY, `json` when piped (matches gh's pipe-friendly autodetect).
-  - `--json` — implies `--output json`. With a comma-separated value (`--json id,name`) limits the payload to those fields. With no value, prints the available fields and exits (gh's introspection trick).
+  - `--json FIELDS` — implies `--output json`; takes a required comma-separated value (`--json id,name`) that limits the payload to those fields. (gh's bare-`--json` introspection trick is not yet exposed — Click/Typer's option parser can't cleanly distinguish "flag with no value" from "flag followed by positional", so it's deferred to a future `--list-fields` flag.)
   - `--jq EXPR` — pipe JSON output through `jq` before printing. Requires the `jq` binary on PATH; clear error with install hint if missing.
   - Commands migrated: `rulesets list/show`, `rulebooks list/show/get-fields/tests list/schema/explain/decide`, `projects list/show`, `account keys`, `profile list`, `guidance list`, `fields`, `explain`, `decide`, `status`. Each command has a sensible JSON shape — `status --output json | jq .identity.key_id` returns the live key id without rooting through any prose.
   - Footer hints (`Try: aethis ...`) are suppressed in JSON mode so pipes get clean output.
   - New module `aethis_cli/render.py` is the single emit point; new test file `tests/test_render.py` covers the matrix.
+- **breaking(guidance export): `--output` renamed to `--output-file`** to avoid clashing with the new global `--output` flag. Short form `-o` unchanged. Affects scripts that pipe to a named file: `aethis guidance export --output foo.yaml` → `aethis guidance export --output-file foo.yaml` (or `-o foo.yaml`).
 
 ## 0.16.3 (2026-05-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.17.0 (2026-05-27)
+
+- **feat(output): gh-style machine-readable output mode (`--output json`, `--json fields`, `--jq`).** Every list/show command (and the decision commands) now emit structured JSON on demand, so `aethis rulesets list --output json | jq '.[0].slug'` just works instead of trying to scrape ANSI-coloured Rich tables.
+  - `--output table|json` — pick the format. Default: `table` on a TTY, `json` when piped (matches gh's pipe-friendly autodetect).
+  - `--json` — implies `--output json`. With a comma-separated value (`--json id,name`) limits the payload to those fields. With no value, prints the available fields and exits (gh's introspection trick).
+  - `--jq EXPR` — pipe JSON output through `jq` before printing. Requires the `jq` binary on PATH; clear error with install hint if missing.
+  - Commands migrated: `rulesets list/show`, `rulebooks list/show/get-fields/tests list/schema/explain/decide`, `projects list/show`, `account keys`, `profile list`, `guidance list`, `fields`, `explain`, `decide`, `status`. Each command has a sensible JSON shape — `status --output json | jq .identity.key_id` returns the live key id without rooting through any prose.
+  - Footer hints (`Try: aethis ...`) are suppressed in JSON mode so pipes get clean output.
+  - New module `aethis_cli/render.py` is the single emit point; new test file `tests/test_render.py` covers the matrix.
+
 ## 0.16.3 (2026-05-27)
 
 - **fix(status, whoami): read the multi-profile credentials file the same way every other command does.** `aethis login --api-key ...` writes `profiles.<name>.api_key` to `~/.config/aethis/credentials` (the multi-profile schema introduced in v0.10), but `aethis status` and `aethis whoami` had stale local resolvers that only looked for a flat top-level `api_key` (and `whoami` was looking at the wrong filename, `credentials.yaml`). Result: after a fresh `aethis login`, `aethis status` reported `no API key` and `aethis whoami` reported `No Aethis API key configured`, even though the same key worked for `aethis projects list`, `aethis generate`, and every other authoring command.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.16.3"
+__version__ = "0.17.0"

--- a/aethis_cli/commands/account_cmd.py
+++ b/aethis_cli/commands/account_cmd.py
@@ -13,6 +13,7 @@ from aethis_cli.commands.login_cmd import save_api_key
 from aethis_cli.config import DEFAULT_BASE_URL
 from aethis_cli.errors import AuthenticationError
 from aethis_cli.output import console, info, success
+from aethis_cli.render import emit, is_json_requested
 
 CLERK_DOMAIN = os.environ.get("AETHIS_CLERK_DOMAIN", "clerk.aethis.ai")
 CLERK_CLIENT_ID = os.environ.get("AETHIS_CLERK_CLIENT_ID", "gEiHOxoeLgZJifjf")
@@ -212,30 +213,34 @@ def keys(
 
     data = resp.json()
     if not data:
-        info("No API keys found.")
+        if is_json_requested():
+            emit([])
+        else:
+            info("No API keys found.")
         return
 
     from rich.table import Table
 
-    table = Table(title="API Keys")
-    table.add_column("Key ID", style="bold")
-    table.add_column("Name")
-    table.add_column("Scopes")
-    table.add_column("Tier")
-    table.add_column("Created")
-    table.add_column("Revoked")
+    def _build_keys_table() -> Table:
+        table = Table(title="API Keys")
+        table.add_column("Key ID", style="bold")
+        table.add_column("Name")
+        table.add_column("Scopes")
+        table.add_column("Tier")
+        table.add_column("Created")
+        table.add_column("Revoked")
+        for key in data:
+            table.add_row(
+                key.get("key_id", ""),
+                key.get("name", ""),
+                ", ".join(key.get("scopes", [])),
+                key.get("rate_limit_tier", ""),
+                key.get("created_at", "")[:10] if key.get("created_at") else "",
+                "yes" if key.get("revoked") else "",
+            )
+        return table
 
-    for key in data:
-        table.add_row(
-            key.get("key_id", ""),
-            key.get("name", ""),
-            ", ".join(key.get("scopes", [])),
-            key.get("rate_limit_tier", ""),
-            key.get("created_at", "")[:10] if key.get("created_at") else "",
-            "yes" if key.get("revoked") else "",
-        )
-
-    console.print(table)
+    emit(data, table=_build_keys_table)
 
 
 @account_app.command()

--- a/aethis_cli/commands/decide_cmd.py
+++ b/aethis_cli/commands/decide_cmd.py
@@ -11,6 +11,7 @@ from aethis_cli.commands._id_utils import require_ruleset_id
 from aethis_cli.config import load_client_or_anon, read_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
+from aethis_cli.render import emit, is_json_requested
 
 
 def decide(
@@ -73,6 +74,10 @@ def decide(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+
+    if is_json_requested():
+        emit(result)
+        return
 
     decision = result["decision"]
     color = {"eligible": "green", "not_eligible": "red"}.get(decision, "yellow")

--- a/aethis_cli/commands/explain_cmd.py
+++ b/aethis_cli/commands/explain_cmd.py
@@ -11,6 +11,7 @@ from aethis_cli.commands._id_utils import require_ruleset_id
 from aethis_cli.config import load_client_or_anon, read_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
+from aethis_cli.render import emit, is_json_requested
 
 
 def explain(
@@ -53,12 +54,19 @@ def explain(
         error_panel(e)
         raise typer.Exit(code=1)
 
-    table = Table(title=f"Rules — {ruleset_id}")
-    table.add_column("Group", style="cyan")
-    table.add_column("Title")
-    table.add_column("Rule")
+    criteria = result.get("criteria", [])
 
-    for c in result.get("criteria", []):
-        table.add_row(c.get("group", ""), c["title"], c["rule_text"])
+    if is_json_requested():
+        emit(criteria)
+        return
 
-    console.print(table)
+    def _build_rules_table() -> Table:
+        table = Table(title=f"Rules — {ruleset_id}")
+        table.add_column("Group", style="cyan")
+        table.add_column("Title")
+        table.add_column("Rule")
+        for c in criteria:
+            table.add_row(c.get("group", ""), c["title"], c["rule_text"])
+        return table
+
+    emit(criteria, table=_build_rules_table)

--- a/aethis_cli/commands/fields_cmd.py
+++ b/aethis_cli/commands/fields_cmd.py
@@ -10,6 +10,7 @@ from rich.table import Table
 from aethis_cli.config import load_client_or_anon, read_state
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel
+from aethis_cli.render import emit, is_json_requested
 
 
 def fields(
@@ -46,14 +47,21 @@ def fields(
         error_panel(e)
         raise typer.Exit(code=1)
 
-    table = Table(title=f"Fields — {ruleset_id}")
-    table.add_column("Field ID", style="cyan")
-    table.add_column("Type")
-    table.add_column("Description")
-    table.add_column("Enum values")
+    field_specs = result.get("fields", [])
 
-    for f in result.get("fields", []):
-        enum_vals = ", ".join(f["enum_values"]) if f.get("enum_values") else ""
-        table.add_row(f["field_id"], f["field_type"], f.get("description") or "", enum_vals)
+    if is_json_requested():
+        emit(field_specs)
+        return
 
-    console.print(table)
+    def _build_fields_table() -> Table:
+        table = Table(title=f"Fields — {ruleset_id}")
+        table.add_column("Field ID", style="cyan")
+        table.add_column("Type")
+        table.add_column("Description")
+        table.add_column("Enum values")
+        for f in field_specs:
+            enum_vals = ", ".join(f["enum_values"]) if f.get("enum_values") else ""
+            table.add_row(f["field_id"], f["field_type"], f.get("description") or "", enum_vals)
+        return table
+
+    emit(field_specs, table=_build_fields_table)

--- a/aethis_cli/commands/guidance_cmd.py
+++ b/aethis_cli/commands/guidance_cmd.py
@@ -11,6 +11,7 @@ import yaml
 from aethis_cli.config import load_project_config, make_authed_client, resolve_api_key
 from aethis_cli.errors import AethisAPIError, ConfigError
 from aethis_cli.output import console, error_panel, success
+from aethis_cli.render import emit, is_json_requested
 
 guidance_app = typer.Typer(
     help="Manage guidance hints for rule authoring.",
@@ -44,7 +45,14 @@ def list_hints(
         raise typer.Exit(code=1)
 
     if not hints:
-        console.print("[dim]No guidance hints found.[/dim]")
+        if is_json_requested():
+            emit([])
+        else:
+            console.print("[dim]No guidance hints found.[/dim]")
+        return
+
+    if is_json_requested():
+        emit(hints)
         return
 
     for h in hints:

--- a/aethis_cli/commands/guidance_cmd.py
+++ b/aethis_cli/commands/guidance_cmd.py
@@ -71,7 +71,12 @@ def list_hints(
 @guidance_app.command("export")
 def export_hints(
     project_id: Optional[str] = typer.Option(None, "--project-id", "-p"),
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Write to file instead of stdout"),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output-file",
+        "-o",
+        help="Write to file instead of stdout. (Renamed from --output in v0.17.0 to avoid clashing with the new global --output flag.)",
+    ),
 ) -> None:
     """Export active guidance hints as YAML."""
     try:

--- a/aethis_cli/commands/profile_cmd.py
+++ b/aethis_cli/commands/profile_cmd.py
@@ -28,6 +28,7 @@ from aethis_cli.config import (
 )
 from aethis_cli.errors import ConfigError
 from aethis_cli.output import console, success
+from aethis_cli.render import emit, is_json_requested
 
 profile_app = typer.Typer(
     name="profile",
@@ -56,24 +57,39 @@ def list_profiles() -> None:
     # even before they configure a real profile.
     names = sorted(set(profiles.keys()) | {DEFAULT_PROFILE, ANONYMOUS_PROFILE})
 
-    table = Table(title="Profiles")
-    table.add_column("", width=1)
-    table.add_column("Name", style="cyan")
-    table.add_column("API Key")
-    table.add_column("Base URL")
+    # Structured form used by --output json. Never leaks the raw key.
+    structured = [
+        {
+            "name": name,
+            "active": name == active,
+            "has_key": bool(profiles.get(name, {}).get("api_key")) and name != ANONYMOUS_PROFILE,
+            "key_preview": (None if name == ANONYMOUS_PROFILE else _mask_key(profiles.get(name, {}).get("api_key"))),
+            "base_url": profiles.get(name, {}).get("base_url"),
+            "auth_mode": profiles.get(name, {}).get("auth_mode") or "api_key",
+        }
+        for name in names
+    ]
 
-    for name in names:
-        profile = profiles.get(name, {})
-        marker = "*" if name == active else ""
-        if name == ANONYMOUS_PROFILE:
-            key_display = "[dim](no key — anonymous mode)[/dim]"
-        else:
-            key_display = _mask_key(profile.get("api_key"))
-        base_display = profile.get("base_url", "[dim](default)[/dim]")
-        table.add_row(marker, name, key_display, base_display)
+    def _build_profile_table() -> Table:
+        table = Table(title="Profiles")
+        table.add_column("", width=1)
+        table.add_column("Name", style="cyan")
+        table.add_column("API Key")
+        table.add_column("Base URL")
+        for name in names:
+            profile = profiles.get(name, {})
+            marker = "*" if name == active else ""
+            if name == ANONYMOUS_PROFILE:
+                key_display = "[dim](no key — anonymous mode)[/dim]"
+            else:
+                key_display = _mask_key(profile.get("api_key"))
+            base_display = profile.get("base_url", "[dim](default)[/dim]")
+            table.add_row(marker, name, key_display, base_display)
+        return table
 
-    console.print(table)
-    console.print(f"\nActive: [cyan]{active}[/cyan]")
+    emit(structured, table=_build_profile_table)
+    if not is_json_requested():
+        console.print(f"\nActive: [cyan]{active}[/cyan]")
 
 
 @profile_app.command(name="use")

--- a/aethis_cli/commands/projects_cmd.py
+++ b/aethis_cli/commands/projects_cmd.py
@@ -8,6 +8,7 @@ from rich.table import Table
 from aethis_cli.config import load_client_or_fallback
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success
+from aethis_cli.render import emit, is_json_requested
 
 projects_app = typer.Typer(
     name="projects",
@@ -37,33 +38,38 @@ def list_projects(
         raise typer.Exit(code=1)
 
     if not projects:
-        console.print("[dim]No projects found.[/dim]")
+        if is_json_requested():
+            emit([])
+        else:
+            console.print("[dim]No projects found.[/dim]")
         return
 
-    table = Table(title="Projects")
-    table.add_column("Project ID", style="cyan")
-    table.add_column("Name")
-    table.add_column("Status")
-    table.add_column("Ruleset")
-    table.add_column("Created")
+    def _build_projects_table() -> Table:
+        table = Table(title="Projects")
+        table.add_column("Project ID", style="cyan")
+        table.add_column("Name")
+        table.add_column("Status")
+        table.add_column("Ruleset")
+        table.add_column("Created")
+        for p in projects:
+            status = p.get("status", "")
+            style = "dim" if status == "archived" else None
+            table.add_row(
+                p["project_id"],
+                p["name"],
+                status,
+                p.get("latest_ruleset_id") or "",
+                p.get("created_at", "")[:10] if p.get("created_at") else "",
+                style=style,
+            )
+        return table
 
-    for p in projects:
-        status = p.get("status", "")
-        style = "dim" if status == "archived" else None
-        table.add_row(
-            p["project_id"],
-            p["name"],
-            status,
-            p.get("latest_ruleset_id") or "",
-            p.get("created_at", "")[:10] if p.get("created_at") else "",
-            style=style,
+    emit(projects, table=_build_projects_table)
+    if not is_json_requested():
+        console.print(
+            "[dim]Tip: copy a Ruleset value and run "
+            "`aethis explain -b <ruleset>` or `aethis decide -b <ruleset> -i '{...}'`.[/dim]"
         )
-
-    console.print(table)
-    console.print(
-        "[dim]Tip: copy a Ruleset value and run "
-        "`aethis explain -b <ruleset>` or `aethis decide -b <ruleset> -i '{...}'`.[/dim]"
-    )
 
 
 @projects_app.command(name="show")
@@ -78,6 +84,10 @@ def show_project(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+
+    if is_json_requested():
+        emit(p)
+        return
 
     console.print(f"[bold]{p['name']}[/bold] ({p['project_id']})")
     console.print(f"  Section:  {p.get('section_id', '')}")

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -37,6 +37,7 @@ from rich.table import Table
 from aethis_cli.config import load_client_or_fallback
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success
+from aethis_cli.render import emit, is_json_requested
 
 rulebooks_app = typer.Typer(
     name="rulebooks",
@@ -89,27 +90,32 @@ def list_rulebooks() -> None:
         raise typer.Exit(code=1)
 
     if not rulebooks:
-        console.print("[dim]No rulebooks yet. Create one with `aethis rulebooks create`.[/dim]")
+        if is_json_requested():
+            emit([])
+        else:
+            console.print("[dim]No rulebooks yet. Create one with `aethis rulebooks create`.[/dim]")
         return
 
-    table = Table(title="Rulebooks")
-    table.add_column("Slug", style="cyan")
-    table.add_column("Rulebook ID", style="dim")
-    table.add_column("Name")
-    table.add_column("Domain")
-    table.add_column("Status")
-    table.add_column("Rulesets", justify="right")
+    def _build_rulebooks_table() -> Table:
+        table = Table(title="Rulebooks")
+        table.add_column("Slug", style="cyan")
+        table.add_column("Rulebook ID", style="dim")
+        table.add_column("Name")
+        table.add_column("Domain")
+        table.add_column("Status")
+        table.add_column("Rulesets", justify="right")
+        for rb in rulebooks:
+            table.add_row(
+                rb.get("slug") or "[dim]—[/dim]",
+                rb.get("rulebook_id", ""),
+                rb.get("name") or "[dim]—[/dim]",
+                rb.get("domain") or "[dim]—[/dim]",
+                rb.get("status", ""),
+                str(len(rb.get("ruleset_refs", []) or [])),
+            )
+        return table
 
-    for rb in rulebooks:
-        table.add_row(
-            rb.get("slug") or "[dim]—[/dim]",
-            rb.get("rulebook_id", ""),
-            rb.get("name") or "[dim]—[/dim]",
-            rb.get("domain") or "[dim]—[/dim]",
-            rb.get("status", ""),
-            str(len(rb.get("ruleset_refs", []) or [])),
-        )
-    console.print(table)
+    emit(rulebooks, table=_build_rulebooks_table)
 
 
 # ============================================================================
@@ -129,7 +135,7 @@ def show_rulebook(
         error_panel(e)
         raise typer.Exit(code=1)
 
-    console.print_json(data=rb)
+    emit(rb)
 
 
 # ============================================================================
@@ -281,24 +287,33 @@ def get_fields(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+
+    if is_json_requested():
+        emit(result)
+        return
+
     console.print(f"Lock state: [cyan]{result['field_lock_state']}[/cyan]")
     fields = result.get("fields", [])
     if not fields:
         console.print("[dim]No fields locked yet.[/dim]")
         return
-    table = Table(title=f"Fields — {rulebook}")
-    table.add_column("Key", style="cyan")
-    table.add_column("Sort")
-    table.add_column("Enum values")
-    table.add_column("Description")
-    for f in fields:
-        table.add_row(
-            f.get("key", ""),
-            f.get("sort", ""),
-            ", ".join(f.get("enum_values") or []) or "[dim]—[/dim]",
-            f.get("description") or "[dim]—[/dim]",
-        )
-    console.print(table)
+
+    def _build_fields_table() -> Table:
+        table = Table(title=f"Fields — {rulebook}")
+        table.add_column("Key", style="cyan")
+        table.add_column("Sort")
+        table.add_column("Enum values")
+        table.add_column("Description")
+        for f in fields:
+            table.add_row(
+                f.get("key", ""),
+                f.get("sort", ""),
+                ", ".join(f.get("enum_values") or []) or "[dim]—[/dim]",
+                f.get("description") or "[dim]—[/dim]",
+            )
+        return table
+
+    emit(fields, table=_build_fields_table)
 
 
 # ============================================================================
@@ -477,7 +492,7 @@ def decide_rulebook(
         error_panel(e)
         raise typer.Exit(code=1)
 
-    console.print_json(data=result)
+    emit(result)
 
 
 # ============================================================================
@@ -496,7 +511,7 @@ def schema_rulebook(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
-    console.print_json(data=result)
+    emit(result)
 
 
 @rulebooks_app.command(name="explain")
@@ -510,7 +525,7 @@ def explain_rulebook(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
-    console.print_json(data=result)
+    emit(result)
 
 
 # ============================================================================
@@ -589,21 +604,28 @@ def tests_list(
         raise typer.Exit(code=1)
     cases = result.get("test_cases", [])
     if not cases:
-        console.print("[dim]No test cases yet.[/dim]")
+        if is_json_requested():
+            emit([])
+        else:
+            console.print("[dim]No test cases yet.[/dim]")
         return
-    table = Table(title=f"Rulebook test cases — {rulebook}")
-    table.add_column("tc_id", style="cyan")
-    table.add_column("Name")
-    table.add_column("Expected outcome")
-    table.add_column("Fields", justify="right")
-    for tc in cases:
-        table.add_row(
-            tc.get("tc_id", ""),
-            tc.get("name", ""),
-            tc.get("expected_outcome", ""),
-            str(len(tc.get("field_values", {}) or {})),
-        )
-    console.print(table)
+
+    def _build_tests_table() -> Table:
+        table = Table(title=f"Rulebook test cases — {rulebook}")
+        table.add_column("tc_id", style="cyan")
+        table.add_column("Name")
+        table.add_column("Expected outcome")
+        table.add_column("Fields", justify="right")
+        for tc in cases:
+            table.add_row(
+                tc.get("tc_id", ""),
+                tc.get("name", ""),
+                tc.get("expected_outcome", ""),
+                str(len(tc.get("field_values", {}) or {})),
+            )
+        return table
+
+    emit(cases, table=_build_tests_table)
 
 
 @tests_app.command(name="delete")

--- a/aethis_cli/commands/rulesets_cmd.py
+++ b/aethis_cli/commands/rulesets_cmd.py
@@ -21,6 +21,7 @@ from aethis_cli.commands._id_utils import require_ruleset_id
 from aethis_cli.config import load_client_or_fallback, resolve_base_url_with_source
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success, warn
+from aethis_cli.render import emit, is_json_requested
 
 rulesets_app = typer.Typer(
     name="rulesets",
@@ -30,7 +31,7 @@ rulesets_app = typer.Typer(
 )
 
 
-def _print_public_table(rulesets: list[dict]) -> None:
+def _build_public_table(rulesets: list[dict]) -> Table:
     table = Table(title="Public showcase rulesets")
     table.add_column("Slug", style="cyan")
     table.add_column("Ruleset ID", style="dim")
@@ -48,8 +49,7 @@ def _print_public_table(rulesets: list[dict]) -> None:
             str(r.get("field_count", 0)),
             str(r.get("rule_count", 0)),
         )
-
-    console.print(table)
+    return table
 
 
 def _list_public(limit: int, offset: int) -> None:
@@ -63,13 +63,17 @@ def _list_public(limit: int, offset: int) -> None:
             raise typer.Exit(code=1)
 
     if not rulesets:
-        console.print("[dim]No public rulesets published yet.[/dim]")
+        if is_json_requested():
+            emit([])
+        else:
+            console.print("[dim]No public rulesets published yet.[/dim]")
         return
 
-    _print_public_table(rulesets)
-    console.print(
-        "\n[dim]Try: aethis fields -b <slug>  ·  aethis explain -b <slug>  ·  aethis decide -b <slug> -i '{...}'[/dim]"
-    )
+    emit(rulesets, table=lambda: _build_public_table(rulesets))
+    if not is_json_requested():
+        console.print(
+            "\n[dim]Try: aethis fields -b <slug>  ·  aethis explain -b <slug>  ·  aethis decide -b <slug> -i '{...}'[/dim]"
+        )
 
 
 @rulesets_app.command(name="list")
@@ -123,10 +127,11 @@ def list_rulesets(
             pid = None
 
     if not pid:
-        console.print(
-            "[dim]No project context — showing public showcase rulesets. "
-            "Pass <rulebook> or --project-id <id> to list your own.[/dim]"
-        )
+        if not is_json_requested():
+            console.print(
+                "[dim]No project context — showing public showcase rulesets. "
+                "Pass <rulebook> or --project-id <id> to list your own.[/dim]"
+            )
         _list_public(limit=limit, offset=offset)
         return
 
@@ -139,33 +144,37 @@ def list_rulesets(
         raise typer.Exit(code=1)
 
     if not rulesets:
-        console.print("[dim]No rulesets found.[/dim]")
+        if is_json_requested():
+            emit([])
+        else:
+            console.print("[dim]No rulesets found.[/dim]")
         return
 
-    table = Table(title=f"Rulesets — {pid}")
-    table.add_column("Ruleset ID", style="cyan")
-    table.add_column("Name")
-    table.add_column("Status")
-    table.add_column("Fields", justify="right")
-    table.add_column("Rules", justify="right")
-    table.add_column("Version")
-    table.add_column("Created")
+    def _build_project_table() -> Table:
+        table = Table(title=f"Rulesets — {pid}")
+        table.add_column("Ruleset ID", style="cyan")
+        table.add_column("Name")
+        table.add_column("Status")
+        table.add_column("Fields", justify="right")
+        table.add_column("Rules", justify="right")
+        table.add_column("Version")
+        table.add_column("Created")
+        for b in rulesets:
+            s = b.get("status", "")
+            style = "dim" if s == "archived" else None
+            table.add_row(
+                b["ruleset_id"],
+                b.get("name") or "[dim]—[/dim]",
+                s,
+                str(b.get("total_fields", 0)),
+                str(b.get("total_rules", 0)),
+                b.get("version", ""),
+                b.get("created_at", "")[:10] if b.get("created_at") else "",
+                style=style,
+            )
+        return table
 
-    for b in rulesets:
-        s = b.get("status", "")
-        style = "dim" if s == "archived" else None
-        table.add_row(
-            b["ruleset_id"],
-            b.get("name") or "[dim]—[/dim]",
-            s,
-            str(b.get("total_fields", 0)),
-            str(b.get("total_rules", 0)),
-            b.get("version", ""),
-            b.get("created_at", "")[:10] if b.get("created_at") else "",
-            style=style,
-        )
-
-    console.print(table)
+    emit(rulesets, table=_build_project_table)
 
 
 def _list_rulebook_rulesets(rulebook: str) -> None:
@@ -179,27 +188,33 @@ def _list_rulebook_rulesets(rulebook: str) -> None:
 
     rulesets = resp.get("rulesets", [])
     if not rulesets:
-        console.print(
-            f"[dim]No rulesets in rulebook {rulebook!r} yet. "
-            "Create one with `aethis rulesets create <rulebook> <name>`.[/dim]"
-        )
+        if is_json_requested():
+            emit([])
+        else:
+            console.print(
+                f"[dim]No rulesets in rulebook {rulebook!r} yet. "
+                "Create one with `aethis rulesets create <rulebook> <name>`.[/dim]"
+            )
         return
 
-    table = Table(title=f"Rulesets in {rulebook}")
-    table.add_column("Ruleset name", style="cyan")
-    table.add_column("Display name")
-    table.add_column("Versions", justify="right")
-    table.add_column("Live version")
-    table.add_column("States seen")
-    for r in rulesets:
-        table.add_row(
-            r.get("ruleset_name", ""),
-            r.get("display_name") or "[dim]—[/dim]",
-            str(r.get("version_count", 0)),
-            r.get("live_version") or "[dim]—[/dim]",
-            ", ".join(r.get("states", [])) or "[dim]—[/dim]",
-        )
-    console.print(table)
+    def _build_rulebook_table() -> Table:
+        table = Table(title=f"Rulesets in {rulebook}")
+        table.add_column("Ruleset name", style="cyan")
+        table.add_column("Display name")
+        table.add_column("Versions", justify="right")
+        table.add_column("Live version")
+        table.add_column("States seen")
+        for r in rulesets:
+            table.add_row(
+                r.get("ruleset_name", ""),
+                r.get("display_name") or "[dim]—[/dim]",
+                str(r.get("version_count", 0)),
+                r.get("live_version") or "[dim]—[/dim]",
+                ", ".join(r.get("states", [])) or "[dim]—[/dim]",
+            )
+        return table
+
+    emit(rulesets, table=_build_rulebook_table)
 
 
 # ============================================================================
@@ -265,6 +280,11 @@ def show_ruleset(
     versions = resp.get("versions", [])
     live_version = resp.get("live_version")
     display_name = resp.get("display_name")
+
+    if is_json_requested():
+        emit(resp)
+        return
+
     console.print(
         f"[bold]{ruleset_name}[/bold]  in  [cyan]{rulebook}[/cyan]"
         + (f"  · [dim]{display_name}[/dim]" if display_name else "")
@@ -277,22 +297,25 @@ def show_ruleset(
     if not versions:
         return
 
-    table = Table(title="Versions")
-    table.add_column("bundle_id", style="cyan")
-    table.add_column("Version")
-    table.add_column("State")
-    table.add_column("Created")
-    for v in versions:
-        state = v.get("state") or "[dim]—[/dim]"
-        style = "dim" if state == "archived" else None
-        table.add_row(
-            v.get("bundle_id", ""),
-            v.get("version", ""),
-            state,
-            (v.get("created_at") or "")[:10],
-            style=style,
-        )
-    console.print(table)
+    def _build_versions_table() -> Table:
+        table = Table(title="Versions")
+        table.add_column("bundle_id", style="cyan")
+        table.add_column("Version")
+        table.add_column("State")
+        table.add_column("Created")
+        for v in versions:
+            state = v.get("state") or "[dim]—[/dim]"
+            style = "dim" if state == "archived" else None
+            table.add_row(
+                v.get("bundle_id", ""),
+                v.get("version", ""),
+                state,
+                (v.get("created_at") or "")[:10],
+                style=style,
+            )
+        return table
+
+    emit(versions, table=_build_versions_table)
 
 
 @rulesets_app.command(name="promote-to-live")

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -259,8 +259,9 @@ def _emit_json_status(project_id: Optional[str]) -> None:
             except AethisAPIError as e:
                 state["identity"] = {
                     "key_present": True,
+                    "error": str(e.detail),
+                    "status_code": e.status_code,
                     "key_rejected": e.status_code in (401, 403, 404),
-                    "error_status": e.status_code,
                 }
 
     # Generation section — only when we have a project id

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 
@@ -20,6 +20,7 @@ from aethis_cli.config import (
 )
 from aethis_cli.errors import AethisAPIError, ConfigError
 from aethis_cli.output import console, error_panel
+from aethis_cli.render import emit, is_json_requested
 
 
 STATUS_HELP = """
@@ -36,6 +37,7 @@ Examples:
     aethis status
     aethis status -p proj_i1HyinBtFJniayUC
     aethis --base-url http://localhost:8080 status
+    aethis status --output json | jq .identity.key_id
 """
 
 
@@ -48,6 +50,10 @@ def status(
     ),
 ) -> None:
     """Show CLI context and optional project generation progress."""
+    if is_json_requested():
+        _emit_json_status(project_id)
+        return
+
     _print_cli_section()
     _print_server_section()
     cfg, state_ruleset = _print_project_section()
@@ -193,3 +199,81 @@ def _print_generation_section(project_id: str) -> None:
     bid = result.get("latest_ruleset_id")
     if bid:
         console.print(f"  Ruleset:  {bid}")
+
+
+def _emit_json_status(project_id: Optional[str]) -> None:
+    """Build and emit a structured status dict for --output json consumers.
+
+    Scriptable view of the same context the human view shows. Keys mirror the
+    section titles so `--json server,identity` gives a clean projection.
+    """
+    base_url, source = resolve_base_url_with_source()
+    profile_name = active_profile_name()
+    profile = get_profile(profile_name)
+
+    state: dict[str, Any] = {
+        "cli": {"version": __version__},
+        "server": {"base_url": base_url, "source": source},
+        "profile": {
+            "name": profile_name,
+            "auth_mode": profile.get("auth_mode") or "api_key",
+            "audience": profile.get("audience"),
+        },
+    }
+
+    # Project section
+    cfg = None
+    try:
+        cfg = load_project_config()
+        ruleset_id = read_state(cfg.config_path).get("ruleset_id")
+        state["project"] = {
+            "name": cfg.project,
+            "config_path": str(cfg.config_path / "aethis.yaml"),
+            "project_id": cfg.project_id,
+            "ruleset_id": ruleset_id,
+        }
+    except ConfigError:
+        state["project"] = None
+
+    # Identity section
+    auth_mode = profile.get("auth_mode") or "api_key"
+    identity_base_url = cfg.base_url if cfg else base_url
+    if auth_mode != "api_key":
+        state["identity"] = {"auth_mode": auth_mode, "provider_minted": True}
+    else:
+        api_key = resolve_cached_key()
+        if api_key is None:
+            state["identity"] = {"key_present": False}
+        else:
+            client = AethisClient(api_key, identity_base_url)
+            try:
+                me = client.whoami()
+                state["identity"] = {
+                    "key_present": True,
+                    "key_id": me.get("key_id"),
+                    "tenant_id": me.get("tenant_id"),
+                    "rate_limit_tier": me.get("rate_limit_tier"),
+                    "scopes": me.get("scopes") or [],
+                    "can_author": me.get("can_author"),
+                }
+            except AethisAPIError as e:
+                state["identity"] = {
+                    "key_present": True,
+                    "key_rejected": e.status_code in (401, 403, 404),
+                    "error_status": e.status_code,
+                }
+
+    # Generation section — only when we have a project id
+    pid = project_id or (cfg.project_id if cfg else None)
+    if pid:
+        api_key = resolve_cached_key()
+        if api_key is None:
+            state["generation"] = {"skipped": "no_api_key"}
+        else:
+            client = AethisClient(api_key, identity_base_url)
+            try:
+                state["generation"] = client.get_status(pid)
+            except AethisAPIError as e:
+                state["generation"] = {"error": str(e.detail), "status_code": e.status_code}
+
+    emit(state)

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -13,6 +13,7 @@ from aethis_cli._version import __version__
 from aethis_cli.auth_helpers import RUNTIME
 from aethis_cli.errors import AethisAPIError, AuthenticationError, AuthRequired, ConfigError
 from aethis_cli.output import console
+from aethis_cli.render import RUNTIME as RENDER_RUNTIME, OutputFormat
 from aethis_cli.commands.account_cmd import account_app
 from aethis_cli.commands.rulebooks_cmd import rulebooks_app
 from aethis_cli.commands.rulesets_cmd import rulesets_app
@@ -116,6 +117,33 @@ def main(
             "unsigned mode. Manage with `aethis profile`."
         ),
     ),
+    output: Optional[OutputFormat] = typer.Option(
+        None,
+        "--output",
+        case_sensitive=False,
+        help=(
+            "Output format for list/show commands: `table` (default on a TTY) "
+            "or `json` (default when piped). JSON is pipe-friendly: no ANSI, "
+            "no banners, no progress text."
+        ),
+    ),
+    json_fields: Optional[str] = typer.Option(
+        None,
+        "--json",
+        help=(
+            "Emit JSON with only the named comma-separated fields "
+            "(e.g. --json id,name). Implies --output json. To see the raw "
+            "payload (all fields), use --output json instead."
+        ),
+    ),
+    jq_expr: Optional[str] = typer.Option(
+        None,
+        "--jq",
+        help=(
+            "Pipe JSON output through `jq` before printing. Requires the `jq` "
+            "binary on PATH (`brew install jq` / `apt install jq`)."
+        ),
+    ),
 ) -> None:
     """CLI for the Aethis developer API — author, test, and publish rulesets."""
     # Stash root-level flags on the lazy-auth runtime so commands and the
@@ -133,6 +161,11 @@ def main(
         os.environ["AETHIS_BASE_URL"] = base_url
     if api_key:
         os.environ["AETHIS_API_KEY"] = api_key
+
+    # Mirror rendering flags onto the renderer's RUNTIME singleton.
+    RENDER_RUNTIME.output = output
+    RENDER_RUNTIME.json_fields = json_fields
+    RENDER_RUNTIME.jq_expr = jq_expr
 
 
 app.add_typer(account_app, name="account")

--- a/aethis_cli/render.py
+++ b/aethis_cli/render.py
@@ -1,0 +1,284 @@
+"""Shared output rendering for list/show commands.
+
+The CLI's list/show commands historically built Rich tables inline and
+called ``console.print(table)``. That worked for humans but broke every
+scripting workflow — pipes saw ANSI escapes, ``| jq`` was impossible
+without scraping, and CI logs were full of box-drawing characters.
+
+This module is the single emit point. Each list/show command:
+
+1. Builds its primary data structure (list of dicts, or a single dict).
+2. Either (a) passes that data and a table-rendering callback to
+   :func:`emit`, or (b) builds the table inline and passes it as a
+   precomputed ``rich.Table`` via ``table=...``.
+3. Calls :func:`emit`, which respects ``--output / --json / --jq``
+   global flags (set on :data:`RUNTIME` at the root callback).
+
+The flag surface mirrors GitHub's ``gh`` CLI:
+
+* ``--output table|json`` — pick the format. Default: ``table`` on a
+  TTY, ``json`` when stdout is piped (gh's "pipe-friendly by default").
+* ``--json`` — alias for ``--output json``; with an optional CSV value
+  (``--json id,name``) limits the emitted object to those fields. With
+  no value (``--json`` alone) prints the available fields and exits 0
+  (gh's introspection trick — invaluable for discovering schema).
+* ``--jq EXPR`` — pipe JSON output through ``jq`` before printing.
+  Requires the ``jq`` binary on PATH; fails with a clear hint if not.
+
+``--jq`` shells out to the ``jq`` binary deliberately: no extra Python
+deps, no libjq wheel-build pain on niche platforms, and it matches the
+user's existing mental model from ``kubectl --jq``, ``aws --query``,
+etc. macOS ships jq via ``brew install jq``; Linux distros via apt /
+dnf / pacman.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Iterable, Optional, Union
+
+import typer
+from rich.table import Table
+
+from aethis_cli.output import console
+
+
+class OutputFormat(str, Enum):
+    """Supported output formats. Subclasses ``str`` for free Typer parsing."""
+
+    TABLE = "table"
+    JSON = "json"
+
+
+# Sentinel: ``--json`` passed with no value (request the field list).
+LIST_FIELDS_SENTINEL = "__list_fields__"
+
+
+@dataclass
+class RenderOpts:
+    """CLI-wide rendering options wired from the root callback.
+
+    Mutable singleton (see :data:`RUNTIME`) so commands and helpers can
+    read the user's choices without threading flags through every signature.
+    """
+
+    output: Optional[OutputFormat] = None  # None = "use default for the surface"
+    json_fields: Optional[str] = None  # None | "" | "field1,field2" | LIST_FIELDS_SENTINEL
+    jq_expr: Optional[str] = None
+
+    def reset(self) -> None:
+        self.output = None
+        self.json_fields = None
+        self.jq_expr = None
+
+
+# Module-level singleton; ``main.cli`` populates it from global Typer flags.
+RUNTIME = RenderOpts()
+
+
+def is_json_requested(opts: Optional[RenderOpts] = None) -> bool:
+    """Return True if the active opts ask for JSON output.
+
+    Centralised so commands can short-circuit human-friendly footers
+    (``Try: aethis ... ``) when JSON is going to a pipe.
+    """
+    o = opts or RUNTIME
+    if o.output == OutputFormat.JSON:
+        return True
+    if o.json_fields is not None or o.jq_expr is not None:
+        return True
+    if o.output is None and not _stdout_is_tty():
+        # Pipe-friendly default: non-TTY callers get JSON.
+        return True
+    return False
+
+
+def _stdout_is_tty() -> bool:
+    try:
+        return sys.stdout.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _resolve_format(opts: RenderOpts) -> OutputFormat:
+    """Apply precedence: explicit flag > non-TTY autodetect > table default."""
+    if opts.output is not None:
+        return opts.output
+    if opts.json_fields is not None or opts.jq_expr is not None:
+        return OutputFormat.JSON
+    if not _stdout_is_tty():
+        return OutputFormat.JSON
+    return OutputFormat.TABLE
+
+
+def _available_fields(data: Any) -> list[str]:
+    """Best-effort field discovery from the primary resource.
+
+    For a list of dicts, returns the union of keys from the first
+    non-empty record (matches gh's behaviour). For a single dict,
+    returns its keys. For anything else, returns an empty list.
+    """
+    if isinstance(data, dict):
+        return list(data.keys())
+    if isinstance(data, list):
+        for record in data:
+            if isinstance(record, dict):
+                return list(record.keys())
+    return []
+
+
+def _filter_fields(data: Any, fields: list[str]) -> Any:
+    """Pluck only the named fields from a dict or list-of-dicts.
+
+    Unknown field names are silently dropped — matches gh. (We surface
+    the available field list via the introspection sentinel, so a typo
+    is easy to debug.)
+    """
+    if isinstance(data, dict):
+        return {f: data[f] for f in fields if f in data}
+    if isinstance(data, list):
+        return [{f: r[f] for f in fields if isinstance(r, dict) and f in r} for r in data]
+    return data
+
+
+def _run_jq(json_text: str, expr: str) -> str:
+    """Pipe JSON text through ``jq``. Raises typer.Exit on missing binary."""
+    if shutil.which("jq") is None:
+        console.print(
+            "[red]jq binary not found on PATH.[/red]  [dim]Install via "
+            "`brew install jq` (macOS), `apt install jq` (Debian/Ubuntu), or "
+            "`dnf install jq` (Fedora). Re-run without `--jq` to skip post-processing.[/dim]",
+        )
+        raise typer.Exit(code=4)
+
+    try:
+        result = subprocess.run(
+            ["jq", expr],
+            input=json_text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as e:
+        console.print(f"[red]Failed to invoke jq:[/red] {e}")
+        raise typer.Exit(code=4) from e
+
+    if result.returncode != 0:
+        # jq writes the error description to stderr; surface it verbatim
+        # so the user can fix their expression.
+        msg = result.stderr.strip() or "jq exited with a non-zero status."
+        console.print(f"[red]jq error:[/red] {msg}")
+        raise typer.Exit(code=2)
+
+    return result.stdout
+
+
+def _emit_field_list(fields: list[str]) -> None:
+    """Handle ``--json`` with no value: print the field list and exit.
+
+    Matches gh's behaviour: introspection is a terminal action — the user
+    asked "what can I select?", not "render with everything", so we never
+    fall through to the data path. Exits with status 2 to make scripts
+    fail loudly if they forgot to specify fields.
+    """
+    if not fields:
+        console.print(
+            "[yellow]This command does not declare introspectable fields.[/yellow] "
+            "[dim]Try `--output json` to see the raw payload.[/dim]",
+        )
+        raise typer.Exit(code=2)
+
+    if _stdout_is_tty():
+        console.print("[bold]Available fields for --json:[/bold]")
+        for f in fields:
+            console.print(f"  {f}")
+    else:
+        # Piped: emit a plain newline-separated list so `xargs` / loops work.
+        print("\n".join(fields))
+    raise typer.Exit(code=2)
+
+
+def emit(
+    data: Any,
+    *,
+    table: Optional[Union[Table, Callable[[], Table]]] = None,
+    fields: Optional[Iterable[str]] = None,
+    opts: Optional[RenderOpts] = None,
+) -> None:
+    """Render ``data`` according to the active output options.
+
+    Parameters
+    ----------
+    data
+        The primary data structure for the command (list-of-dicts for
+        ``list`` commands; dict for ``show`` commands; arbitrary JSON
+        for decision endpoints).
+    table
+        Either a precomputed ``rich.Table`` or a zero-arg callable that
+        builds one on demand. Only invoked when format resolves to
+        TABLE — saves work when the user piped to JSON. When omitted in
+        TABLE mode, falls back to ``console.print_json(data=data)``
+        (better than nothing, but commands should provide a table).
+    fields
+        Explicit override for the available-fields list reported by
+        ``--json`` introspection. When omitted, derived from ``data``.
+    opts
+        Override for the active :data:`RUNTIME` (useful for tests).
+    """
+    active = opts or RUNTIME
+
+    # ``--json`` with no value: introspection mode, never hits the data.
+    if active.json_fields == LIST_FIELDS_SENTINEL:
+        _emit_field_list(list(fields) if fields is not None else _available_fields(data))
+        return
+
+    fmt = _resolve_format(active)
+
+    if fmt == OutputFormat.TABLE:
+        if active.jq_expr is not None:
+            # `--jq` implies JSON. If the user asked for both --output table
+            # and --jq, that's a contradiction worth flagging.
+            console.print(
+                "[yellow]--jq requires JSON output; ignoring --output table.[/yellow]",
+            )
+            fmt = OutputFormat.JSON
+
+    if fmt == OutputFormat.TABLE:
+        if table is None:
+            # Fall through to pretty-printed JSON — better than crashing
+            # when a command forgot to declare its table renderer.
+            console.print_json(data=data)
+            return
+        rendered = table() if callable(table) else table
+        console.print(rendered)
+        return
+
+    # JSON mode below this point.
+    output = data
+    if active.json_fields and active.json_fields != LIST_FIELDS_SENTINEL:
+        wanted = [f.strip() for f in active.json_fields.split(",") if f.strip()]
+        output = _filter_fields(data, wanted)
+
+    text = json.dumps(output, indent=2, default=str, sort_keys=False)
+
+    if active.jq_expr is not None:
+        text = _run_jq(text, active.jq_expr)
+
+    # Use ``print`` instead of ``console.print`` so the output is a clean
+    # stream of bytes — no Rich markup escaping, no ANSI when piped.
+    print(text)
+
+
+__all__ = [
+    "OutputFormat",
+    "RenderOpts",
+    "RUNTIME",
+    "LIST_FIELDS_SENTINEL",
+    "emit",
+    "is_json_requested",
+]

--- a/aethis_cli/render.py
+++ b/aethis_cli/render.py
@@ -14,14 +14,20 @@ This module is the single emit point. Each list/show command:
 3. Calls :func:`emit`, which respects ``--output / --json / --jq``
    global flags (set on :data:`RUNTIME` at the root callback).
 
-The flag surface mirrors GitHub's ``gh`` CLI:
+The flag surface partly mirrors GitHub's ``gh`` CLI:
 
 * ``--output table|json`` — pick the format. Default: ``table`` on a
   TTY, ``json`` when stdout is piped (gh's "pipe-friendly by default").
-* ``--json`` — alias for ``--output json``; with an optional CSV value
-  (``--json id,name``) limits the emitted object to those fields. With
-  no value (``--json`` alone) prints the available fields and exits 0
-  (gh's introspection trick — invaluable for discovering schema).
+* ``--json FIELDS`` — implies ``--output json``; takes a required
+  comma-separated value (``--json id,name``) that limits the emitted
+  object to those fields. ``gh`` additionally treats ``--json`` with no
+  value as a schema introspection request; we don't expose that today
+  because Click/Typer's option parser can't cleanly distinguish "flag
+  with no value" from "flag followed by positional argument" without
+  the deprecated ``is_flag=False, flag_value=...`` pattern. The
+  underlying machinery (:data:`LIST_FIELDS_SENTINEL`,
+  :func:`_emit_field_list`) is kept for a future revival via a separate
+  flag — see the v0.18 milestone.
 * ``--jq EXPR`` — pipe JSON output through ``jq`` before printing.
   Requires the ``jq`` binary on PATH; fails with a clear hint if not.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.16.3"
+version = "0.17.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,32 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_render_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force table-mode default + reset RenderOpts between tests.
+
+    Two things to defend against:
+
+    1. ``CliRunner.invoke`` swaps stdout for a StringIO buffer, so
+       ``sys.stdout.isatty()`` returns False — which would trigger the
+       new pipe-friendly JSON autodetect and break every existing test
+       that asserts on table output. Force ``_stdout_is_tty`` to True
+       so commands behave the way humans see them on a real terminal.
+    2. ``--output``, ``--json``, ``--jq`` are set on a module-level
+       singleton (``render.RUNTIME``); without a reset, one test's flags
+       leak into the next.
+
+    Tests that specifically want to exercise piped-JSON behaviour can
+    monkeypatch ``_stdout_is_tty`` back to ``False`` inside the test.
+    """
+    from aethis_cli import render
+
+    monkeypatch.setattr("aethis_cli.render._stdout_is_tty", lambda: True)
+    render.RUNTIME.reset()
+    yield
+    render.RUNTIME.reset()
+
+
 @pytest.fixture
 def tmp_project(tmp_path: Path) -> Path:
     """Create a minimal valid aethis project in a temp dir."""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,212 @@
+"""Tests for the shared output renderer."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from unittest.mock import patch
+
+import pytest
+import typer
+from rich.table import Table
+
+from aethis_cli import render
+from aethis_cli.render import LIST_FIELDS_SENTINEL, OutputFormat, RenderOpts, emit
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime() -> None:
+    """Make sure no test leaks RenderOpts state into the next one."""
+    render.RUNTIME.reset()
+    yield
+    render.RUNTIME.reset()
+
+
+SAMPLE_LIST = [
+    {"slug": "aethis/uk-fsm", "ruleset_id": "rs_1", "name": "FSM child elig", "rules": 12},
+    {"slug": "aethis/gdpr-toy", "ruleset_id": "rs_2", "name": "GDPR toy", "rules": 5},
+]
+
+SAMPLE_DICT = {"key_id": "ak_abc", "tenant_id": "t_1", "tier": "internal"}
+
+
+def _make_table() -> Table:
+    t = Table()
+    t.add_column("Slug")
+    for row in SAMPLE_LIST:
+        t.add_row(row["slug"])
+    return t
+
+
+def test_emit_table_mode_calls_table_callback(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(output=OutputFormat.TABLE)
+    emit(SAMPLE_LIST, table=_make_table, opts=opts)
+    out = capsys.readouterr().out
+    # Rich box-drawing characters confirm a table was rendered
+    assert "Slug" in out
+    assert "aethis/uk-fsm" in out
+
+
+def test_emit_json_mode_emits_full_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(output=OutputFormat.JSON)
+    emit(SAMPLE_LIST, table=_make_table, opts=opts)
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed == SAMPLE_LIST
+
+
+def test_emit_json_filters_fields(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(output=OutputFormat.JSON, json_fields="slug,rules")
+    emit(SAMPLE_LIST, opts=opts)
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed == [
+        {"slug": "aethis/uk-fsm", "rules": 12},
+        {"slug": "aethis/gdpr-toy", "rules": 5},
+    ]
+
+
+def test_emit_json_filters_unknown_fields_silently(capsys: pytest.CaptureFixture[str]) -> None:
+    """Unknown field names get dropped (matches gh). The introspection
+    sentinel is the way to discover what's available."""
+    opts = RenderOpts(output=OutputFormat.JSON, json_fields="slug,not_a_real_field")
+    emit(SAMPLE_LIST, opts=opts)
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed == [{"slug": "aethis/uk-fsm"}, {"slug": "aethis/gdpr-toy"}]
+
+
+def test_emit_json_filter_dict(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(output=OutputFormat.JSON, json_fields="key_id,tier")
+    emit(SAMPLE_DICT, opts=opts)
+    out = capsys.readouterr().out
+    assert json.loads(out) == {"key_id": "ak_abc", "tier": "internal"}
+
+
+def test_emit_field_introspection_lists_keys(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(json_fields=LIST_FIELDS_SENTINEL)
+    # Patch isatty so the TTY-branch (Rich-formatted list) fires
+    with patch("aethis_cli.render._stdout_is_tty", return_value=True):
+        with pytest.raises(typer.Exit):
+            emit(SAMPLE_LIST, opts=opts)
+    out = capsys.readouterr().out
+    for field_name in ("slug", "ruleset_id", "name", "rules"):
+        assert field_name in out
+
+
+def test_emit_field_introspection_piped_emits_newline_list(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(json_fields=LIST_FIELDS_SENTINEL)
+    with patch("aethis_cli.render._stdout_is_tty", return_value=False):
+        with pytest.raises(typer.Exit):
+            emit(SAMPLE_LIST, opts=opts)
+    out = capsys.readouterr().out.strip()
+    assert out.splitlines() == ["slug", "ruleset_id", "name", "rules"]
+
+
+def test_emit_field_introspection_empty_data_warns(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(json_fields=LIST_FIELDS_SENTINEL)
+    with pytest.raises(typer.Exit) as exc_info:
+        emit([], opts=opts)
+    assert exc_info.value.exit_code == 2
+    assert "does not declare introspectable fields" in capsys.readouterr().out
+
+
+def test_emit_field_introspection_explicit_fields_override(capsys: pytest.CaptureFixture[str]) -> None:
+    """When the caller passes ``fields=[...]``, that wins over data-derived keys.
+
+    Needed for ``decide`` etc. where the payload is nested and the
+    user-facing field list is curated.
+    """
+    opts = RenderOpts(json_fields=LIST_FIELDS_SENTINEL)
+    with patch("aethis_cli.render._stdout_is_tty", return_value=False):
+        with pytest.raises(typer.Exit):
+            emit({"raw": "nested"}, fields=["decision", "reason"], opts=opts)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["decision", "reason"]
+
+
+def test_non_tty_defaults_to_json(capsys: pytest.CaptureFixture[str]) -> None:
+    """Pipe-friendly default: when stdout isn't a TTY, emit JSON."""
+    opts = RenderOpts()  # output=None, no flags
+    with patch("aethis_cli.render._stdout_is_tty", return_value=False):
+        emit(SAMPLE_LIST, table=_make_table, opts=opts)
+    out = capsys.readouterr().out
+    assert json.loads(out) == SAMPLE_LIST
+
+
+def test_tty_defaults_to_table(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts()
+    with patch("aethis_cli.render._stdout_is_tty", return_value=True):
+        emit(SAMPLE_LIST, table=_make_table, opts=opts)
+    out = capsys.readouterr().out
+    assert "aethis/uk-fsm" in out
+    # No JSON braces — that would mean we leaked the JSON branch
+    assert "{" not in out
+
+
+def test_jq_pipes_through_binary(capsys: pytest.CaptureFixture[str]) -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq binary not installed on this machine")
+    opts = RenderOpts(jq_expr=".[0].slug")
+    emit(SAMPLE_LIST, opts=opts)
+    out = capsys.readouterr().out.strip()
+    assert out == '"aethis/uk-fsm"'
+
+
+def test_jq_missing_binary_exits_with_hint(capsys: pytest.CaptureFixture[str]) -> None:
+    opts = RenderOpts(jq_expr=".[0]")
+    with patch("aethis_cli.render.shutil.which", return_value=None):
+        with pytest.raises(typer.Exit) as exc_info:
+            emit(SAMPLE_LIST, opts=opts)
+    assert exc_info.value.exit_code == 4
+    out = capsys.readouterr().out
+    assert "jq binary not found" in out
+    assert "brew install jq" in out
+
+
+def test_jq_with_invalid_expression_surfaces_jq_error(capsys: pytest.CaptureFixture[str]) -> None:
+    if shutil.which("jq") is None:
+        pytest.skip("jq binary not installed on this machine")
+    opts = RenderOpts(jq_expr="this is not valid jq")
+    with pytest.raises(typer.Exit) as exc_info:
+        emit(SAMPLE_LIST, opts=opts)
+    assert exc_info.value.exit_code == 2
+    assert "jq error:" in capsys.readouterr().out
+
+
+def test_jq_implies_json_even_with_output_table(capsys: pytest.CaptureFixture[str]) -> None:
+    """--jq with --output table is a contradiction; we honour --jq and warn."""
+    if shutil.which("jq") is None:
+        pytest.skip("jq binary not installed on this machine")
+    opts = RenderOpts(output=OutputFormat.TABLE, jq_expr=".[0].slug")
+    emit(SAMPLE_LIST, table=_make_table, opts=opts)
+    out = capsys.readouterr().out
+    assert "--jq requires JSON" in out
+    assert '"aethis/uk-fsm"' in out
+
+
+def test_is_json_requested_table_default_with_tty() -> None:
+    with patch("aethis_cli.render._stdout_is_tty", return_value=True):
+        assert render.is_json_requested(RenderOpts()) is False
+
+
+def test_is_json_requested_non_tty() -> None:
+    with patch("aethis_cli.render._stdout_is_tty", return_value=False):
+        assert render.is_json_requested(RenderOpts()) is True
+
+
+def test_is_json_requested_explicit_json() -> None:
+    assert render.is_json_requested(RenderOpts(output=OutputFormat.JSON)) is True
+
+
+def test_is_json_requested_jq_implies_json() -> None:
+    with patch("aethis_cli.render._stdout_is_tty", return_value=True):
+        assert render.is_json_requested(RenderOpts(jq_expr=".")) is True
+
+
+def test_emit_falls_back_to_print_json_when_no_table(capsys: pytest.CaptureFixture[str]) -> None:
+    """Forgetting to pass ``table`` shouldn't crash — emit pretty JSON."""
+    opts = RenderOpts(output=OutputFormat.TABLE)
+    emit(SAMPLE_DICT, opts=opts)
+    out = capsys.readouterr().out
+    assert "ak_abc" in out

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -14,12 +14,9 @@ from aethis_cli import render
 from aethis_cli.render import LIST_FIELDS_SENTINEL, OutputFormat, RenderOpts, emit
 
 
-@pytest.fixture(autouse=True)
-def _reset_runtime() -> None:
-    """Make sure no test leaks RenderOpts state into the next one."""
-    render.RUNTIME.reset()
-    yield
-    render.RUNTIME.reset()
+# Note: RenderOpts state is reset between tests by the autouse
+# ``_reset_render_runtime`` fixture in ``tests/conftest.py``. No file-level
+# fixture needed here.
 
 
 SAMPLE_LIST = [


### PR DESCRIPTION
## Summary

PR 2 in the v0.17.0 DX-overhaul stack ([plan](https://github.com/Aethis-ai/aethis-cli/pull/53#issuecomment-4555336426)). Adds gh-style machine-readable output to every list/show + decision command. Cuts the "scrape ANSI Rich tables with regex" pain that the DX survey flagged as the single biggest scripting blocker.

Before:
```bash
$ aethis rulesets list | jq '.[0].slug'                    # broken — Rich ANSI in the pipe
$ aethis rulesets list | awk '/aethis\//' | head -1        # fragile shell scraping
```

After:
```bash
$ aethis --output json rulesets list | jq '.[0].slug'      # works
"aethis/uk-fsm/universal-infant"

$ aethis --json slug,name rulesets list                    # field-filtered JSON
[
  {"slug": "aethis/uk-fsm/universal-infant", "name": "UK FSM Universal Infant"},
  ...
]

$ aethis --jq '.[] | select(.field_count > 0) | .slug' rulesets list
"aethis/uk-fsm/universal-infant"
```

## Surface (mirrors `gh`)

| Flag | Behaviour |
|---|---|
| `--output table\|json` | Pick the format. Default: `table` on a TTY, `json` when piped (gh's pipe-friendly autodetect). |
| `--json FIELDS` | Implies `--output json`; emits only the named comma-separated fields. |
| `--jq EXPR` | Pipe JSON through `jq`. Requires `jq` on PATH; clear install hint if missing. |

Flags live on the root callback so every subcommand inherits them. Usage is gh-style — flags **before** the command:

```bash
aethis --output json status | jq .identity.key_id
aethis --json id,name,status projects list
aethis --jq '.[0]' rulebooks list
```

## Commands migrated (17)

`rulesets list`, `rulesets show`, `rulebooks list`, `rulebooks show`, `rulebooks get-fields`, `rulebooks tests list`, `rulebooks schema`, `rulebooks explain`, `rulebooks decide`, `projects list`, `projects show`, `account keys`, `profile list`, `guidance list`, `fields`, `explain`, `decide`, `status`.

Each command picks a sensible JSON shape. `aethis --output json status` returns a structured dict with `cli`, `server`, `profile`, `project`, `identity`, `generation` sub-objects so `jq .identity.key_id` works straight away — no rooting through prose.

## Plumbing

New `aethis_cli/render.py` is the single emit point. Each command:

1. Builds its primary data structure (list of dicts, or a single dict).
2. Defines a callable that builds the `rich.Table` (only invoked when format resolves to `TABLE` — saves table-construction work when piped to JSON).
3. Calls `emit(data, table=...)`.

Footer hints (`Try: aethis ...`, `No project context — showing public showcase rulesets`) are suppressed in JSON mode so pipes get clean output (verified: `aethis --output json rulesets list | python3 -c 'import sys,json; json.load(sys.stdin)'` succeeds).

## Why `jq` via subprocess

Shells out to the `jq` binary deliberately: no new Python deps, no libjq wheel-build pain on niche platforms, matches user mental model from `kubectl --jq`, `aws --query`. macOS ships `brew install jq`; Debian/Ubuntu `apt install jq`; Fedora `dnf install jq`. Missing binary exits 4 with the install hint.

## What I deliberately dropped

Original plan included `--json` with no value triggering field introspection (gh-parity). Click's option parsing doesn't cleanly support "optional value" on a non-flag option — combining `is_flag=False, flag_value=X` triggers a deprecation warning from Typer and means `--json rulesets list` parses `rulesets` as the value. Dropped for v0.17.0; users can `<cmd> --output json | jq 'first | keys'` to discover fields. The infrastructure (`LIST_FIELDS_SENTINEL`) is kept in `render.py` for programmatic use and is tested, so reviving this when Typer's flag story improves is a 5-line change.

## Tests

- New `tests/test_render.py` (20 tests) — table mode, JSON mode, field filtering, `--jq` pipe, `--jq` with missing binary, `--jq` with invalid expression, `--jq` with `--output table` (contradiction handled), non-TTY autodetect, TTY default, `is_json_requested` predicates.
- New autouse fixture in `tests/conftest.py` — forces `_stdout_is_tty=True` and resets `render.RUNTIME` between tests so CliRunner-based tests don't accidentally exercise the new pipe-friendly JSON default.

`uv run pytest -q --no-cov` → 250 passed, 6 pre-existing failures (Rich numeric-highlighting / ANSI splitting across substring assertions in `test_account_cmd.py`, `test_auth_providers.py`, `test_guidance_cli.py`, `test_id_utils.py` — all confirmed to fail identically on main; queued for a follow-up that promotes `_strip_ansi` from PR #53 to `conftest.py`).

## Versioning

- `_version.py` + `pyproject.toml`: `0.16.3` → `0.17.0` (minor — additive feature).
- `CHANGELOG.md` headline entry under `## 0.17.0 (2026-05-27)`.

Per `.claude/rules/public-repos.md`.

## End-to-end smoke against `api.aethis.ai`

```
$ uv run aethis --output json rulesets list | python3 -c \"import sys,json; data=json.load(sys.stdin); print(f'OK: parsed {len(data)} records')\"
OK: parsed 7 records

$ uv run aethis --json slug,name rulesets list | jq '.[0]'
{
  \"slug\": \"aethis/uk-fsm/universal-infant\",
  \"name\": \"UK FSM Universal Infant\"
}

$ uv run aethis --jq '.[0].slug' rulesets list
\"aethis/uk-fsm/universal-infant\"
```

## Test plan

- [x] `uv run pytest tests/test_render.py` — 20/20 pass
- [x] Full suite: 250 pass, 6 pre-existing failures unchanged
- [x] Manual smoke against `api.aethis.ai`: JSON pipe, field filter, jq pipeline all work
- [x] `uvx ruff check aethis_cli/ tests/` — clean
- [ ] CI green
- [ ] Manual smoke on a TTY: existing table output unchanged