### PR TITLE
feat: rulebooks list anonymous fallthrough to the public catalogue (v0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.20.0 (2026-06-03)
+
+- **feat(rulebooks list): anonymous fallthrough to the public rulebook catalogue.** With no cached API key, `aethis rulebooks list` now lists the cross-tenant public catalogue (rulebooks with public visibility, active status) instead of printing the v0.19.1 pointer message — completing the parity with `aethis rulesets list`. A dim one-liner ("No API key — showing public rulebooks…") distinguishes the anonymous view; with a key, the tenant listing is unchanged.
+  - New `AethisClient.list_public_rulebooks()`; use with `make_anonymous_client` so a cached key doesn't promote the call to an authenticated tenant listing.
+  - Requires aethis-core v0.29.0+ on the target API (live on api.aethis.ai). Against an older engine the anonymous path surfaces the server's 401 cleanly.
+
 ## 0.19.1 (2026-06-03)
 
 - **fix(rulebooks list): stop prompting browser sign-in for anonymous users.** `aethis rulebooks list` with no cached API key used to trigger the lazy-auth browser login — bad first-contact DX for a read-only browse command. Rulebooks are tenant-scoped, so an anonymous caller has nothing to list; the command now prints a pointer to the anonymous public catalogue (`aethis rulesets list`) and to `aethis login`, and exits 1 without ever opening a browser.

--- a/README.md
+++ b/README.md
@@ -161,13 +161,13 @@ Project guidance lives in `.aethis/guidance/hints.yaml` and is uploaded by `aeth
 | `aethis rulesets list` | List published rulesets |
 | `aethis rulesets archive <ruleset_id>` | Archive a ruleset |
 
-### Rulebooks (the converged 2-term model, login required)
+### Rulebooks (the converged 2-term model, login required for authoring)
 
 A Rulebook is the whole form — the unit `/decide` evaluates against. It owns a locked field vocabulary, an `outcome_logic` composition expression, rulebook-level test cases, and an integer version history. Rulesets are named, versioned members of a Rulebook.
 
 | Command | Description |
 |---------|-------------|
-| `aethis rulebooks list` | List your tenant's rulebooks |
+| `aethis rulebooks list` | List your tenant's rulebooks (or, with no key, the public catalogue) |
 | `aethis rulebooks show <id-or-slug>` | Full configuration including outcome_logic |
 | `aethis rulebooks create <name> --domain <d> [--slug ...]` | Create a draft rulebook |
 | `aethis rulebooks set-fields <id> -f fields.yaml` | Replace the locked field vocabulary |

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -306,6 +306,18 @@ class AethisClient:
     def list_rulebooks(self) -> list[dict]:
         return self._request("GET", "/api/v1/public/rulebooks/")
 
+    def list_public_rulebooks(self) -> list[dict]:
+        """List rulebooks visible to anonymous callers.
+
+        Hits the cross-tenant catalogue (``visibility="public"`` AND
+        ``status="active"``) on the same route as :meth:`list_rulebooks` —
+        the server keys the behaviour on the absence of an API key. Use
+        with :func:`make_anonymous_client` so a cached key doesn't promote
+        the call to an authenticated tenant listing. Requires aethis-core
+        v0.29.0+ on the target API.
+        """
+        return self._request("GET", "/api/v1/public/rulebooks/")
+
     def get_rulebook(self, rulebook_id_or_slug: str) -> dict:
         return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}")
 

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -35,7 +35,8 @@ import typer
 from rich.table import Table
 
 from aethis_cli.auth_helpers import resolve_cached_key
-from aethis_cli.config import load_client_or_fallback
+from aethis_cli.client import make_anonymous_client
+from aethis_cli.config import load_client_or_fallback, resolve_base_url_with_source
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success
 from aethis_cli.render import emit, is_json_requested
@@ -75,24 +76,67 @@ def _load_yaml_or_json(path: Path) -> Any:
 # ============================================================================
 
 
+def _build_rulebooks_table(rulebooks: list[dict], title: str = "Rulebooks") -> Table:
+    table = Table(title=title)
+    table.add_column("Slug", style="cyan")
+    table.add_column("Rulebook ID", style="dim")
+    table.add_column("Name")
+    table.add_column("Domain")
+    table.add_column("Status")
+    table.add_column("Rulesets", justify="right")
+    for rb in rulebooks:
+        table.add_row(
+            rb.get("slug") or "[dim]—[/dim]",
+            rb.get("rulebook_id", ""),
+            rb.get("name") or "[dim]—[/dim]",
+            rb.get("domain") or "[dim]—[/dim]",
+            rb.get("status", ""),
+            str(len(rb.get("ruleset_refs", []) or [])),
+        )
+    return table
+
+
+def _list_public_rulebooks() -> None:
+    """Hit the anonymous rulebook catalogue and render the result.
+
+    Mirrors the anonymous fallthrough on ``aethis rulesets list``. Requires
+    aethis-core v0.29.0+ on the target API (live on api.aethis.ai).
+    """
+    base_url, _ = resolve_base_url_with_source()
+    with make_anonymous_client(base_url) as client:
+        try:
+            rulebooks = client.list_public_rulebooks()
+        except AethisAPIError as e:
+            error_panel(e)
+            raise typer.Exit(code=1)
+
+    if not is_json_requested():
+        console.print("[dim]No API key — showing public rulebooks. Run `aethis login` to see yours.[/dim]")
+    if not rulebooks:
+        if is_json_requested():
+            emit([])
+        else:
+            console.print(
+                "[dim]No public rulebooks published yet. Browse public rulesets with `aethis rulesets list`.[/dim]"
+            )
+        return
+    emit(rulebooks, table=lambda: _build_rulebooks_table(rulebooks, title="Public rulebooks"))
+
+
 @rulebooks_app.command(name="list")
 def list_rulebooks() -> None:
-    """List rulebooks visible to the current tenant.
+    """List rulebooks — your tenant's (with an API key) or the public catalogue.
 
     Example::
 
         aethis rulebooks list
     """
-    # Rulebooks are tenant-scoped, so an anonymous caller has nothing to
-    # list — don't drag a brand-new user through the browser sign-in for a
-    # read-only browse. Point them at the anonymous public catalogue instead.
+    # Rulebooks are tenant-scoped; with no key cached, fall through to the
+    # anonymous cross-tenant public catalogue instead of dragging a
+    # brand-new user through the browser sign-in for a read-only browse.
     if resolve_cached_key() is None:
-        console.print(
-            "[yellow]No API key found — rulebooks are private to your tenant.[/yellow]\n"
-            "[dim]Browse the public catalogue without an account: `aethis rulesets list`\n"
-            "Or sign in to list your own rulebooks: `aethis login`[/dim]"
-        )
-        raise typer.Exit(code=1)
+        _list_public_rulebooks()
+        return
 
     _cfg, client = load_client_or_fallback()
     try:
@@ -108,26 +152,7 @@ def list_rulebooks() -> None:
             console.print("[dim]No rulebooks yet. Create one with `aethis rulebooks create`.[/dim]")
         return
 
-    def _build_rulebooks_table() -> Table:
-        table = Table(title="Rulebooks")
-        table.add_column("Slug", style="cyan")
-        table.add_column("Rulebook ID", style="dim")
-        table.add_column("Name")
-        table.add_column("Domain")
-        table.add_column("Status")
-        table.add_column("Rulesets", justify="right")
-        for rb in rulebooks:
-            table.add_row(
-                rb.get("slug") or "[dim]—[/dim]",
-                rb.get("rulebook_id", ""),
-                rb.get("name") or "[dim]—[/dim]",
-                rb.get("domain") or "[dim]—[/dim]",
-                rb.get("status", ""),
-                str(len(rb.get("ruleset_refs", []) or [])),
-            )
-        return table
-
-    emit(rulebooks, table=_build_rulebooks_table)
+    emit(rulebooks, table=lambda: _build_rulebooks_table(rulebooks))
 
 
 # ============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.19.1"
+version = "0.20.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -729,29 +729,73 @@ def test_tests_delete_with_yes(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# rulebooks list — anonymous (no API key)
+# rulebooks list — anonymous fallthrough (no API key)
 # ---------------------------------------------------------------------------
 
 
-def test_rulebooks_list_no_key_does_not_prompt_login(tmp_path, monkeypatch):
-    """A fresh user with no key gets a pointer to the public catalogue —
+def _patch_anonymous(rulebooks):
+    """Patch the no-key path: resolver returns None, anonymous client returns
+    the given catalogue, lazy-auth client construction is observable."""
+    anon_client = MagicMock()
+    anon_client.__enter__ = MagicMock(return_value=anon_client)
+    anon_client.__exit__ = MagicMock(return_value=False)
+    anon_client.list_public_rulebooks.return_value = rulebooks
+    return anon_client
+
+
+def test_rulebooks_list_no_key_falls_through_to_public_catalogue(tmp_path, monkeypatch):
+    """A fresh user with no key gets the anonymous public catalogue —
     never a browser sign-in prompt — from a read-only browse command."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.setenv("COLUMNS", "200")
 
+    anon_client = _patch_anonymous(
+        [
+            {
+                "rulebook_id": "rb_pub",
+                "slug": "aethis/uk-fsm",
+                "name": "UK Free School Meals",
+                "domain": "uk_fsm",
+                "status": "active",
+                "visibility": "public",
+                "ruleset_refs": [],
+            }
+        ]
+    )
     with (
         patch("aethis_cli.commands.rulebooks_cmd.resolve_cached_key", return_value=None),
+        patch("aethis_cli.commands.rulebooks_cmd.make_anonymous_client", return_value=anon_client),
         patch("aethis_cli.commands.rulebooks_cmd.load_client_or_fallback") as load_client,
     ):
         result = _runner_invoke(["rulebooks", "list"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 0, result.output
     out = _strip(result.output)
-    assert "No API key found" in out
-    assert "aethis rulesets list" in out
-    assert "aethis login" in out
+    assert "showing public rulebooks" in out
+    assert "aethis/uk-fsm" in out
     # The lazy-auth client (and therefore the browser login hook) must never
     # be constructed on this path.
+    load_client.assert_not_called()
+
+
+def test_rulebooks_list_no_key_empty_catalogue_points_at_rulesets(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AETHIS_API_KEY", raising=False)
+    monkeypatch.setenv("COLUMNS", "200")
+
+    anon_client = _patch_anonymous([])
+    with (
+        patch("aethis_cli.commands.rulebooks_cmd.resolve_cached_key", return_value=None),
+        patch("aethis_cli.commands.rulebooks_cmd.make_anonymous_client", return_value=anon_client),
+        patch("aethis_cli.commands.rulebooks_cmd.load_client_or_fallback") as load_client,
+    ):
+        result = _runner_invoke(["rulebooks", "list"])
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "No public rulebooks published yet" in out
+    assert "aethis rulesets list" in out
     load_client.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Closes #59 — phase 2 (CLI side) of the anonymous-rulebooks DX fix. The engine dependency (Aethis-ai/aethis-core#169, anonymous rulebook catalogue) is **live on api.aethis.ai as v0.29.0** (verified: anonymous `GET /rulebooks/` → `200 []`).

- With no cached key, `aethis rulebooks list` now lists the anonymous cross-tenant public catalogue — full parity with `aethis rulesets list` — replacing the v0.19.1 interim pointer message. A dim banner ("No API key — showing public rulebooks…") marks the anonymous view; suppressed in JSON mode.
- Keyed behaviour unchanged (tenant listing).
- New `AethisClient.list_public_rulebooks()`, called through `make_anonymous_client` so a cached key never silently promotes the call to an authenticated listing.
- Empty catalogue points at `aethis rulesets list` (the showcase content lives there until rulebooks are flipped public).

Minor bump 0.19.1 → 0.20.0 with CHANGELOG; README rulebooks section updated.

## Test plan

- [x] Updated/new tests: anonymous fallthrough renders catalogue + never constructs the lazy-auth client; empty-catalogue hint; keyed path unchanged (264 passed; 5 pre-existing ANSI-env failures unrelated)
- [x] ruff check + format clean
- [x] Live against prod: anonymous clean-config run → `200 []` exit 0; keyed run with real credentials → tenant listing exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)