### PR TITLE
feat: aethis refine / generate --mode refine (v0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.18.0 (2026-05-29)
+
+- **feat(refine): `aethis refine` + `aethis generate --mode refine` for incremental, seed-from-existing re-authoring.** Instead of re-authoring a whole section from scratch, refine seeds generation from the section's active ruleset and makes the **minimal edit** to fix failing tests while keeping passing tests green.
+  - `aethis refine [--hint "..."] [--seed-ruleset-id <id>]` — the phase-3 TDD-loop command: optionally add a guidance hint, then refine. Defaults to seeding from the section's active ruleset.
+  - `aethis generate --mode refine [--seed-ruleset-id <id>]` — the same capability via a flag on `generate`; `--mode fresh` (default) is unchanged from-scratch authoring.
+  - `AethisClient.generate()` gains optional `mode` / `seed_ruleset_id`; a no-arg call still sends no body, so it stays backwards-compatible against engines without the parameter.
+  - Requires aethis-core with the `mode` parameter on `/generate` (live on `api.aethis.ai`). Against an older engine the flags no-op (empty body = fresh).
+
 ## 0.17.0 (2026-05-27)
 
 - **feat(output): gh-style machine-readable output mode (`--output json`, `--json fields`, `--jq`).** Every list/show command (and the decision commands) now emit structured JSON on demand, so `aethis rulesets list --output json | jq '.[0].slug'` just works instead of trying to scrape ANSI-coloured Rich tables.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -192,8 +192,24 @@ class AethisClient:
             },
         )
 
-    def generate(self, project_id: str) -> dict:
-        return self._request("POST", f"/api/v1/public/projects/{project_id}/generate")
+    def generate(
+        self,
+        project_id: str,
+        mode: Optional[str] = None,
+        seed_ruleset_id: Optional[str] = None,
+    ) -> dict:
+        """Trigger generation. ``mode="refine"`` seeds from the section's active
+        ruleset and makes the minimal edit to fix failing tests; omitting ``mode``
+        (or ``mode="fresh"``) authors from scratch. A no-arg call sends no body, so
+        it stays backwards-compatible against engines without the ``mode`` parameter.
+        """
+        body: dict = {}
+        if mode is not None:
+            body["mode"] = mode
+        if seed_ruleset_id is not None:
+            body["seed_ruleset_id"] = seed_ruleset_id
+        kwargs = {"json": body} if body else {}
+        return self._request("POST", f"/api/v1/public/projects/{project_id}/generate", **kwargs)
 
     def get_status(self, project_id: str) -> dict:
         return self._request("GET", f"/api/v1/public/projects/{project_id}/status")

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -31,8 +31,32 @@ def generate(
     project_id: Optional[str] = typer.Option(None, "--project-id", "-p"),
     poll: bool = typer.Option(True, "--poll/--no-poll", help="Poll until generation completes"),
     timeout: int = typer.Option(600, "--timeout", "-t", help="Polling timeout in seconds"),
+    mode: str = typer.Option(
+        "fresh", "--mode",
+        help="fresh = author from scratch; refine = minimal edit seeded from the active ruleset",
+    ),
+    seed_ruleset_id: Optional[str] = typer.Option(
+        None, "--seed-ruleset-id",
+        help="Ruleset to seed a refine from (defaults to the section's active ruleset)",
+    ),
 ) -> None:
     """Upload sources + guidance, trigger ruleset generation, and poll until done."""
+    _run_generate(
+        project_id=project_id, poll=poll, timeout=timeout,
+        mode=mode, seed_ruleset_id=seed_ruleset_id,
+    )
+
+
+def _run_generate(
+    *,
+    project_id: Optional[str],
+    poll: bool,
+    timeout: int,
+    mode: str = "fresh",
+    seed_ruleset_id: Optional[str] = None,
+    extra_hint: Optional[str] = None,
+) -> None:
+    """Shared machinery for ``aethis generate`` and ``aethis refine``."""
     try:
         cfg = load_project_config()
         api_key = resolve_api_key(cfg)
@@ -77,6 +101,12 @@ def generate(
             pid = result["project_id"]
             write_state(project_dir, {"project_id": pid})
             info(f"Created project {pid}")
+
+        # Refinement hint (aethis refine --hint): add before regenerating so it
+        # informs the minimal edit.
+        if extra_hint:
+            client.add_guidance(pid, extra_hint)
+            info("Added refinement hint")
 
         # Upload source files (batch in groups of 5)
         sources_dir = project_dir / "sources"
@@ -142,7 +172,12 @@ def generate(
                 info(f"Added {len(test_cases)} test case(s)")
 
         # Trigger generation
-        job = client.generate(pid)
+        if mode == "refine":
+            info(
+                "Refining: seeding from the active ruleset and making the minimal "
+                "edit to fix failing tests"
+            )
+        job = client.generate(pid, mode=mode, seed_ruleset_id=seed_ruleset_id)
         write_state(project_dir, {"project_id": pid, "job_id": job["job_id"]})
         info(f"Generation queued (job={job['job_id']})")
 

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -32,18 +32,23 @@ def generate(
     poll: bool = typer.Option(True, "--poll/--no-poll", help="Poll until generation completes"),
     timeout: int = typer.Option(600, "--timeout", "-t", help="Polling timeout in seconds"),
     mode: str = typer.Option(
-        "fresh", "--mode",
+        "fresh",
+        "--mode",
         help="fresh = author from scratch; refine = minimal edit seeded from the active ruleset",
     ),
     seed_ruleset_id: Optional[str] = typer.Option(
-        None, "--seed-ruleset-id",
+        None,
+        "--seed-ruleset-id",
         help="Ruleset to seed a refine from (defaults to the section's active ruleset)",
     ),
 ) -> None:
     """Upload sources + guidance, trigger ruleset generation, and poll until done."""
     _run_generate(
-        project_id=project_id, poll=poll, timeout=timeout,
-        mode=mode, seed_ruleset_id=seed_ruleset_id,
+        project_id=project_id,
+        poll=poll,
+        timeout=timeout,
+        mode=mode,
+        seed_ruleset_id=seed_ruleset_id,
     )
 
 
@@ -173,10 +178,7 @@ def _run_generate(
 
         # Trigger generation
         if mode == "refine":
-            info(
-                "Refining: seeding from the active ruleset and making the minimal "
-                "edit to fix failing tests"
-            )
+            info("Refining: seeding from the active ruleset and making the minimal edit to fix failing tests")
         job = client.generate(pid, mode=mode, seed_ruleset_id=seed_ruleset_id)
         write_state(project_dir, {"project_id": pid, "job_id": job["job_id"]})
         info(f"Generation queued (job={job['job_id']})")

--- a/aethis_cli/commands/refine_cmd.py
+++ b/aethis_cli/commands/refine_cmd.py
@@ -11,12 +11,11 @@ from aethis_cli.commands.generate_cmd import _run_generate
 
 
 def refine(
-    hint: Optional[str] = typer.Option(
-        None, "--hint", help="Guidance hint to add before refining"
-    ),
+    hint: Optional[str] = typer.Option(None, "--hint", help="Guidance hint to add before refining"),
     project_id: Optional[str] = typer.Option(None, "--project-id", "-p"),
     seed_ruleset_id: Optional[str] = typer.Option(
-        None, "--seed-ruleset-id",
+        None,
+        "--seed-ruleset-id",
         help="Ruleset to seed from (defaults to the section's active ruleset)",
     ),
     poll: bool = typer.Option(True, "--poll/--no-poll", help="Poll until refinement completes"),
@@ -28,6 +27,10 @@ def refine(
     from-scratch build.
     """
     _run_generate(
-        project_id=project_id, poll=poll, timeout=timeout,
-        mode="refine", seed_ruleset_id=seed_ruleset_id, extra_hint=hint,
+        project_id=project_id,
+        poll=poll,
+        timeout=timeout,
+        mode="refine",
+        seed_ruleset_id=seed_ruleset_id,
+        extra_hint=hint,
     )

--- a/aethis_cli/commands/refine_cmd.py
+++ b/aethis_cli/commands/refine_cmd.py
@@ -1,0 +1,33 @@
+"""aethis refine — add an optional hint, then make the minimal edit to fix failing
+tests (finding-driven incremental re-authoring, seeded from the active ruleset)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from aethis_cli.commands.generate_cmd import _run_generate
+
+
+def refine(
+    hint: Optional[str] = typer.Option(
+        None, "--hint", help="Guidance hint to add before refining"
+    ),
+    project_id: Optional[str] = typer.Option(None, "--project-id", "-p"),
+    seed_ruleset_id: Optional[str] = typer.Option(
+        None, "--seed-ruleset-id",
+        help="Ruleset to seed from (defaults to the section's active ruleset)",
+    ),
+    poll: bool = typer.Option(True, "--poll/--no-poll", help="Poll until refinement completes"),
+    timeout: int = typer.Option(600, "--timeout", "-t", help="Polling timeout in seconds"),
+) -> None:
+    """Refine the active ruleset: add an optional --hint, then make the minimal
+    edit to fix failing test cases (seeded from the section's active ruleset)
+    rather than re-authoring the whole section. Use ``aethis generate`` for a
+    from-scratch build.
+    """
+    _run_generate(
+        project_id=project_id, poll=poll, timeout=timeout,
+        mode="refine", seed_ruleset_id=seed_ruleset_id, extra_hint=hint,
+    )

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -24,6 +24,7 @@ from aethis_cli.commands.projects_cmd import projects_app
 from aethis_cli.commands.init_cmd import init
 from aethis_cli.commands.login_cmd import login
 from aethis_cli.commands.generate_cmd import generate
+from aethis_cli.commands.refine_cmd import refine
 from aethis_cli.commands.status_cmd import status
 from aethis_cli.commands.test_cmd import test
 from aethis_cli.commands.publish_cmd import publish
@@ -178,6 +179,7 @@ app.add_typer(projects_app, name="projects")
 app.command()(init)
 app.command()(login)
 app.command()(generate)
+app.command()(refine)
 app.command()(status)
 app.command(name="test")(test)
 app.command()(publish)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.17.0"
+version = "0.18.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 import httpx
 import respx
@@ -207,6 +209,28 @@ def test_generate(respx_mock):
     result = AethisClient("ak", BASE).generate("proj_abc")
     assert result["job_id"] == "job_1"
     assert result["status"] == "queued"
+
+
+@respx.mock(base_url=BASE)
+def test_generate_refine_mode(respx_mock):
+    route = respx_mock.post("/api/v1/public/projects/proj_abc/generate").mock(
+        return_value=httpx.Response(202, json={"job_id": "job_2", "status": "queued"})
+    )
+    result = AethisClient("ak", BASE).generate("proj_abc", mode="refine", seed_ruleset_id="rs_xyz")
+    assert result["job_id"] == "job_2"
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"mode": "refine", "seed_ruleset_id": "rs_xyz"}
+
+
+@respx.mock(base_url=BASE)
+def test_generate_fresh_sends_no_body(respx_mock):
+    # Backwards compatible: a no-arg generate() sends no body (engine treats absent
+    # body as fresh), so it still works against engines without the mode parameter.
+    route = respx_mock.post("/api/v1/public/projects/proj_abc/generate").mock(
+        return_value=httpx.Response(202, json={"job_id": "job_3", "status": "queued"})
+    )
+    AethisClient("ak", BASE).generate("proj_abc")
+    assert route.calls.last.request.content in (b"", None)
 
 
 @respx.mock(base_url=BASE)


### PR DESCRIPTION
## Summary

Exposes aethis-core's new **refine** mode in the CLI: finding-driven incremental re-authoring — seed from the section's active ruleset and make the **minimal edit** to fix failing tests, rather than only from-scratch `generate`.

Closes #55. Part of epic Aethis-ai/aethis-core#163.

## Changes
- `client.generate()` — optional `mode` / `seed_ruleset_id`; sends `{mode, seed_ruleset_id}` body. A no-arg call sends **no body**, so it stays backwards-compatible against engines without the parameter.
- `commands/generate_cmd.py` — extract shared `_run_generate()`; add `--mode` (fresh|refine) + `--seed-ruleset-id`.
- `commands/refine_cmd.py` (new) + `main.py` — `aethis refine [--hint "..."] [--seed-ruleset-id <id>]`, the phase-3 TDD-loop command CLAUDE.md already documents.
- Tests: refine sends the body; fresh sends none. `tests/test_client.py` green (21 passed). (6 unrelated ANSI-color test failures pre-date this branch — verified by stashing this change.)
- Version 0.17.0 → 0.18.0 + CHANGELOG.

## Dependency / gate
Requires aethis-core with the `mode` parameter on `/generate`:
<!-- aethis-needs: aethis-core (live on api.aethis.ai) -->
- aethis-core PR Aethis-ai/aethis-core#162 must be **live on `api.aethis.ai`** before the PyPI publish of 0.18.0 (aethis-core isn't a registry package, so "live on api.aethis.ai" is the gate). The code is backwards-compatible and safe to merge now; against an older engine the flags no-op (empty body = fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
