### PR TITLE
feat: aethis update — self-update the CLI to the latest release (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.19.0 (2026-06-03)
+
+- **feat(update): `aethis update` — self-update the CLI to the latest release.** Detects how the CLI was installed (uv tool, pipx, or pip) and runs the matching upgrade command. `aethis update --check` reports whether a newer release exists without installing anything.
+  - Editable (development) installs are refused with a pointer to `git pull && uv sync` instead of clobbering the checkout.
+  - The exit-time "new release available" banner now points at `aethis update` rather than a method-specific command.
+  - **fix:** the banner's uv upgrade hint was `uv tool install --upgrade aethis-cli`, which re-resolves from scratch and silently drops any extra `--with` requirements (e.g. plugin packages installed alongside the CLI). Both the banner's install-method detection and `aethis update` now use `uv tool upgrade aethis-cli`, which honours the original install receipt.
+  - A successful (or no-op) `aethis update` refreshes the banner's 24h cache, so the notice goes quiet immediately after updating.
+
 ## 0.18.0 (2026-05-29)
 
 - **feat(refine): `aethis refine` + `aethis generate --mode refine` for incremental, seed-from-existing re-authoring.** Instead of re-authoring a whole section from scratch, refine seeds generation from the section's active ruleset and makes the **minimal edit** to fix failing tests while keeping passing tests green.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ uv tool install aethis-cli
 pipx install aethis-cli
 ```
 
+Already installed? `aethis update` upgrades to the latest release in place
+(it detects how the CLI was installed and runs the matching upgrade command).
+
 ## Quick start
 
 > **Authoring is in private beta.** Decision tools (`decide`, `fields`, `explain`) are public — no key required. Authoring tools (rule generation, test refinement, publishing) require an invite. Request access at [aethis.ai/developer-access](https://aethis.ai/developer-access).
@@ -186,6 +189,7 @@ A Rulebook is the whole form — the unit `/decide` evaluates against. It owns a
 | `aethis account generate` | Mint an additional API key (rotation, multi-machine, scoped access) |
 | `aethis account keys` | List your API keys (masked) |
 | `aethis account revoke <key_id>` | Revoke a key |
+| `aethis update [--check]` | Update the CLI to the latest release (`--check` only reports) |
 
 ### Profiles
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/aethis_cli/commands/update_cmd.py
+++ b/aethis_cli/commands/update_cmd.py
@@ -100,8 +100,7 @@ def update(
         result = subprocess.run(argv)
     except FileNotFoundError:
         console.print(
-            f"[red]Error:[/red] `{argv[0]}` not found on PATH. "
-            f"Upgrade manually with your installer of choice."
+            f"[red]Error:[/red] `{argv[0]}` not found on PATH. Upgrade manually with your installer of choice."
         )
         raise typer.Exit(code=1)
     if result.returncode != 0:

--- a/aethis_cli/commands/update_cmd.py
+++ b/aethis_cli/commands/update_cmd.py
@@ -1,0 +1,111 @@
+"""aethis update — update the CLI to the latest release."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import typer
+
+from aethis_cli._version import __version__
+from aethis_cli.output import console
+from aethis_cli.update_check import (
+    _detect_install_method,
+    _fetch_latest_pypi,
+    _is_newer,
+    _save_cache,
+)
+
+PACKAGE = "aethis-cli"
+
+
+def _is_editable_install(package: str) -> bool:
+    """True when the package was installed editable (a development checkout)."""
+    try:
+        from importlib.metadata import distribution
+
+        raw = distribution(package).read_text("direct_url.json")
+    except Exception:
+        return False
+    if not raw:
+        return False
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    dir_info = data.get("dir_info")
+    return isinstance(dir_info, dict) and bool(dir_info.get("editable"))
+
+
+def _upgrade_argv(method: str, package: str) -> list[str]:
+    """Map a detected install method to the argv that upgrades it."""
+    if method == "uv":
+        # `uv tool upgrade` honours the install receipt, so extra
+        # `--with` requirements (e.g. staff plugins) are preserved.
+        # `uv tool install --upgrade` would re-resolve without them.
+        return ["uv", "tool", "upgrade", package]
+    if method == "pipx":
+        return ["pipx", "upgrade", package]
+    return [sys.executable, "-m", "pip", "install", "--upgrade", package]
+
+
+def update(
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Only check whether a newer release exists; don't install anything.",
+    ),
+) -> None:
+    """Update the aethis CLI to the latest release.
+
+    Detects how the CLI was installed (uv tool, pipx, or pip) and runs the
+    matching upgrade command. Use --check to see what's available without
+    changing anything.
+    """
+    console.print(f"[dim]Current version: {__version__}[/dim]")
+    latest = _fetch_latest_pypi(PACKAGE)
+    if latest is None:
+        console.print(
+            "[red]Error:[/red] could not reach PyPI to look up the latest release. "
+            "Check your network connection and try again."
+        )
+        raise typer.Exit(code=1)
+
+    # Refresh the banner cache so the exit-time notice agrees with what we
+    # just learned (and goes quiet after a successful update).
+    _save_cache(latest)
+
+    if not _is_newer(latest, __version__):
+        console.print(f"[green]✓ Already up to date[/green] (aethis-cli {__version__}).")
+        return
+
+    console.print(f"[bold]New release available:[/bold] {__version__} → {latest}")
+
+    if check:
+        console.print("[dim]Run `aethis update` to install it.[/dim]")
+        return
+
+    if _is_editable_install(PACKAGE):
+        console.print(
+            "[yellow]This looks like a development (editable) install.[/yellow]\n"
+            "[dim]Update your checkout instead: git pull && uv sync[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    method, _ = _detect_install_method(PACKAGE)
+    argv = _upgrade_argv(method, PACKAGE)
+    console.print(f"[dim]Running: {' '.join(argv)}[/dim]")
+    try:
+        result = subprocess.run(argv)
+    except FileNotFoundError:
+        console.print(
+            f"[red]Error:[/red] `{argv[0]}` not found on PATH. "
+            f"Upgrade manually with your installer of choice."
+        )
+        raise typer.Exit(code=1)
+    if result.returncode != 0:
+        console.print(f"[red]Upgrade command failed[/red] (exit code {result.returncode}).")
+        raise typer.Exit(code=result.returncode)
+
+    console.print(f"[green]✓ Updated[/green] aethis-cli {__version__} → {latest}.")

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -32,6 +32,7 @@ from aethis_cli.commands.fields_cmd import fields
 from aethis_cli.commands.explain_cmd import explain
 from aethis_cli.commands.decide_cmd import decide
 from aethis_cli.commands.whoami_cmd import whoami
+from aethis_cli.commands.update_cmd import update
 
 
 PLUGIN_GROUP = "aethis_cli.plugins"
@@ -187,6 +188,7 @@ app.command()(fields)
 app.command()(explain)
 app.command()(decide)
 app.command()(whoami)
+app.command()(update)
 
 
 def _load_plugins(target: typer.Typer) -> None:

--- a/aethis_cli/update_check.py
+++ b/aethis_cli/update_check.py
@@ -110,15 +110,16 @@ def _detect_install_method(package: str) -> tuple[str, str]:
     exe = (sys.executable or "").lower()
     prefix = (sys.prefix or "").lower()
     if "/uv/tools/" in exe or "/uv/tools/" in prefix:
-        return ("uv", f"uv tool install --upgrade {package}")
+        # `uv tool upgrade` honours the install receipt (extra `--with`
+        # requirements survive); `install --upgrade` would drop them.
+        return ("uv", f"uv tool upgrade {package}")
     if "/pipx/venvs/" in exe or "/pipx/venvs/" in prefix:
         return ("pipx", f"pipx upgrade {package}")
     return ("pip", f"pip install --upgrade {package}")
 
 
 def _print_banner(package: str, current: str, latest: str) -> None:
-    _, command = _detect_install_method(package)
-    msg = f"\nA new release of {package} is available: {current} → {latest}\nTo upgrade, run: {command}\n"
+    msg = f"\nA new release of {package} is available: {current} → {latest}\nTo upgrade, run: aethis update\n"
     try:
         sys.stderr.write(msg)
         sys.stderr.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.18.0"
+version = "0.19.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -42,7 +42,7 @@ def test_detect_install_method_uv() -> None:
     with patch.object(uc.sys, "executable", "/Users/x/.local/share/uv/tools/aethis-cli/bin/python"):
         method, cmd = uc._detect_install_method("aethis-cli")
     assert method == "uv"
-    assert cmd == "uv tool install --upgrade aethis-cli"
+    assert cmd == "uv tool upgrade aethis-cli"
 
 
 def test_detect_install_method_pipx() -> None:
@@ -153,7 +153,7 @@ def test_print_banner_writes_to_stderr(capsys: pytest.CaptureFixture[str]) -> No
     uc._print_banner("aethis-cli", "0.10.0", "0.11.0")
     captured = capsys.readouterr()
     assert "A new release of aethis-cli is available: 0.10.0 → 0.11.0" in captured.err
-    assert "To upgrade, run:" in captured.err
+    assert "To upgrade, run: aethis update" in captured.err
     assert captured.out == ""
 
 

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -1,0 +1,101 @@
+"""Tests for `aethis update`."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from aethis_cli.commands import update_cmd
+
+
+def _run(args, **patches_kw):
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    defaults = {
+        "_fetch_latest_pypi": "9.9.9",
+        "_save_cache": None,
+        "_is_editable_install": False,
+        "_detect_install_method": ("uv", "uv tool upgrade aethis-cli"),
+        "subprocess_returncode": 0,
+    }
+    defaults.update(patches_kw)
+
+    run_result = MagicMock(returncode=defaults["subprocess_returncode"])
+    with (
+        patch.object(update_cmd, "_fetch_latest_pypi", return_value=defaults["_fetch_latest_pypi"]),
+        patch.object(update_cmd, "_save_cache") as save_cache,
+        patch.object(update_cmd, "_is_editable_install", return_value=defaults["_is_editable_install"]),
+        patch.object(update_cmd, "_detect_install_method", return_value=defaults["_detect_install_method"]),
+        patch.object(update_cmd.subprocess, "run", return_value=run_result) as sub_run,
+    ):
+        result = runner.invoke(app, args)
+    return result, sub_run, save_cache
+
+
+def test_update_already_current() -> None:
+    from aethis_cli._version import __version__
+
+    result, sub_run, _ = _run(["update"], _fetch_latest_pypi=__version__)
+    assert result.exit_code == 0
+    assert "Already up to date" in result.output
+    sub_run.assert_not_called()
+
+
+def test_update_runs_uv_upgrade() -> None:
+    result, sub_run, save_cache = _run(["update"])
+    assert result.exit_code == 0
+    sub_run.assert_called_once_with(["uv", "tool", "upgrade", "aethis-cli"])
+    assert "Updated" in result.output
+    save_cache.assert_called_once_with("9.9.9")
+
+
+def test_update_runs_pipx_upgrade() -> None:
+    result, sub_run, _ = _run(["update"], _detect_install_method=("pipx", "pipx upgrade aethis-cli"))
+    assert result.exit_code == 0
+    sub_run.assert_called_once_with(["pipx", "upgrade", "aethis-cli"])
+
+
+def test_update_check_flag_does_not_install() -> None:
+    result, sub_run, _ = _run(["update", "--check"])
+    assert result.exit_code == 0
+    assert "New release available" in result.output
+    sub_run.assert_not_called()
+
+
+def test_update_pypi_unreachable_errors() -> None:
+    result, sub_run, _ = _run(["update"], _fetch_latest_pypi=None)
+    assert result.exit_code == 1
+    assert "could not reach PyPI" in result.output
+    sub_run.assert_not_called()
+
+
+def test_update_refuses_editable_install() -> None:
+    result, sub_run, _ = _run(["update"], _is_editable_install=True)
+    assert result.exit_code == 1
+    assert "development" in result.output
+    sub_run.assert_not_called()
+
+
+def test_update_propagates_upgrade_failure() -> None:
+    result, sub_run, _ = _run(["update"], subprocess_returncode=3)
+    assert result.exit_code == 3
+    assert "failed" in result.output
+    sub_run.assert_called_once()
+
+
+def test_is_editable_install_reads_direct_url() -> None:
+    dist = MagicMock()
+    dist.read_text.return_value = json.dumps({"dir_info": {"editable": True}})
+    with patch("importlib.metadata.distribution", return_value=dist):
+        assert update_cmd._is_editable_install("aethis-cli") is True
+
+    dist.read_text.return_value = json.dumps({"dir_info": {"editable": False}})
+    with patch("importlib.metadata.distribution", return_value=dist):
+        assert update_cmd._is_editable_install("aethis-cli") is False
+
+    dist.read_text.return_value = None  # regular wheel install: no direct_url.json
+    with patch("importlib.metadata.distribution", return_value=dist):
+        assert update_cmd._is_editable_install("aethis-cli") is False


### PR DESCRIPTION
## Summary

Adds an `aethis update` command that upgrades the CLI to the latest release in place — the active counterpart to the existing passive exit-time banner.

- **`aethis update`** — looks up the latest release on PyPI, detects how the CLI was installed (uv tool / pipx / pip), and runs the matching upgrade command.
- **`aethis update --check`** — reports whether a newer release exists without installing anything.
- **Editable (development) installs are refused** with a pointer to `git pull && uv sync` instead of clobbering the checkout.
- **Banner now points at `aethis update`** instead of a method-specific command.
- **fix:** the banner's uv hint was `uv tool install --upgrade aethis-cli`, which re-resolves from scratch and silently drops extra `--with` requirements (e.g. plugin packages installed alongside the CLI). Detection now yields `uv tool upgrade aethis-cli`, which honours the original install receipt.
- A successful (or no-op) update refreshes the banner's 24h cache so the notice goes quiet immediately after upgrading.

Version bumped 0.18.0 → 0.19.0 (minor, additive) with CHANGELOG entry; README install section + command table updated.

## Test plan

- [x] 8 new tests in `tests/test_update_cmd.py` (up-to-date no-op, uv/pipx upgrade argv, `--check` doesn't install, PyPI unreachable, editable refusal, subprocess failure propagation, `direct_url.json` parsing)
- [x] `tests/test_update_check.py` updated for the new uv command + banner text
- [x] Full suite: 261 passed; the 5 failures in `test_guidance_cli`/`test_id_utils` are pre-existing on `main` (ANSI-escape env quirk, reproduced on a clean checkout)
- [x] ruff clean
- [x] Live smoke test: `aethis update --check` against real PyPI correctly reports up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)
