### PR TITLE
fix: rulebooks list no longer prompts browser sign-in for anonymous users (v0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.19.1 (2026-06-03)
+
+- **fix(rulebooks list): stop prompting browser sign-in for anonymous users.** `aethis rulebooks list` with no cached API key used to trigger the lazy-auth browser login — bad first-contact DX for a read-only browse command. Rulebooks are tenant-scoped, so an anonymous caller has nothing to list; the command now prints a pointer to the anonymous public catalogue (`aethis rulesets list`) and to `aethis login`, and exits 1 without ever opening a browser.
+  - True anonymous fallthrough (listing public rulebooks without an account, mirroring `aethis rulesets list`) needs engine support for a public rulebook catalogue and is tracked separately; this release removes the login prompt in the meantime.
+
 ## 0.19.0 (2026-06-03)
 
 - **feat(update): `aethis update` — self-update the CLI to the latest release.** Detects how the CLI was installed (uv tool, pipx, or pip) and runs the matching upgrade command. `aethis update --check` reports whether a newer release exists without installing anything.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -34,6 +34,7 @@ from typing import Any, Optional
 import typer
 from rich.table import Table
 
+from aethis_cli.auth_helpers import resolve_cached_key
 from aethis_cli.config import load_client_or_fallback
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success
@@ -82,6 +83,17 @@ def list_rulebooks() -> None:
 
         aethis rulebooks list
     """
+    # Rulebooks are tenant-scoped, so an anonymous caller has nothing to
+    # list — don't drag a brand-new user through the browser sign-in for a
+    # read-only browse. Point them at the anonymous public catalogue instead.
+    if resolve_cached_key() is None:
+        console.print(
+            "[yellow]No API key found — rulebooks are private to your tenant.[/yellow]\n"
+            "[dim]Browse the public catalogue without an account: `aethis rulesets list`\n"
+            "Or sign in to list your own rulebooks: `aethis login`[/dim]"
+        )
+        raise typer.Exit(code=1)
+
     _cfg, client = load_client_or_fallback()
     try:
         rulebooks = client.list_rulebooks()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.19.0"
+version = "0.19.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -726,3 +726,51 @@ def test_tests_delete_with_yes(tmp_path, monkeypatch):
         result = _runner_invoke(["rulebooks", "tests", "delete", "rb_x", "tc_abc", "--yes"])
     assert result.exit_code == 0, result.output
     client.delete_rulebook_test_case.assert_called_once_with("rb_x", "tc_abc")
+
+
+# ---------------------------------------------------------------------------
+# rulebooks list — anonymous (no API key)
+# ---------------------------------------------------------------------------
+
+
+def test_rulebooks_list_no_key_does_not_prompt_login(tmp_path, monkeypatch):
+    """A fresh user with no key gets a pointer to the public catalogue —
+    never a browser sign-in prompt — from a read-only browse command."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+
+    with (
+        patch("aethis_cli.commands.rulebooks_cmd.resolve_cached_key", return_value=None),
+        patch("aethis_cli.commands.rulebooks_cmd.load_client_or_fallback") as load_client,
+    ):
+        result = _runner_invoke(["rulebooks", "list"])
+
+    assert result.exit_code == 1
+    out = _strip(result.output)
+    assert "No API key found" in out
+    assert "aethis rulesets list" in out
+    assert "aethis login" in out
+    # The lazy-auth client (and therefore the browser login hook) must never
+    # be constructed on this path.
+    load_client.assert_not_called()
+
+
+def test_rulebooks_list_with_cached_key_lists_normally(tmp_path, monkeypatch):
+    """A cached key (no env var) goes straight to the normal listing path."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.setenv("COLUMNS", "200")
+
+    client = MagicMock()
+    client.list_rulebooks.return_value = []
+    with (
+        patch("aethis_cli.commands.rulebooks_cmd.resolve_cached_key", return_value="ak_cached"),
+        patch(
+            "aethis_cli.commands.rulebooks_cmd.load_client_or_fallback",
+            return_value=(MagicMock(), client),
+        ),
+    ):
+        result = _runner_invoke(["rulebooks", "list"])
+
+    assert result.exit_code == 0
+    assert "No rulebooks yet" in _strip(result.output)


### PR DESCRIPTION
## Summary

Reported DX bug: a brand-new user running `aethis rulebooks list` got dragged through the lazy-auth browser sign-in — for a read-only browse command. `aethis rulesets list` already falls through to the anonymous public catalogue; `rulebooks list` couldn't, because the engine has no anonymous rulebook catalogue (`GET /api/v1/public/rulebooks/` returns 401 `missing_api_key`, and the `Rulebook` model has no `visibility` field yet).

This is **phase 1** of the agreed phased fix: with no cached key, `rulebooks list` now prints a pointer to `aethis rulesets list` (anonymous catalogue) and `aethis login`, exits 1, and never constructs the lazy-auth client — so no browser ever opens.

**Phase 2** (tracked separately): aethis-core grows `Rulebook.visibility` + an optional-auth list route + an anonymous rate-limit category (the `internal-only-rulebook-flag` spec already anticipates rulebook visibility); then the CLI gains true anonymous fallthrough mirroring `rulesets list`.

Patch bump 0.19.0 → 0.19.1 with CHANGELOG entry.

## Test plan

- [x] New test: no key → exit 1, message names both `aethis rulesets list` and `aethis login`, `load_client_or_fallback` never called (browser hook unreachable)
- [x] New test: cached key (no env var) → normal listing path
- [x] Full suite 263 passed (5 pre-existing ANSI-env failures, reproduced on clean main); ruff check + format clean
- [x] Live repro with a clean `XDG_CONFIG_HOME`: message + exit 1, no browser prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)