### PR TITLE
feat: graph command + --include-graph-overlay + engine_version (v0.26.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.26.0 (2026-07-17)
+
+- **feat(rulebooks): `aethis rulebooks graph <id>`** — fetch and render the rulebook-level ruleset-map dependency graph (field -> criterion -> group -> outcome). Prints a node-count summary + a table of nodes (id, type, the criterion's human-readable `display.sentence`, field count); `--mermaid` prints the raw Mermaid diagram source for piping into a renderer; `--output json` returns the full payload (`{rulebook_id, graph: {nodes, edges, sections, stats}, mermaid}`), including each node's `display.routes`/`display.expr` for programmatic consumers. This endpoint requires a valid API key even for a public rulebook (confirmed against the live engine) — unlike the ruleset-level graph below, there's no anonymous path. New `AethisClient.get_rulebook_graph()`.
+- **feat(rulesets): `aethis rulesets graph <ruleset_id>`** — the single-ruleset analogue, open for public rulesets with no API key required (`load_client_or_anon`). Same table/`--mermaid`/`--output json` shape. New `AethisClient.get_ruleset_graph()`.
+- **feat: `--include-graph-overlay` on `aethis decide` and `aethis rulebooks decide`** — stamps the decision's per-criterion status onto the rule-map graph, returned as a `graph_overlay` field on the response (`--output json` to inspect it). Additive request flag; a plain-text hint is printed when the overlay is present and JSON wasn't explicitly requested.
+- **feat(rulebooks): `aethis rulebooks schema` surfaces `engine_version`.** The schema response already carries the aethis-core build that served it (e.g. `aethis-core@0.45.2`); the CLI now prints it as a header line ahead of the schema payload instead of leaving it buried in the JSON.
+- Requires aethis-core 0.40.0+ (live on `api.aethis.ai` / `staging.api.aethis.ai` as of this release) for `/graph`, `include_graph_overlay`, and `engine_version` on `/schema`. `robot_hints` (shipped v0.23.0) is unaffected by this release.
+
 ## 0.25.0 (2026-07-15)
 
 - **feat: authorization errors now render the server's `hint` and the missing scope readably.** A `403 denied_missing_permission` (and `401`) previously printed the raw error object on commands that render their own errors (`projects`, `whoami`, …); the CLI now renders one clean line naming the missing permission plus, on its own dim line, the server's follow-up hint (e.g. how to request access). The top-level handler and the per-command renderer now share one formatter (`aethis_cli.output.format_error_detail` / `render_api_error`), so every command surfaces the same readable message. The hint is rendered with markup disabled (so a hint containing `[brackets]` isn't dropped) and non-string `missing_permissions` items are coerced (so a server quirk can't turn the error into a traceback).

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -389,6 +389,35 @@ class AethisClient:
     def explain_rulebook(self, rulebook_id_or_slug: str) -> dict:
         return self._request("GET", f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/explain")
 
+    def get_rulebook_graph(self, rulebook_id_or_slug: str, *, format: str = "all") -> dict:
+        """Fetch the rulebook-level ruleset-map graph (field -> criterion -> group -> outcome).
+
+        Returns ``{rulebook_id, graph: {nodes, edges, sections, stats}, mermaid}``.
+        Unlike :meth:`get_ruleset_graph`, this endpoint requires a valid API
+        key even for a public rulebook (confirmed against the live engine,
+        2026-07-17) — there is no anonymous fallback here.
+        """
+        params = {} if format == "all" else {"format": format}
+        return self._request(
+            "GET",
+            f"/api/v1/public/rulebooks/{rulebook_id_or_slug}/graph",
+            params=params,
+        )
+
+    def get_ruleset_graph(self, ruleset_id: str, *, format: str = "all") -> dict:
+        """Fetch the single-ruleset dependency graph (field -> criterion -> group -> outcome).
+
+        Returns ``{ruleset_id, slug, name, graph: {nodes}, mermaid}``. Public
+        rulesets can be inspected without an API key — pair with
+        :func:`make_anonymous_client`.
+        """
+        params = {} if format == "all" else {"format": format}
+        return self._request(
+            "GET",
+            f"/api/v1/public/rulesets/{ruleset_id}/graph",
+            params=params,
+        )
+
     # -- Rulebook fields (Phase A.6) --
 
     def set_rulebook_fields(self, rulebook_id_or_slug: str, fields: list[dict]) -> dict:

--- a/aethis_cli/commands/decide_cmd.py
+++ b/aethis_cli/commands/decide_cmd.py
@@ -27,6 +27,14 @@ def decide(
         ),
     ),
     explain: bool = typer.Option(False, "--explain", "-e", help="Show reasoning for the decision"),
+    include_graph_overlay: bool = typer.Option(
+        False,
+        "--include-graph-overlay",
+        help=(
+            "Stamp this decision's per-criterion status onto the rule-map graph "
+            "(adds a `graph_overlay` field to the response — see `aethis rulesets graph`)."
+        ),
+    ),
 ) -> None:
     """Evaluate eligibility against a published ruleset. No API key required for public rulesets.
 
@@ -35,6 +43,7 @@ def decide(
         aethis decide -b aethis/spacecraft-crew-certification -i '{"space.crew.age": 34, "space.crew.flight_hours": 900}'
         aethis decide -b my_ruleset:20260401-a1b2c3d -i '{"age": 21, "country": "UK"}'
         aethis decide -b my_ruleset:20260401-a1b2c3d --input @inputs.json --explain
+        aethis decide -b aethis/spacecraft-crew-certification -i '{...}' --include-graph-overlay --output json
         aethis decide -i '{...}'         # uses ruleset from .aethis/state.json
 
     Input is a JSON object mapping field IDs to values. Use `aethis fields -b <ruleset>`
@@ -68,6 +77,8 @@ def decide(
     if explain:
         opts["include_trace"] = True
         opts["include_explanation"] = True
+    if include_graph_overlay:
+        opts["include_graph_overlay"] = True
 
     try:
         result = client.decide(ruleset_id, field_values, **opts)
@@ -78,6 +89,9 @@ def decide(
     if is_json_requested():
         emit(result)
         return
+
+    if include_graph_overlay and result.get("graph_overlay"):
+        console.print("[dim]Graph overlay included in the response — rerun with --output json to inspect it.[/dim]")
 
     decision = result.get("decision", "unknown")
     color = {"eligible": "green", "not_eligible": "red"}.get(decision, "yellow")

--- a/aethis_cli/commands/rulebooks_cmd.py
+++ b/aethis_cli/commands/rulebooks_cmd.py
@@ -23,6 +23,7 @@ This command group covers the rulebook lifecycle and configuration:
     aethis rulebooks decide <id> -i '{"field":"value"}'
     aethis rulebooks schema <id>
     aethis rulebooks explain <id>
+    aethis rulebooks graph <id>
 """
 
 from __future__ import annotations
@@ -609,6 +610,14 @@ def decide_rulebook(
         help="YAML or JSON file with field values (alternative to --inputs).",
     ),
     explain: bool = typer.Option(False, "--explain", help="Include a human-readable explanation."),
+    include_graph_overlay: bool = typer.Option(
+        False,
+        "--include-graph-overlay",
+        help=(
+            "Stamp this decision's per-criterion status onto the rule-map graph "
+            "(adds a `graph_overlay` field to the response — see `aethis rulebooks graph`)."
+        ),
+    ),
 ) -> None:
     """Evaluate a rulebook against a set of field values.
 
@@ -616,6 +625,7 @@ def decide_rulebook(
 
         aethis rulebooks decide aethis/uk-fsm -i '{"applicant.age": 6}'
         aethis rulebooks decide aethis/uk-fsm --input-file persona.yaml --explain
+        aethis rulebooks decide aethis/uk-fsm -i '{...}' --include-graph-overlay --output json
     """
     if inputs is None and input_file is None:
         raise typer.BadParameter("Provide field values via --inputs / -i or --input-file.")
@@ -642,10 +652,15 @@ def decide_rulebook(
         opts: dict[str, Any] = {}
         if explain:
             opts["include_explanation"] = True
+        if include_graph_overlay:
+            opts["include_graph_overlay"] = True
         result = client.decide_rulebook(rulebook, field_values, **opts)
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+
+    if include_graph_overlay and not is_json_requested() and result.get("graph_overlay"):
+        console.print("[dim]Graph overlay included in the response — rerun with --output json to inspect it.[/dim]")
 
     emit(result)
 
@@ -659,13 +674,24 @@ def decide_rulebook(
 def schema_rulebook(
     rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
 ) -> None:
-    """Print the combined field schema across all live rulesets."""
+    """Print the combined field schema across all live rulesets.
+
+    The response carries `engine_version` (the aethis-core build that served
+    it, e.g. "aethis-core@0.45.2") — printed as a header line here, and always
+    present in the underlying JSON (`--output json` / piped output).
+    """
     _cfg, client = load_client_or_fallback()
     try:
         result = client.get_rulebook_schema(rulebook)
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+
+    if not is_json_requested():
+        engine_version = result.get("engine_version")
+        if engine_version:
+            console.print(f"[dim]Engine: {engine_version}[/dim]")
+
     emit(result)
 
 
@@ -681,6 +707,95 @@ def explain_rulebook(
         error_panel(e)
         raise typer.Exit(code=1)
     emit(result)
+
+
+# ============================================================================
+# rulebooks graph
+# ============================================================================
+
+
+def _build_graph_nodes_table(nodes: list[dict], title: str) -> Table:
+    table = Table(title=title)
+    table.add_column("ID", style="cyan")
+    table.add_column("Type")
+    table.add_column("Label / rule text")
+    table.add_column("Fields", justify="right")
+    for n in nodes:
+        display = n.get("display") or {}
+        text = display.get("sentence") or n.get("label") or n.get("title") or "[dim]—[/dim]"
+        table.add_row(
+            n.get("id", ""),
+            n.get("type", ""),
+            text,
+            str(len(n.get("fields", []) or [])),
+        )
+    return table
+
+
+@rulebooks_app.command(name="graph")
+def graph_rulebook(
+    rulebook: str = typer.Argument(..., help="Rulebook ID or slug."),
+    mermaid: bool = typer.Option(
+        False,
+        "--mermaid",
+        help="Print only the raw Mermaid diagram source (pipe into a Mermaid renderer).",
+    ),
+) -> None:
+    """Show the ruleset-map dependency graph: field -> criterion -> group -> outcome.
+
+    Each criterion node carries a human-readable `display.sentence` (shown in
+    the summary table below) plus `display.routes`/`display.expr` for
+    programmatic consumers — full detail via `--output json`.
+
+    Note: this endpoint requires a valid API key even for a public rulebook
+    (unlike `aethis rulesets graph`, which is open for public rulesets) — run
+    `aethis login` first if you see a 401.
+
+    Examples::
+
+        aethis rulebooks graph aethis/uk-fsm
+        aethis rulebooks graph aethis/uk-fsm --mermaid
+        aethis rulebooks graph aethis/uk-fsm --output json
+    """
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.get_rulebook_graph(rulebook)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    if mermaid:
+        diagram = result.get("mermaid")
+        if not diagram:
+            console.print("[dim]No Mermaid diagram in the response.[/dim]")
+            raise typer.Exit(code=1)
+        print(diagram)
+        return
+
+    if is_json_requested():
+        emit(result)
+        return
+
+    graph = result.get("graph") or {}
+    nodes = graph.get("nodes", []) or []
+    stats = graph.get("stats") or {}
+
+    console.print(f"[bold]Graph[/bold] — {rulebook}")
+    if stats:
+        console.print(
+            f"  fields: {stats.get('total_fields', 0)}  ·  "
+            f"criteria: {stats.get('total_criteria', 0)}  ·  "
+            f"groups: {stats.get('total_groups', 0)}  ·  "
+            f"sections: {stats.get('sections', len(graph.get('sections', []) or []))}"
+        )
+
+    if not nodes:
+        console.print("[dim]No graph nodes yet — add rulesets or `set-logic` first.[/dim]")
+        return
+
+    console.print(_build_graph_nodes_table(nodes, title=f"Nodes — {rulebook}"))
+    if result.get("mermaid"):
+        console.print("\n[dim]Mermaid diagram available — rerun with --mermaid to print it.[/dim]")
 
 
 # ============================================================================

--- a/aethis_cli/commands/rulesets_cmd.py
+++ b/aethis_cli/commands/rulesets_cmd.py
@@ -18,7 +18,7 @@ from rich.table import Table
 
 from aethis_cli.client import make_anonymous_client
 from aethis_cli.commands._id_utils import require_ruleset_id
-from aethis_cli.config import load_client_or_fallback, resolve_base_url_with_source
+from aethis_cli.config import load_client_or_anon, load_client_or_fallback, resolve_base_url_with_source
 from aethis_cli.errors import AethisAPIError
 from aethis_cli.output import console, error_panel, success, warn
 from aethis_cli.prompts import confirm_or_abort
@@ -361,6 +361,78 @@ def promote_ruleset(
     if prior:
         console.print(f"  prior live archived: [dim]{prior}[/dim]")
     console.print(f"  cut reason: [dim]{resp.get('cut_reason')}[/dim]")
+
+
+def _build_ruleset_graph_nodes_table(nodes: list[dict], title: str) -> Table:
+    table = Table(title=title)
+    table.add_column("ID", style="cyan")
+    table.add_column("Type")
+    table.add_column("Label / rule text")
+    table.add_column("Fields", justify="right")
+    for n in nodes:
+        display = n.get("display") or {}
+        text = display.get("sentence") or n.get("label") or n.get("title") or "[dim]—[/dim]"
+        table.add_row(
+            n.get("id", ""),
+            n.get("type", ""),
+            text,
+            str(len(n.get("fields", []) or [])),
+        )
+    return table
+
+
+@rulesets_app.command(name="graph")
+def graph_ruleset(
+    ruleset_id: str = typer.Argument(..., help="Ruleset ID (e.g. example_ruleset:20260408-abc1234)."),
+    mermaid: bool = typer.Option(
+        False,
+        "--mermaid",
+        help="Print only the raw Mermaid diagram source (pipe into a Mermaid renderer).",
+    ),
+) -> None:
+    """Show a single ruleset's dependency graph: field -> criterion -> group -> outcome.
+
+    The single-ruleset (one-section) analogue of `aethis rulebooks graph`. No
+    API key required for a public ruleset.
+
+    Examples::
+
+        aethis rulesets graph construction-all-risks:20260412-gold
+        aethis rulesets graph construction-all-risks:20260412-gold --mermaid
+        aethis rulesets graph construction-all-risks:20260412-gold --output json
+    """
+    require_ruleset_id(ruleset_id)
+    _cfg, client = load_client_or_anon()
+    try:
+        result = client.get_ruleset_graph(ruleset_id)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    if mermaid:
+        diagram = result.get("mermaid")
+        if not diagram:
+            console.print("[dim]No Mermaid diagram in the response.[/dim]")
+            raise typer.Exit(code=1)
+        print(diagram)
+        return
+
+    if is_json_requested():
+        emit(result)
+        return
+
+    nodes = (result.get("graph") or {}).get("nodes", []) or []
+    console.print(f"[bold]Graph[/bold] — {result.get('name') or ruleset_id}")
+    if result.get("slug"):
+        console.print(f"  slug: [cyan]{result['slug']}[/cyan]")
+
+    if not nodes:
+        console.print("[dim]No graph nodes in this ruleset.[/dim]")
+        return
+
+    console.print(_build_ruleset_graph_nodes_table(nodes, title=f"Nodes — {ruleset_id}"))
+    if result.get("mermaid"):
+        console.print("\n[dim]Mermaid diagram available — rerun with --mermaid to print it.[/dim]")
 
 
 @rulesets_app.command(name="archive")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.25.0"
+version = "0.26.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
<!-- aethis-needs: aethis-core (live 0.45.2 on api.aethis.ai) -->

Closes aethis-cli#71. Part of the [aethis-core 0.40 authoring-surface propagation epic](https://github.com/Aethis-ai/aethis-workspace/issues/327). Spec: `docs/specs/2026-06-30-aethis-core-0.40-authoring-surface-propagation.md` (workspace repo).

**Deploy gate already green**: `api.aethis.ai` / `staging.api.aethis.ai` both serve `0.45.2` (verified `info.version` at `/openapi.json`, plus `/graph`, `graph_overlay`, and `engine_version` all confirmed live before writing any code).

## What shipped

1. **`aethis rulebooks graph <id>`** — fetches `/api/v1/public/rulebooks/{id}/graph` and renders a node-count summary + a table (id, type, the criterion's human-readable `display.sentence`, field count). `--mermaid` prints the raw Mermaid diagram source; `--output json` returns the full payload. **Finding:** this endpoint requires a valid API key even for a *public* rulebook (confirmed live — anonymous gets `401 missing_api_key`, and a different tenant's key gets `404` rather than the content) — there's no anonymous path at the rulebook level, unlike ruleset-level graph. `aethis rulebooks graph` therefore uses the same authenticated `load_client_or_fallback()` pattern as `schema`/`show`.
2. **`aethis rulesets graph <ruleset_id>`** — the single-ruleset analogue, which genuinely *is* open for public rulesets with **no API key** (confirmed live). Added so the new `AethisClient.get_ruleset_graph()` client method isn't dead code, and so public-showcase graph browsing works with zero setup — the more useful command for a first-time visitor.
3. **`--include-graph-overlay`** on `aethis decide` and `aethis rulebooks decide` — threads through to the request body; the response's `graph_overlay` field is confirmed populated live (27 stamped nodes on a real round-trip below). A one-line hint is printed in table mode pointing at `--output json`.
4. **`aethis rulebooks schema`** now prints the response's `engine_version` (e.g. `aethis-core@0.45.2`) as a header line ahead of the payload — it was already in the JSON, just not surfaced for a human reading table output.
5. Version `0.25.0` → `0.26.0` (minor, additive) + `CHANGELOG.md` rolled in this commit.

`robot_hints` (aethis-core#220) already shipped in v0.23.0 (PR #70) and is **untouched** by this PR.

## Live round-trip proof (staging.api.aethis.ai + api.aethis.ai, engine 0.45.2)

Ran via the CLI itself (`uv run aethis ...`), using a real key minted through the existing staging-integration harness (`tests/integration/staging_auth.py`), revoked after testing:

- `aethis rulebooks graph <id>` on an owned rulebook — JSON shape confirmed `{rulebook_id, graph: {nodes, edges, sections, stats}, mermaid}`; `--mermaid` prints clean diagram source.
- `aethis rulesets graph construction-all-risks:20260412-gold` (anonymous, public showcase) — rendered a real 27-node table (criterion/group/field/outcome types) with correct `display.sentence` text, no errors.
- `aethis decide -b aethis/spacecraft-crew-certification --include-graph-overlay --output json` (anonymous) — response carried a populated `graph_overlay` with 27 stamped nodes.
- `aethis rulebooks schema <id>` — printed `Engine: aethis-core@0.45.2` header line ahead of the JSON payload.
- `aethis rulebooks decide <id> --include-graph-overlay` against an empty (no live rulesets) rulebook correctly surfaced the server's `rulebook_no_sections` 422 — proves the flag reaches the server and is threaded correctly through the same code path proven to work at the ruleset level.

## Tests

`uv run pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`: 324 passed, same 5 pre-existing local ANSI-rendering flakes present identically on a clean `main` checkout (verified via `git stash`/`git stash pop` — unrelated to this change; matches the known local-flake class documented elsewhere in the workspace). `ruff check` clean on all touched files.

## Not in scope

- `aethis-mcp`, `aethis-sdk-python`, `aethis-examples`, `mintlify-docs`, `aethis-core` version/tag hygiene — separate sub-issues of workspace epic #327.