### PR TITLE
feat(rulebooks): robot_hints in rulebook.yaml → create/set-logic (v0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.23.0 (2026-06-25)
+
+- **feat(rulebooks): declare `robot_hints:` in a rulebook file and push them to the engine.** Rulebook authors can now provide natural-language guidance for the conversational assistant alongside the rulebook's other configuration.
+  - **`aethis rulebooks create <name> --file rulebook.yaml`** — a new `--file`/`-f` option reads a `robot_hints:` block (a sibling of `name`/`domain`/`outcome_logic`) from a `rulebook.yaml`/`.json` and sends it on create. CLI flags still own `name`/`domain`/`slug`/`description`; only the hints are taken from the file. No `--file` (or a file without a `robot_hints:` key) is a clean no-op — behaviour is unchanged.
+  - **`aethis rulebooks set-logic <id> -f rulebook.yaml`** now also accepts a *wrapped* form: when the top-level object carries an `outcome_logic:` key, a sibling `robot_hints:` block is pushed in the same update. A bare Expr AST file (the prior shape) is still accepted unchanged.
+  - `robot_hints` is a mapping of beat-name to a natural-language string. Active beats: `general_context`, `preamble`, `session_start`, `postamble`, `session_end`, `stuck`. Reserved beats (accepted, not yet acted on): `persona`, `conversational_style`, `section_transition`. Unknown beat keys and non-string values are rejected client-side with a clear message before the round-trip.
+  - New optional `robot_hints` parameter on `AethisClient.create_rulebook()` / `update_rulebook()`; omitted from the request body when not supplied, so calls against an older engine are unaffected.
+  - Requires aethis-core with the rulebook `robot_hints` field (aethis-core#220); mid-deploy to staging at time of writing. Against an engine without it, the field is ignored/rejected server-side.
+
 ## 0.22.0 (2026-06-16)
 
 - **feat(fields): `aethis fields` is now a command group for the full field-authoring loop.** Bare `aethis fields [-b <ruleset>]` still shows a ruleset's field schema (unchanged); three subcommands manage the local `fields/fields.yaml`:

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -312,6 +312,7 @@ class AethisClient:
         slug: Optional[str] = None,
         ruleset_refs: Optional[list[dict]] = None,
         outcome_logic: Optional[dict] = None,
+        robot_hints: Optional[dict] = None,
     ) -> dict:
         body: dict[str, Any] = {
             "name": name,
@@ -324,6 +325,8 @@ class AethisClient:
             body["slug"] = slug
         if outcome_logic is not None:
             body["outcome_logic"] = outcome_logic
+        if robot_hints is not None:
+            body["robot_hints"] = robot_hints
         return self._request("POST", "/api/v1/public/rulebooks/", json=body)
 
     def list_rulebooks(self) -> list[dict]:
@@ -353,6 +356,7 @@ class AethisClient:
         ruleset_refs: Optional[list[dict]] = None,
         outcome_logic: Optional[dict] = None,
         slug: Optional[str] = None,
+        robot_hints: Optional[dict] = None,
     ) -> dict:
         body: dict[str, Any] = {}
         if name is not None:
@@ -365,6 +369,8 @@ class AethisClient:
             body["outcome_logic"] = outcome_logic
         if slug is not None:
             body["slug"] = slug
+        if robot_hints is not None:
+            body["robot_hints"] = robot_hints
         return self._request(
             "PATCH",
             f"/api/v1/public/rulebooks/{rulebook_id_or_slug}",

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -104,9 +104,7 @@ def _validate_robot_hints(raw: Any) -> dict[str, str]:
     strings only — no DSL, no field keys.
     """
     if not isinstance(raw, dict):
-        raise typer.BadParameter(
-            f"robot_hints must be a mapping of beat-name to text; got {type(raw).__name__}."
-        )
+        raise typer.BadParameter(f"robot_hints must be a mapping of beat-name to text; got {type(raw).__name__}.")
     hints: dict[str, str] = {}
     for beat, text in raw.items():
         if beat not in _KNOWN_ROBOT_HINT_BEATS:
@@ -535,9 +533,7 @@ def set_logic(
             robot_hints = _validate_robot_hints(payload["robot_hints"])
         outcome_logic = payload["outcome_logic"]
         if not isinstance(outcome_logic, dict):
-            raise typer.BadParameter(
-                "outcome_logic must be a JSON object (Expr AST), not a list or scalar."
-            )
+            raise typer.BadParameter("outcome_logic must be a JSON object (Expr AST), not a list or scalar.")
     else:
         outcome_logic = payload
 

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -71,6 +71,73 @@ def _load_yaml_or_json(path: Path) -> Any:
     return json.loads(text)
 
 
+# Robot-hint "beats" the engine consumes today, plus the reserved beats it
+# accepts but does not yet act on. Mirrors the aethis-core P1a contract
+# (aethis-core#220). Unknown keys are rejected by the engine (422); we surface
+# them client-side with a friendlier message before the round-trip.
+_ACTIVE_ROBOT_HINT_BEATS = frozenset(
+    {
+        "general_context",
+        "preamble",
+        "session_start",
+        "postamble",
+        "session_end",
+        "stuck",
+    }
+)
+_RESERVED_ROBOT_HINT_BEATS = frozenset(
+    {
+        "persona",
+        "conversational_style",
+        "section_transition",
+    }
+)
+_KNOWN_ROBOT_HINT_BEATS = _ACTIVE_ROBOT_HINT_BEATS | _RESERVED_ROBOT_HINT_BEATS
+
+
+def _validate_robot_hints(raw: Any) -> dict[str, str]:
+    """Validate a ``robot_hints:`` block: a mapping of beat-name → prose string.
+
+    Returns the validated mapping. Raises ``typer.BadParameter`` on a bad shape,
+    an unknown beat key, or a non-string value, so the CLI fails fast with a
+    clear message rather than letting the engine 422 on a typo. Natural-language
+    strings only — no DSL, no field keys.
+    """
+    if not isinstance(raw, dict):
+        raise typer.BadParameter(
+            f"robot_hints must be a mapping of beat-name to text; got {type(raw).__name__}."
+        )
+    hints: dict[str, str] = {}
+    for beat, text in raw.items():
+        if beat not in _KNOWN_ROBOT_HINT_BEATS:
+            known = ", ".join(sorted(_KNOWN_ROBOT_HINT_BEATS))
+            raise typer.BadParameter(f"robot_hints: unknown beat '{beat}'. Known beats: {known}.")
+        if not isinstance(text, str):
+            raise typer.BadParameter(
+                f"robot_hints['{beat}'] must be a natural-language string; got {type(text).__name__}."
+            )
+        hints[beat] = text
+    return hints
+
+
+def _robot_hints_from_file(file: Optional[Path]) -> Optional[dict[str, str]]:
+    """Read and validate a ``robot_hints:`` block from a rulebook YAML/JSON.
+
+    Returns ``None`` when no file is given or the file has no ``robot_hints:``
+    key, so the create/update payload omits the field entirely (clean no-op,
+    unchanged behaviour). The block is a sibling of ``name``/``domain``/
+    ``outcome_logic`` in a ``rulebook.yaml``.
+    """
+    if file is None:
+        return None
+    payload = _load_yaml_or_json(file)
+    if not isinstance(payload, dict):
+        raise typer.BadParameter(f"{file} must be a mapping (rulebook.yaml/.json), not a list or scalar.")
+    if "robot_hints" not in payload or payload["robot_hints"] is None:
+        return None
+    return _validate_robot_hints(payload["robot_hints"])
+
+
 # ============================================================================
 # rulebooks list
 # ============================================================================
@@ -199,6 +266,19 @@ def create_rulebook(
         ),
     ),
     description: Optional[str] = typer.Option(None, "--description", help="Optional description."),
+    file: Optional[Path] = typer.Option(
+        None,
+        "--file",
+        "-f",
+        exists=True,
+        readable=True,
+        help=(
+            "Optional rulebook.yaml/.json to read a 'robot_hints:' block from "
+            "(a mapping of beat-name to natural-language guidance for the "
+            "assistant). Other rulebook keys in the file are ignored by this "
+            "command; CLI flags own name/domain/slug/description."
+        ),
+    ),
 ) -> None:
     """Create a new Rulebook.
 
@@ -208,7 +288,20 @@ def create_rulebook(
         aethis rulebooks set-fields <id> -f fields.yaml
         aethis rulebooks tests add <id> -f scenario.yaml
         aethis rulesets create <rulebook> <ruleset_name>   # (Phase B.1b)
+
+    Robot hints (assistant guidance) can be declared in a ``rulebook.yaml``
+    and passed with ``--file``::
+
+        robot_hints:
+          preamble: "Greet the applicant and explain what you'll cover."
+          stuck: "If an answer is unclear, ask one focused follow-up question."
+
+    Active beats: general_context, preamble, session_start, postamble,
+    session_end, stuck. Use natural language only — no rule syntax or field
+    keys.
     """
+    robot_hints = _robot_hints_from_file(file)
+
     _cfg, client = load_client_or_fallback()
     try:
         rb = client.create_rulebook(
@@ -216,6 +309,7 @@ def create_rulebook(
             domain=domain,
             slug=slug,
             description=description,
+            robot_hints=robot_hints,
         )
     except AethisAPIError as e:
         error_panel(e)
@@ -404,6 +498,18 @@ def set_logic(
     backwards compatibility. Pass the expression as either a file
     (``--file logic.yaml``) or inline JSON (``--logic '{...}'``). Exactly
     one of the two is required.
+
+    A wrapped ``rulebook.yaml`` shape is also accepted: when the top-level
+    object carries an ``outcome_logic:`` key, that key is the Expr AST and a
+    sibling ``robot_hints:`` block (assistant guidance, beat-name → prose) is
+    pushed alongside it in the same update. This lets a single ``rulebook.yaml``
+    declare both composition and robot hints::
+
+        outcome_logic:
+          type: field_ref
+          key: single_ruleset_name
+        robot_hints:
+          preamble: "Greet the applicant and explain what you'll cover."
     """
     if (file is None) == (logic is None):
         # Either both supplied or both missing — neither is valid.
@@ -420,15 +526,33 @@ def set_logic(
     if not isinstance(payload, dict):
         raise typer.BadParameter("outcome_logic must be a JSON object (Expr AST), not a list or scalar.")
 
+    # Wrapped rulebook.yaml form: `outcome_logic:` (and optional sibling
+    # `robot_hints:`) at the top level. A bare Expr AST has a `type` key and no
+    # `outcome_logic`, so it stays the default — backwards compatible.
+    robot_hints: Optional[dict[str, str]] = None
+    if "outcome_logic" in payload:
+        if "robot_hints" in payload and payload["robot_hints"] is not None:
+            robot_hints = _validate_robot_hints(payload["robot_hints"])
+        outcome_logic = payload["outcome_logic"]
+        if not isinstance(outcome_logic, dict):
+            raise typer.BadParameter(
+                "outcome_logic must be a JSON object (Expr AST), not a list or scalar."
+            )
+    else:
+        outcome_logic = payload
+
     _cfg, client = load_client_or_fallback()
     try:
-        client.update_rulebook(rulebook, outcome_logic=payload)
+        client.update_rulebook(rulebook, outcome_logic=outcome_logic, robot_hints=robot_hints)
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
 
-    op = payload.get("operator") or payload.get("type")
-    success(f"Set outcome_logic on rulebook {rulebook} (top-level: {op})")
+    op = outcome_logic.get("operator") or outcome_logic.get("type")
+    msg = f"Set outcome_logic on rulebook {rulebook} (top-level: {op})"
+    if robot_hints:
+        msg += f" + {len(robot_hints)} robot hint(s)"
+    success(msg)
 
 
 # ============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.22.0"
+version = "0.23.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_rulebooks_cmd.py
+++ b/tests/test_rulebooks_cmd.py
@@ -140,6 +140,7 @@ def test_rulebooks_create_with_all_options(tmp_path, monkeypatch):
         domain="uk_fsm",
         slug="aethis/uk-fsm",
         description="Free school meals eligibility",
+        robot_hints=None,
     )
     assert "rb_new" in _strip(result.output)
     assert "aethis/uk-fsm" in _strip(result.output)
@@ -153,7 +154,9 @@ def test_rulebooks_create_minimal(tmp_path, monkeypatch):
     with patch("aethis_cli.client.AethisClient", return_value=client):
         result = _runner_invoke(["rulebooks", "create", "Bare bones"])
     assert result.exit_code == 0
-    client.create_rulebook.assert_called_once_with(name="Bare bones", domain="", slug=None, description=None)
+    client.create_rulebook.assert_called_once_with(
+        name="Bare bones", domain="", slug=None, description=None, robot_hints=None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -726,6 +729,225 @@ def test_tests_delete_with_yes(tmp_path, monkeypatch):
         result = _runner_invoke(["rulebooks", "tests", "delete", "rb_x", "tc_abc", "--yes"])
     assert result.exit_code == 0, result.output
     client.delete_rulebook_test_case.assert_called_once_with("rb_x", "tc_abc")
+
+
+# ---------------------------------------------------------------------------
+# rulebooks robot_hints — create --file (P1b)
+# ---------------------------------------------------------------------------
+
+
+def _robot_hints_block() -> dict:
+    """A representative robot_hints block — natural language only, no rule
+    syntax or field keys (public-surface safe)."""
+    return {
+        "preamble": "Greet the applicant and explain what you'll cover.",
+        "stuck": "If an answer is unclear, ask one focused follow-up question.",
+    }
+
+
+def test_create_threads_robot_hints_from_yaml_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    import importlib.util
+
+    if importlib.util.find_spec("yaml") is None:
+        import pytest
+
+        pytest.skip("PyYAML not installed")
+
+    rb_path = tmp_path / "rulebook.yaml"
+    rb_path.write_text(
+        "name: Community Grants\n"
+        "domain: community_grants\n"
+        "robot_hints:\n"
+        '  preamble: "Greet the applicant and explain what you\'ll cover."\n'
+        '  stuck: "If an answer is unclear, ask one focused follow-up question."\n'
+    )
+
+    client = MagicMock()
+    client.create_rulebook.return_value = {"rulebook_id": "rb_new"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(
+            ["rulebooks", "create", "Community Grants", "--domain", "community_grants", "-f", str(rb_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    _args, kwargs = client.create_rulebook.call_args
+    assert kwargs["robot_hints"] == _robot_hints_block()
+    assert kwargs["name"] == "Community Grants"
+    assert kwargs["domain"] == "community_grants"
+
+
+def test_create_threads_robot_hints_from_json_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    rb_path = tmp_path / "rulebook.json"
+    rb_path.write_text(json.dumps({"name": "x", "robot_hints": _robot_hints_block()}))
+
+    client = MagicMock()
+    client.create_rulebook.return_value = {"rulebook_id": "rb_new"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "x", "-f", str(rb_path)])
+
+    assert result.exit_code == 0, result.output
+    assert client.create_rulebook.call_args.kwargs["robot_hints"] == _robot_hints_block()
+
+
+def test_create_without_file_omits_robot_hints(tmp_path, monkeypatch):
+    """No --file -> robot_hints is omitted entirely (None), unchanged behaviour."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    client = MagicMock()
+    client.create_rulebook.return_value = {"rulebook_id": "rb_min"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "Bare bones"])
+    assert result.exit_code == 0, result.output
+    assert client.create_rulebook.call_args.kwargs["robot_hints"] is None
+
+
+def test_create_file_without_robot_hints_is_clean_noop(tmp_path, monkeypatch):
+    """A rulebook.yaml with no robot_hints: key -> robot_hints stays None."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    rb_path = tmp_path / "rulebook.json"
+    rb_path.write_text(json.dumps({"name": "x", "domain": "d"}))
+    client = MagicMock()
+    client.create_rulebook.return_value = {"rulebook_id": "rb_min"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "x", "-f", str(rb_path)])
+    assert result.exit_code == 0, result.output
+    assert client.create_rulebook.call_args.kwargs["robot_hints"] is None
+
+
+def test_create_rejects_unknown_robot_hint_beat(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    rb_path = tmp_path / "rulebook.json"
+    rb_path.write_text(json.dumps({"name": "x", "robot_hints": {"not_a_beat": "hi"}}))
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "x", "-f", str(rb_path)])
+    assert result.exit_code != 0
+    assert "unknown beat" in _strip(result.output).lower()
+    client.create_rulebook.assert_not_called()
+
+
+def test_create_accepts_reserved_robot_hint_beat(tmp_path, monkeypatch):
+    """Reserved beats (persona, conversational_style, section_transition) are
+    accepted client-side — the engine takes them even if it doesn't act yet."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    rb_path = tmp_path / "rulebook.json"
+    rb_path.write_text(json.dumps({"name": "x", "robot_hints": {"persona": "Warm and precise."}}))
+    client = MagicMock()
+    client.create_rulebook.return_value = {"rulebook_id": "rb_new"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "x", "-f", str(rb_path)])
+    assert result.exit_code == 0, result.output
+    assert client.create_rulebook.call_args.kwargs["robot_hints"] == {"persona": "Warm and precise."}
+
+
+def test_create_rejects_non_string_robot_hint_value(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    rb_path = tmp_path / "rulebook.json"
+    rb_path.write_text(json.dumps({"name": "x", "robot_hints": {"preamble": ["a", "list"]}}))
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "create", "x", "-f", str(rb_path)])
+    assert result.exit_code != 0
+    client.create_rulebook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# rulebooks robot_hints — set-logic wrapped form (P1b)
+# ---------------------------------------------------------------------------
+
+
+def test_set_logic_wrapped_form_threads_logic_and_hints(tmp_path, monkeypatch):
+    """A wrapped rulebook.yaml ({outcome_logic, robot_hints}) sends both."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    wrapped = {"outcome_logic": _logic_expr(), "robot_hints": _robot_hints_block()}
+    logic_path = tmp_path / "rulebook.json"
+    logic_path.write_text(json.dumps(wrapped))
+
+    client = MagicMock()
+    client.update_rulebook.return_value = {"rulebook_id": "rb_x"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "-f", str(logic_path)])
+
+    assert result.exit_code == 0, result.output
+    kwargs = client.update_rulebook.call_args.kwargs
+    assert kwargs["outcome_logic"] == _logic_expr()
+    assert kwargs["robot_hints"] == _robot_hints_block()
+    assert "robot hint" in _strip(result.output).lower()
+
+
+def test_set_logic_bare_expr_sends_no_robot_hints(tmp_path, monkeypatch):
+    """Backwards compat: a bare Expr AST file -> robot_hints stays None."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    logic_path = tmp_path / "logic.json"
+    logic_path.write_text(json.dumps(_logic_expr()))
+
+    client = MagicMock()
+    client.update_rulebook.return_value = {"rulebook_id": "rb_x"}
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "-f", str(logic_path)])
+
+    assert result.exit_code == 0, result.output
+    kwargs = client.update_rulebook.call_args.kwargs
+    assert kwargs["outcome_logic"] == _logic_expr()
+    assert kwargs["robot_hints"] is None
+
+
+def test_set_logic_wrapped_form_rejects_unknown_beat(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    wrapped = {"outcome_logic": _logic_expr(), "robot_hints": {"bogus": "x"}}
+    logic_path = tmp_path / "rulebook.json"
+    logic_path.write_text(json.dumps(wrapped))
+    client = MagicMock()
+    with patch("aethis_cli.client.AethisClient", return_value=client):
+        result = _runner_invoke(["rulebooks", "set-logic", "rb_x", "-f", str(logic_path)])
+    assert result.exit_code != 0
+    client.update_rulebook.assert_not_called()
+
+
+def test_client_create_rulebook_omits_robot_hints_when_none():
+    """Unit: the client builds no robot_hints key when not supplied."""
+    from aethis_cli.client import AethisClient
+
+    client = AethisClient(base_url="http://x", api_key="k")
+    captured = {}
+
+    def fake_request(method, path, **kw):
+        captured["json"] = kw.get("json")
+        return {}
+
+    client._request = fake_request  # type: ignore[assignment]
+    client.create_rulebook(name="x")
+    assert "robot_hints" not in captured["json"]
+    client.create_rulebook(name="x", robot_hints={"preamble": "hi"})
+    assert captured["json"]["robot_hints"] == {"preamble": "hi"}
+
+
+def test_client_update_rulebook_robot_hints_roundtrip():
+    from aethis_cli.client import AethisClient
+
+    client = AethisClient(base_url="http://x", api_key="k")
+    captured = {}
+
+    def fake_request(method, path, **kw):
+        captured["json"] = kw.get("json")
+        return {}
+
+    client._request = fake_request  # type: ignore[assignment]
+    client.update_rulebook("rb_x", outcome_logic={"type": "field_ref", "key": "a"})
+    assert "robot_hints" not in captured["json"]
+    client.update_rulebook("rb_x", robot_hints={"stuck": "ask again"})
+    assert captured["json"]["robot_hints"] == {"stuck": "ask again"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase **P1b** of the "Rulebook-governed agnostic Lisa" epic (#238). Lets rulebook authors declare a `robot_hints:` block in a `rulebook.yaml` and have `aethis rulebooks` push it to aethis-core, consuming the P1a contract (`robot_hints` field on `Rulebook` / create+update requests, aethis-core#220).

`robot_hints` is a mapping of beat-name → natural-language string. Active beats: `general_context`, `preamble`, `session_start`, `postamble`, `session_end`, `stuck`. Reserved (accepted, not yet acted on): `persona`, `conversational_style`, `section_transition`. Unknown beat keys and non-string values are rejected client-side with a clear message before the round-trip.

## What changed

- **`aethis rulebooks create <name> --file rulebook.yaml`** — new `--file`/`-f` option reads a `robot_hints:` block (sibling of `name`/`domain`/`outcome_logic`) and sends it on create. CLI flags still own `name`/`domain`/`slug`/`description`. No file (or a file without `robot_hints:`) is a clean no-op.
- **`aethis rulebooks set-logic <id> -f rulebook.yaml`** — now also accepts a *wrapped* form: when the top-level object carries an `outcome_logic:` key, a sibling `robot_hints:` block is pushed in the same update. A bare Expr AST file (the prior shape) is still accepted unchanged (backwards compatible).
- `AethisClient.create_rulebook()` / `update_rulebook()` gain an optional `robot_hints` param, omitted from the body when not supplied (safe against an older engine).
- Version bumped to **0.23.0** (`_version.py` + `pyproject.toml`) and CHANGELOG rolled, per public-repos rule 6.

## YAML shape

```yaml
# rulebook.yaml — robot_hints is a sibling of name/domain/outcome_logic
name: Community Grants
domain: community_grants
robot_hints:
  preamble: "Greet the applicant and explain what you'll cover."
  stuck: "If an answer is unclear, ask one focused follow-up question."
```

For `set-logic`, the wrapped form additionally carries `outcome_logic:` at the top level.

## Tests

`uv run pytest tests/test_rulebooks_cmd.py` → **47 passed**. New tests assert: YAML/JSON file → request body carries the hints; absence is a clean no-op (field omitted); unknown beat / non-string value rejected; reserved beats accepted; `set-logic` wrapped form threads both logic + hints; bare Expr AST stays hint-free; plus client-level round-trip unit tests. Real assertions on the assembled request body, no shallow field-existence mocks.

The 6 failures elsewhere in the full suite are the known pre-existing ANSI-colour-code flake (verified failing on clean `origin/main` too), unrelated to this change.

## Verification status

Parsing + threading + unit tests are complete. Live end-to-end verification against staging is **pending the aethis-core P1a deploy** (aethis-core#220 mid-deploy to staging).

Closes #69. Part of epic #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)