### PR TITLE
feat(init): field-definition home + rulebook scaffolding (v0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.21.0 (2026-06-16)
+
+- **feat(init): field definitions get a real home (`fields/fields.yaml`).** `aethis init` now scaffolds a `fields/` directory with a `fields.yaml` for declaring the field vocabulary (key + `type` + optional `label`/`question`/`hints`). Previously fields had no dedicated home and only surfaced implicitly as the `inputs:` keys inside `tests/scenarios.yaml`. `aethis generate` reads `fields/fields.yaml`, pins the field keys/types via the project field-spec endpoint, and routes each field's label/question/hints through guidance so a field is defined once.
+- **feat(init): `--kind rulebook` scaffolds a rulebook.** `aethis init <name> --kind rulebook` lays down a rulebook directory with shared `guidance/` and `fields/` plus a `rulesets/` directory for member rulesets. When a ruleset lives under a rulebook (`<rulebook>/rulesets/<ruleset>/`), `aethis generate` propagates the rulebook's guidance hints and field vocabulary into the ruleset — **the rulebook definition wins on shared field keys** — so a common field (e.g. date of birth) is defined once at the rulebook level and the end user is asked for it only once. `--kind` defaults to `ruleset`, so existing behaviour is unchanged.
+  - New `AethisClient.set_field_spec()` (project field-spec endpoint, already served by aethis-core / used by the MCP server). No engine change required.
+
 ## 0.20.0 (2026-06-03)
 
 - **feat(rulebooks list): anonymous fallthrough to the public rulebook catalogue.** With no cached API key, `aethis rulebooks list` now lists the cross-tenant public catalogue (rulebooks with public visibility, active status) instead of printing the v0.19.1 pointer message — completing the parity with `aethis rulesets list`. A dim one-liner ("No API key — showing public rulebooks…") distinguishes the anonymous view; with a key, the tenant listing is unchanged.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -192,6 +192,20 @@ class AethisClient:
             },
         )
 
+    def set_field_spec(self, project_id: str, expected_fields: list[dict]) -> dict:
+        """Pin the project's expected field vocabulary (key + type + enum values).
+
+        Each entry is ``{key, sort, enum_values?}``. This constrains generation
+        to the declared field keys so the same field (e.g. date of birth) is not
+        re-invented under a different key. Field hints / questions are carried as
+        guidance, not here — this endpoint only fixes the vocabulary.
+        """
+        return self._request(
+            "POST",
+            f"/api/v1/public/projects/{project_id}/fields/spec",
+            json={"expected_fields": expected_fields},
+        )
+
     def generate(
         self,
         project_id: str,

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -27,6 +27,117 @@ def _chunks(lst: list, n: int):
         yield lst[i : i + n]
 
 
+def _load_yaml_file(path: Path) -> dict:
+    """Read + parse a project YAML file, failing fast on oversize / bad YAML."""
+    if path.stat().st_size > 1_000_000:
+        console.print(f"[red]{path} exceeds 1 MB limit[/red]")
+        raise typer.Exit(code=1)
+    try:
+        return yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as e:
+        console.print(f"[red]Invalid YAML in {path}: {e}[/red]")
+        raise typer.Exit(code=1)
+
+
+def _parent_rulebook_dir(project_dir: Path) -> Optional[Path]:
+    """Return the enclosing rulebook directory if this project is a member ruleset.
+
+    Matches the scaffold shape ``<rulebook>/rulesets/<ruleset>/`` so rulebook-level
+    guidance + fields can be propagated down into the ruleset's generation.
+    """
+    parent = project_dir.parent
+    if parent.name == "rulesets" and (parent.parent / "aethis.yaml").exists():
+        return parent.parent
+    return None
+
+
+def _parse_fields_yaml(path: Path) -> dict:
+    """Parse a fields.yaml into an ordered ``{key: field_dict}`` map."""
+    raw = _load_yaml_file(path)
+    out: dict = {}
+    for f in raw.get("fields", []) or []:
+        if isinstance(f, dict) and f.get("key"):
+            out[f["key"]] = f
+    return out
+
+
+def _field_guidance_lines(key: str, field: dict) -> list[str]:
+    """Natural-language guidance derived from a field's label/question/hints.
+
+    The ``/fields/spec`` endpoint only fixes key + type, so the human-facing
+    phrasing and the "why we ask" notes ride along as guidance instead.
+    """
+    lines: list[str] = []
+    if field.get("question"):
+        lines.append(f'Ask field "{key}" using this question: {field["question"]}')
+    if field.get("label"):
+        lines.append(f'Label field "{key}" as: {field["label"]}')
+    for hint in field.get("hints", []) or []:
+        if hint:
+            lines.append(f'Field "{key}": {hint}')
+    return lines
+
+
+def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) -> None:
+    """Push the field vocabulary for this project (rulebook-level fields win).
+
+    Merges the enclosing rulebook's ``fields/fields.yaml`` (if any) with the
+    project's own — the rulebook definition wins on shared keys — then pins the
+    expected field keys/types via ``/fields/spec`` and routes each field's
+    label/question/hints through guidance so a shared field is defined once.
+    """
+    field_map: dict = {}
+
+    rb_dir = _parent_rulebook_dir(project_dir)
+    if rb_dir is not None:
+        rb_fields = rb_dir / "fields" / "fields.yaml"
+        if rb_fields.exists():
+            field_map.update(_parse_fields_yaml(rb_fields))
+
+    own_fields = project_dir / "fields" / "fields.yaml"
+    if own_fields.exists():
+        for key, field in _parse_fields_yaml(own_fields).items():
+            field_map.setdefault(key, field)  # rulebook wins: don't overwrite
+
+    if not field_map:
+        return
+
+    expected_fields: list[dict] = []
+    guidance_lines: list[str] = []
+    for key, field in field_map.items():
+        spec = {"key": key, "sort": field.get("type") or field.get("sort")}
+        if field.get("enum_values"):
+            spec["enum_values"] = field["enum_values"]
+        expected_fields.append(spec)
+        guidance_lines.extend(_field_guidance_lines(key, field))
+
+    client.set_field_spec(pid, expected_fields)
+    for line in guidance_lines:
+        client.add_guidance(pid, line)
+    info(f"Set field spec ({len(expected_fields)} field(s))")
+
+
+def _upload_rulebook_guidance(client: AethisClient, pid: str, project_dir: Path) -> None:
+    """Propagate the enclosing rulebook's guidance hints into this ruleset."""
+    rb_dir = _parent_rulebook_dir(project_dir)
+    if rb_dir is None:
+        return
+    rb_hints = rb_dir / "guidance" / "hints.yaml"
+    if not rb_hints.exists():
+        return
+    raw = _load_yaml_file(rb_hints)
+    count = 0
+    for hint in raw.get("hints", []) or []:
+        if not hint:
+            continue
+        text = hint if isinstance(hint, str) else hint.get("text", "")
+        if text:
+            client.add_guidance(pid, text)
+            count += 1
+    if count:
+        info(f"Propagated {count} rulebook guidance hint(s)")
+
+
 def generate(
     project_id: Optional[str] = typer.Option(None, "--project-id", "-p"),
     poll: bool = typer.Option(True, "--poll/--no-poll", help="Poll until generation completes"),
@@ -151,6 +262,12 @@ def _run_generate(
                 count += 1
             if count:
                 info(f"Added {count} guidance hint(s)")
+
+        # Propagate rulebook-level guidance + push the field vocabulary. A field
+        # (e.g. date of birth) defined once at the rulebook level flows down here
+        # so the end user is only asked for it once. Rulebook fields win.
+        _upload_rulebook_guidance(client, pid, project_dir)
+        _upload_field_vocabulary(client, pid, project_dir)
 
         # Upload test cases
         tests_path = project_dir / "tests" / "scenarios.yaml"

--- a/aethis_cli/commands/init_cmd.py
+++ b/aethis_cli/commands/init_cmd.py
@@ -14,6 +14,7 @@ from aethis_cli.output import console, info, success
 
 AETHIS_YAML_TEMPLATE = """\
 project: {name}
+kind: {kind}
 api_key_env: AETHIS_API_KEY
 # base_url: https://api.aethis.ai
 """
@@ -21,6 +22,28 @@ api_key_env: AETHIS_API_KEY
 HINTS_YAML_TEMPLATE = """\
 hints:
   # - "Add your guidance hints here"
+"""
+
+# Rulebook-level guidance carries a note that it reaches every member ruleset.
+RULEBOOK_HINTS_YAML_TEMPLATE = """\
+hints:
+  # Rulebook-level guidance — applied to every ruleset under this rulebook.
+  # - "Add shared guidance hints here"
+"""
+
+# The field vocabulary lives in its own file (not in tests/ or guidance/) so a
+# field is defined once and reused. `type` is the field's value type; `hints`
+# are plain-language notes that explain why a field is asked.
+FIELDS_YAML_TEMPLATE = """\
+# fields/fields.yaml — the field vocabulary for this {scope}.
+# Define each field once here so an end user is only asked for it once.
+fields:
+  # - key: applicant.date_of_birth
+  #   type: date
+  #   label: "Date of birth"
+  #   question: "What is your date of birth?"
+  #   hints:
+  #     - "Why we ask: age determines which route applies."
 """
 
 SCENARIOS_YAML_TEMPLATE = """\
@@ -65,20 +88,63 @@ def _ensure_logged_in(no_prompt: bool) -> None:
     login_cmd.login()
 
 
-def _print_next_steps(name: str) -> None:
+def _scaffold_ruleset(proj: Path, name: str) -> None:
+    """Lay down a ruleset project: sources + guidance + fields + tests."""
+    (proj / "aethis.yaml").write_text(AETHIS_YAML_TEMPLATE.format(name=name, kind="ruleset"))
+    (proj / "sources").mkdir()
+    (proj / "guidance").mkdir()
+    (proj / "guidance" / "hints.yaml").write_text(HINTS_YAML_TEMPLATE)
+    (proj / "fields").mkdir()
+    (proj / "fields" / "fields.yaml").write_text(FIELDS_YAML_TEMPLATE.format(scope="ruleset"))
+    (proj / "tests").mkdir()
+    (proj / "tests" / "scenarios.yaml").write_text(SCENARIOS_YAML_TEMPLATE)
+    (proj / ".gitignore").write_text(GITIGNORE)
+
+
+def _scaffold_rulebook(proj: Path, name: str) -> None:
+    """Lay down a rulebook: shared guidance + field vocabulary + rulesets/.
+
+    A rulebook composes rulesets. Its `guidance/` and `fields/` are defined once
+    here and propagate down to every member ruleset (rulebook wins). Sources
+    belong to the individual rulesets, so a rulebook has no `sources/`.
+    """
+    (proj / "aethis.yaml").write_text(AETHIS_YAML_TEMPLATE.format(name=name, kind="rulebook"))
+    (proj / "guidance").mkdir()
+    (proj / "guidance" / "hints.yaml").write_text(RULEBOOK_HINTS_YAML_TEMPLATE)
+    (proj / "fields").mkdir()
+    (proj / "fields" / "fields.yaml").write_text(FIELDS_YAML_TEMPLATE.format(scope="rulebook"))
+    (proj / "tests").mkdir()
+    (proj / "tests" / "scenarios.yaml").write_text(SCENARIOS_YAML_TEMPLATE)
+    # rulesets/ holds the member ruleset directories (scaffold each with
+    # `aethis init <name> --kind ruleset` from inside it).
+    (proj / "rulesets").mkdir()
+    (proj / ".gitignore").write_text(GITIGNORE)
+
+
+def _print_next_steps(name: str, kind: str) -> None:
     """Emit the canonical next-step ladder shown after init."""
-    success(f"Project initialised: {name}")
+    success(f"Project initialised: {name} ({kind})")
     console.print()
     console.print("Next:")
     console.print(f"  cd {name}")
-    console.print("  aethis generate --poll")
-    console.print("  aethis test && aethis publish")
+    if kind == "rulebook":
+        console.print("  # edit fields/fields.yaml and guidance/hints.yaml (shared by all rulesets)")
+        console.print("  cd rulesets && aethis init <ruleset-name> --kind ruleset")
+    else:
+        console.print("  # edit fields/fields.yaml to declare your field vocabulary")
+        console.print("  aethis generate --poll")
+        console.print("  aethis test && aethis publish")
 
 
 def init(
     name: Optional[str] = typer.Argument(
         None,
         help="Project name (will prompt if omitted, defaults to current directory name).",
+    ),
+    kind: str = typer.Option(
+        "ruleset",
+        "--kind",
+        help="What to scaffold: 'ruleset' (a single rule set) or 'rulebook' (composes rulesets, with shared guidance + fields).",
     ),
     no_prompt: bool = typer.Option(
         False,
@@ -93,7 +159,14 @@ def init(
         aethis init                    # interactive wizard (login if needed, prompt for name)
         aethis init my-policy          # positional name, prompts only if no auth cached
         aethis init my-policy --no-prompt    # scripted use; errors if anything is missing
+        aethis init my-rulebook --kind rulebook   # scaffold a rulebook (shared fields + guidance)
     """
+    # 0. Validate kind up front.
+    kind = (kind or "").strip().lower()
+    if kind not in ("ruleset", "rulebook"):
+        console.print("[red]--kind must be 'ruleset' or 'rulebook'.[/red]")
+        raise typer.Exit(code=1)
+
     # 1. Resolve project name (prompt if missing, unless --no-prompt).
     if name is None:
         if no_prompt:
@@ -113,20 +186,17 @@ def init(
     #    a half-scaffolded directory if they Ctrl-C the browser flow.
     _ensure_logged_in(no_prompt=no_prompt)
 
-    # 3. Scaffold (unchanged behaviour).
+    # 3. Scaffold.
     proj = Path(name)
     if proj.exists():
         console.print(f"[red]Directory '{name}' already exists.[/red]")
         raise typer.Exit(code=1)
 
     proj.mkdir()
-    (proj / "aethis.yaml").write_text(AETHIS_YAML_TEMPLATE.format(name=name))
-    (proj / "sources").mkdir()
-    (proj / "guidance").mkdir()
-    (proj / "guidance" / "hints.yaml").write_text(HINTS_YAML_TEMPLATE)
-    (proj / "tests").mkdir()
-    (proj / "tests" / "scenarios.yaml").write_text(SCENARIOS_YAML_TEMPLATE)
-    (proj / ".gitignore").write_text(GITIGNORE)
+    if kind == "rulebook":
+        _scaffold_rulebook(proj, name)
+    else:
+        _scaffold_ruleset(proj, name)
 
     # Pre-create .aethis/state.json so downstream commands can assume it
     # exists. The project_id stays unset until `aethis generate` actually
@@ -134,4 +204,4 @@ def init(
     write_state(proj, {})
 
     # 4. Print the next-step ladder. Always shown (prompted or not).
-    _print_next_steps(name)
+    _print_next_steps(name, kind)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.20.0"
+version = "0.21.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_generate_fields.py
+++ b/tests/test_generate_fields.py
@@ -1,0 +1,109 @@
+"""Tests for fields.yaml parsing + field-vocabulary upload in `aethis generate`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aethis_cli.commands import generate_cmd
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _write_fields(path, body: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+RULESET_FIELDS = """\
+fields:
+  - key: applicant.income
+    type: int
+    question: "What is your annual income?"
+  - key: applicant.date_of_birth
+    type: date
+    label: "Date of birth"
+    hints:
+      - "Why we ask: age determines the route."
+"""
+
+RULEBOOK_FIELDS = """\
+fields:
+  - key: applicant.date_of_birth
+    type: date
+    question: "Please give your date of birth."
+"""
+
+
+# --- pure parsing ----------------------------------------------------------
+
+
+def test_parse_fields_yaml_keys(tmp_path):
+    p = tmp_path / "fields" / "fields.yaml"
+    _write_fields(p, RULESET_FIELDS)
+    parsed = generate_cmd._parse_fields_yaml(p)
+    assert list(parsed) == ["applicant.income", "applicant.date_of_birth"]
+
+
+def test_field_guidance_lines_from_question_label_hints():
+    lines = generate_cmd._field_guidance_lines(
+        "applicant.date_of_birth",
+        {"question": "DOB?", "label": "Date of birth", "hints": ["age matters"]},
+    )
+    joined = "\n".join(lines)
+    assert "DOB?" in joined
+    assert "Date of birth" in joined
+    assert "age matters" in joined
+
+
+def test_parent_rulebook_dir_detection(tmp_path):
+    rb = tmp_path / "rb"
+    (rb / "rulesets" / "child").mkdir(parents=True)
+    (rb / "aethis.yaml").write_text("kind: rulebook\n")
+    found = generate_cmd._parent_rulebook_dir(rb / "rulesets" / "child")
+    assert found == rb
+    # A standalone project has no parent rulebook.
+    assert generate_cmd._parent_rulebook_dir(tmp_path / "solo") is None
+
+
+# --- upload (rulebook-wins merge) ------------------------------------------
+
+
+def test_upload_field_vocabulary_standalone(tmp_path):
+    _write_fields(tmp_path / "fields" / "fields.yaml", RULESET_FIELDS)
+    client = MagicMock()
+    generate_cmd._upload_field_vocabulary(client, "proj_1", tmp_path)
+
+    client.set_field_spec.assert_called_once()
+    _, expected_fields = client.set_field_spec.call_args.args
+    keys = {f["key"]: f["sort"] for f in expected_fields}
+    assert keys == {"applicant.income": "int", "applicant.date_of_birth": "date"}
+
+
+def test_upload_field_vocabulary_rulebook_wins(tmp_path):
+    """A field defined at the rulebook level wins over the ruleset's own."""
+    rb = tmp_path / "rb"
+    child = rb / "rulesets" / "child"
+    child.mkdir(parents=True)
+    (rb / "aethis.yaml").write_text("kind: rulebook\n")
+    _write_fields(rb / "fields" / "fields.yaml", RULEBOOK_FIELDS)
+    _write_fields(child / "fields" / "fields.yaml", RULESET_FIELDS)
+
+    client = MagicMock()
+    generate_cmd._upload_field_vocabulary(client, "proj_1", child)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    keys = [f["key"] for f in expected_fields]
+    # Shared key appears once; income from the ruleset still flows through.
+    assert keys.count("applicant.date_of_birth") == 1
+    assert "applicant.income" in keys
+
+    # The rulebook's wording for the shared field is what gets pushed as guidance.
+    guidance = " ".join(c.args[1] for c in client.add_guidance.call_args_list)
+    assert "Please give your date of birth." in guidance
+
+
+def test_upload_field_vocabulary_noop_when_absent(tmp_path):
+    client = MagicMock()
+    generate_cmd._upload_field_vocabulary(client, "proj_1", tmp_path)
+    client.set_field_spec.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -47,6 +47,65 @@ def test_init_creates_project_structure(tmp_path, monkeypatch):
     assert (proj / "tests" / "scenarios.yaml").exists()
 
 
+# --- fields home (Part A) --------------------------------------------------
+
+
+def test_init_ruleset_creates_fields_home(tmp_path, monkeypatch):
+    """Fields get a dedicated home, not implied by tests/scenarios.yaml."""
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "with-fields"])
+    assert result.exit_code == 0, result.output
+    proj = tmp_path / "with-fields"
+    assert (proj / "fields" / "fields.yaml").exists()
+    assert "fields:" in (proj / "fields" / "fields.yaml").read_text()
+
+
+def test_init_default_kind_is_ruleset(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        runner.invoke(app, ["init", "default-kind"])
+    content = (tmp_path / "default-kind" / "aethis.yaml").read_text()
+    assert "kind: ruleset" in content
+
+
+# --- rulebook scaffold (Part B) --------------------------------------------
+
+
+def test_init_rulebook_scaffold(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "my-rulebook", "--kind", "rulebook"])
+    assert result.exit_code == 0, result.output
+    rb = tmp_path / "my-rulebook"
+    assert "kind: rulebook" in (rb / "aethis.yaml").read_text()
+    assert (rb / "guidance" / "hints.yaml").exists()
+    assert (rb / "fields" / "fields.yaml").exists()
+    assert (rb / "tests" / "scenarios.yaml").exists()
+    assert (rb / "rulesets").is_dir()
+    # A rulebook composes rulesets; sources belong to the rulesets, not here.
+    assert not (rb / "sources").exists()
+
+
+def test_init_ruleset_kind_has_sources(tmp_path, monkeypatch):
+    """--kind ruleset reproduces today's flat layout (sources present)."""
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "flat-rs", "--kind", "ruleset"])
+    assert result.exit_code == 0, result.output
+    proj = tmp_path / "flat-rs"
+    assert (proj / "sources").is_dir()
+    assert (proj / "fields" / "fields.yaml").exists()
+
+
+def test_init_rejects_invalid_kind(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with _patch_auth_present():
+        result = runner.invoke(app, ["init", "bad-kind", "--kind", "widget"])
+    assert result.exit_code != 0
+    assert "kind" in result.output.lower()
+
+
 def test_init_yaml_has_project_name(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     with _patch_auth_present():


### PR DESCRIPTION
Closes Aethis-ai/aethis-cli#65 · Phase 1 of epic Aethis-ai/aethis-core#196

## Why
Field definitions had no home in an authored project — the vocabulary only surfaced
implicitly as the `inputs:` keys inside `tests/scenarios.yaml` (the "fields live in the
tests dir" report). This gives fields a first-class home and lets the CLI scaffold a
rulebook whose shared guidance + field vocabulary propagate down into its rulesets.

## What
- **`aethis init`** scaffolds `fields/fields.yaml` (key + `type` + optional
  `label`/`question`/`hints`).
- **`aethis init --kind rulebook`** scaffolds a rulebook (shared `guidance/` + `fields/`
  + `rulesets/`). `--kind` defaults to `ruleset`, so existing behaviour is unchanged.
- **`aethis generate`** reads `fields/fields.yaml`, pins keys/types via the project
  field-spec endpoint, and routes label/question/hints through guidance. For a ruleset
  under a rulebook (`<rulebook>/rulesets/<ruleset>/`) it propagates the rulebook's
  guidance + fields — **rulebook wins on shared keys** — so a common field (e.g. date of
  birth) is defined once and the user is asked once.
- **`AethisClient.set_field_spec()`** — endpoint already served by aethis-core (used by
  the MCP server). **No engine change required.**

## Decisions
- Rulebook wins on everything for shared fields.
- Field definitions live in a dedicated `fields/fields.yaml`.

## Blast radius
aethis-cli only — no engine/API change, no deploy. Existing rulebooks/rulesets and all
downstream consumers (SDKs, MCP, ok_swift, tda-server, API callers) are unaffected. New
scaffold files appear only in new projects; `generate` reads `fields/fields.yaml` only if
present; `--kind` defaults to `ruleset`. The only opt-in downstream effect is a deliberate
re-publish of an existing rulebook with a populated `fields.yaml`.

## Tests
- New scaffold tests (ruleset `fields/` home, `--kind rulebook` tree, invalid kind) and
  generate-time field-vocabulary tests (parse, rulebook-wins merge, guidance derivation).
- Full suite green except 6 pre-existing failures on `main` (ANSI-color/text-wrap
  assertions in account/auth/guidance/id_utils — unrelated to this change).
- Version bump v0.20.0 → v0.21.0 + CHANGELOG.

## Follow-up
- Docs (mintlify) — separate downstream PR gated on v0.21.0 publishing (`aethis-needs: aethis-cli >= 0.21.0`).