### PR TITLE
feat: aethis review — Authoring Coach report (+ X-Aethis-Client header)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.27.0 (2026-07-19)
+
+- **feat: `aethis review [<project>]`** — the Authoring Coach report for a project. Runs the server-side rubric and prints an authoring score, 2–3 evidence-cited strengths, and the single highest-leverage next improvement (with its docs link and the lever that fixes it). Defaults to the current project in `.aethis/state.json`; pass a `proj_…` id to review any of your projects from anywhere. `--verbose` shows the full per-check table; `--json` (and any piped/`--output json` invocation) emits the raw `ReviewReport`. The deterministic report needs only your API key; `--coach` opts into LLM mentoring prose billed to your own Anthropic key (`ANTHROPIC_API_KEY`). Advisory only — the exit code is always 0 regardless of score. New `AethisClient.review()`.
+- **feat: every request now sends `X-Aethis-Client: cli/<version>`** so the server can attribute per-surface telemetry (CLI vs MCP). The header carries no credentials and no PII, and is set once at client construction for all commands.
+- Requires aethis-core with the `/api/v1/public/projects/{id}/review` endpoint live (epic aethis-workspace#514, P1). The public release of this version is held until that endpoint is live on `api.aethis.ai`.
+
 ## 0.26.0 (2026-07-17)
 
 - **feat(rulebooks): `aethis rulebooks graph <id>`** — fetch and render the rulebook-level ruleset-map dependency graph (field -> criterion -> group -> outcome). Prints a node-count summary + a table of nodes (id, type, the criterion's human-readable `display.sentence`, field count); `--mermaid` prints the raw Mermaid diagram source for piping into a renderer; `--output json` returns the full payload (`{rulebook_id, graph: {nodes, edges, sections, stats}, mermaid}`), including each node's `display.routes`/`display.expr` for programmatic consumers. This endpoint requires a valid API key even for a public rulebook (confirmed against the live engine) — unlike the ruleset-level graph below, there's no anonymous path. New `AethisClient.get_rulebook_graph()`.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Optional
 
 import httpx
 
+from aethis_cli._version import __version__
 from aethis_cli.auth_providers import AuthProvider, ProviderContext, get_provider
 from aethis_cli.errors import AethisAPIError
 
@@ -43,6 +44,10 @@ class AethisClient:
             profile=profile or {},
         )
         headers: dict[str, str] = dict(auth_provider(ctx))
+        # Per-surface telemetry: identify the calling client + its version so the
+        # server can attribute `/review` (and future) records to `cli` vs `mcp`.
+        # Always sent — the header carries no credentials and no PII.
+        headers["X-Aethis-Client"] = f"cli/{__version__}"
         if anthropic_key:
             headers["X-Anthropic-Key"] = anthropic_key
         self._auth_provider = auth_provider
@@ -239,6 +244,21 @@ class AethisClient:
 
     def run_tests(self, project_id: str) -> dict:
         return self._request("POST", f"/api/v1/public/projects/{project_id}/test-run")
+
+    def review(self, project_id: str, *, coach: bool = False) -> dict:
+        """Run the Authoring Coach rubric over a project.
+
+        Returns the deterministic ``ReviewReport`` (objective checks, a
+        reproducible score, and the single author-actionable ``next_skill``).
+        ``coach=True`` opts into LLM mentoring prose — the server requires the
+        author's own ``X-Anthropic-Key`` (set at client construction) for
+        external keys; the deterministic report needs no key.
+        """
+        return self._request(
+            "POST",
+            f"/api/v1/public/projects/{project_id}/review",
+            json={"coach": coach},
+        )
 
     def publish(
         self,

--- a/aethis_cli/commands/review_cmd.py
+++ b/aethis_cli/commands/review_cmd.py
@@ -1,0 +1,204 @@
+"""aethis review — the Authoring Coach report for a project.
+
+Thin CLI over ``POST /api/v1/public/projects/{id}/review``. The deterministic
+report (objective checks, a reproducible score, the single author-actionable
+``next_skill``) needs only your API key. ``--coach`` opts into LLM mentoring
+prose on your own Anthropic key.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import typer
+from rich.table import Table
+
+from aethis_cli.config import (
+    ProjectConfig,
+    load_project_config,
+    make_authed_client,
+    resolve_anthropic_key,
+    resolve_api_key,
+    resolve_base_url_with_source,
+)
+from aethis_cli.errors import AethisAPIError, ConfigError
+from aethis_cli.output import console, error_panel, warn
+from aethis_cli.render import is_json_requested
+
+
+def review(
+    project_id: Optional[str] = typer.Argument(
+        None,
+        help="Project ID (proj_…). Defaults to the current project in .aethis/state.json.",
+    ),
+    coach: bool = typer.Option(
+        False,
+        "--coach",
+        help="Add LLM coaching prose (opt-in, billed to your own Anthropic key via ANTHROPIC_API_KEY).",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw ReviewReport as JSON (pipe-friendly).",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show the full per-check table, not just the headline + next step.",
+    ),
+) -> None:
+    """Review a project against the Authoring Coach rubric.
+
+    Prints an authoring score, a couple of evidence-cited strengths, and the
+    single highest-leverage next improvement. Advisory only — the exit code is
+    always 0 regardless of score.
+
+    Examples:
+
+        aethis review                       # review the current project dir
+        aethis review proj_abc123           # review a specific project
+        aethis review --coach               # add LLM mentoring prose
+        aethis review --json | jq .score    # machine-readable report
+        aethis review --verbose             # full per-check breakdown
+    """
+    try:
+        cfg = load_project_config()
+    except ConfigError:
+        # Allow reviewing any project by id from outside a project dir.
+        if not project_id:
+            console.print(
+                "[red]No project.[/red] Pass a project id (proj_…) or run from a "
+                "project directory where `aethis generate` has been run."
+            )
+            raise typer.Exit(code=1)
+        base_url, _ = resolve_base_url_with_source()
+        cfg = ProjectConfig(project="", base_url=base_url)
+
+    pid = project_id or cfg.project_id
+    if not pid:
+        console.print("[red]No project id.[/red] Pass a project id, or run `aethis generate` in this directory first.")
+        raise typer.Exit(code=1)
+
+    try:
+        api_key = resolve_api_key(cfg)
+    except ConfigError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1)
+
+    anthropic_key = resolve_anthropic_key(cfg) if coach else None
+    if coach and not anthropic_key:
+        warn(
+            "--coach needs an Anthropic key (set ANTHROPIC_API_KEY). Proceeding: "
+            "internal keys use the server key; external keys will get a 400."
+        )
+
+    client = make_authed_client(api_key, cfg.base_url, anthropic_key=anthropic_key)
+
+    try:
+        report = client.review(pid, coach=coach)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    if json_out or is_json_requested():
+        # Raw ReviewReport — plain `print` so pipes see clean bytes, no ANSI.
+        print(json.dumps(report, indent=2, default=str))
+        return
+
+    _render_report(report, verbose=verbose)
+
+
+def _score_colour(score: Optional[int]) -> str:
+    """Green ≥80, yellow ≥50, red below — a plain heuristic for the headline."""
+    if score is None:
+        return "yellow"
+    if score >= 80:
+        return "green"
+    if score >= 50:
+        return "yellow"
+    return "red"
+
+
+def _render_report(report: dict, *, verbose: bool) -> None:
+    """Human render: headline · strengths · the single next step · (optional) table."""
+    score = report.get("score")
+    completeness = report.get("data_completeness", "ok")
+    strengths = report.get("strengths") or []
+    next_skill = report.get("next_skill")
+    coaching = report.get("coaching")
+    checks = report.get("checks") or []
+
+    # Headline — score, with a friendly empty state for thin projects.
+    if completeness == "thin":
+        console.print("\n[bold]Authoring review[/bold] — [yellow]just getting started[/yellow]")
+        console.print("[dim]Not enough in this project to score yet.[/dim]")
+    else:
+        colour = _score_colour(score)
+        score_txt = f"{score}/100" if score is not None else "n/a"
+        console.print(f"\n[bold]Authoring review[/bold] — score [bold {colour}]{score_txt}[/bold {colour}]")
+
+    # Strengths (evidence-cited; the server sends the phrasing).
+    if strengths:
+        console.print("\n[bold]Strengths[/bold]")
+        for s in strengths[:3]:
+            console.print(f"  [green]✓[/green] {s}")
+
+    # The single highest-leverage, author-actionable next step.
+    if next_skill:
+        console.print("\n[bold]Do this next[/bold]")
+        message = next_skill.get("message", "")
+        if message:
+            console.print(f"  {message}")
+        lever = next_skill.get("actionable_via")
+        if lever:
+            console.print(f"  [dim]via {lever}[/dim]")
+        docs = next_skill.get("docs_url")
+        if docs:
+            console.print(f"  [dim]{docs}[/dim]")
+    elif completeness != "thin":
+        console.print("\n[green]No higher-leverage improvement to suggest — nice work.[/green]")
+
+    # LLM coaching prose (only present with --coach).
+    if coaching:
+        console.print("\n[bold]Coaching[/bold]")
+        console.print(coaching, markup=False)
+
+    # Full per-check table on --verbose; otherwise a one-line pointer.
+    if checks:
+        if verbose:
+            _print_check_table(checks)
+        else:
+            console.print(
+                f"\n[dim]{len(checks)} checks evaluated. Run with --verbose for the full "
+                "table, or --json for the raw report.[/dim]"
+            )
+
+
+_CHECK_STATUS = {
+    "pass": "[green]PASS[/green]",
+    "warn": "[yellow]WARN[/yellow]",
+    "fail": "[red]FAIL[/red]",
+    "na": "[dim]n/a[/dim]",
+    "info": "[cyan]info[/cyan]",
+}
+
+
+def _print_check_table(checks: list) -> None:
+    """Render every rubric check with its status, group, and evidence."""
+    table = Table(title="Checks", show_lines=False, expand=False)
+    table.add_column("Check", style="bold", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Group", no_wrap=True)
+    table.add_column("Evidence")
+    for c in checks:
+        status = c.get("status", "")
+        table.add_row(
+            c.get("id", ""),
+            _CHECK_STATUS.get(status, status),
+            c.get("group", ""),
+            c.get("evidence", "") or c.get("why", ""),
+        )
+    console.print()
+    console.print(table)

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -29,6 +29,7 @@ from aethis_cli.commands.refine_cmd import refine
 from aethis_cli.commands.status_cmd import status
 from aethis_cli.commands.test_cmd import test
 from aethis_cli.commands.publish_cmd import publish
+from aethis_cli.commands.review_cmd import review
 from aethis_cli.commands.fields_cmd import fields_app
 from aethis_cli.commands.explain_cmd import explain
 from aethis_cli.commands.decide_cmd import decide
@@ -181,6 +182,7 @@ app.command()(refine)
 app.command()(status)
 app.command(name="test")(test)
 app.command()(publish)
+app.command()(review)
 app.command()(explain)
 app.command()(decide)
 app.command()(whoami)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.26.0"
+version = "0.27.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -318,3 +318,59 @@ def test_non_json_error_body(respx_mock):
     with pytest.raises(AethisAPIError) as exc_info:
         AethisClient("ak", BASE).decide("b:1", {})
     assert exc_info.value.status_code == 500
+
+
+# ============================================================================
+# Authoring Coach — /review + the X-Aethis-Client telemetry header
+# ============================================================================
+
+
+@respx.mock(base_url=BASE)
+def test_review_posts_deterministic_body(respx_mock):
+    """Default review: POST to the project's /review with coach=false."""
+    route = respx_mock.post("/api/v1/public/projects/proj_abc/review").mock(
+        return_value=httpx.Response(200, json={"project_id": "proj_abc", "rubric_version": "1", "score": 72})
+    )
+    result = AethisClient("ak_live_x", BASE).review("proj_abc")
+    assert result["score"] == 72
+    body = json.loads(route.calls[0].request.content)
+    assert body == {"coach": False}
+
+
+@respx.mock(base_url=BASE)
+def test_review_coach_sends_anthropic_key(respx_mock):
+    """coach=True + a constructed anthropic key => X-Anthropic-Key on the wire
+    and coach=true in the body."""
+    route = respx_mock.post("/api/v1/public/projects/proj_abc/review").mock(
+        return_value=httpx.Response(200, json={"project_id": "proj_abc", "rubric_version": "1"})
+    )
+    client = AethisClient("ak_live_x", BASE, anthropic_key="sk-ant-secret")
+    client.review("proj_abc", coach=True)
+    req = route.calls[0].request
+    assert req.headers["x-anthropic-key"] == "sk-ant-secret"
+    assert json.loads(req.content) == {"coach": True}
+
+
+@respx.mock(base_url=BASE)
+def test_review_sends_client_id_header(respx_mock):
+    """Every /review carries X-Aethis-Client: cli/<version> for telemetry."""
+    from aethis_cli._version import __version__
+
+    route = respx_mock.post("/api/v1/public/projects/proj_abc/review").mock(
+        return_value=httpx.Response(200, json={"project_id": "proj_abc", "rubric_version": "1"})
+    )
+    AethisClient("ak_live_x", BASE).review("proj_abc")
+    assert route.calls[0].request.headers["x-aethis-client"] == f"cli/{__version__}"
+
+
+@respx.mock(base_url=BASE)
+def test_client_id_header_sent_on_every_request(respx_mock):
+    """The client-id header isn't review-specific — it rides every call so the
+    server can attribute per-surface telemetry (regression guard)."""
+    from aethis_cli._version import __version__
+
+    route = respx_mock.post("/api/v1/public/decide").mock(
+        return_value=httpx.Response(200, json={"decision": "eligible"})
+    )
+    AethisClient("ak_live_x", BASE).decide("b:1", {})
+    assert route.calls[0].request.headers["x-aethis-client"] == f"cli/{__version__}"

--- a/tests/test_review_cmd.py
+++ b/tests/test_review_cmd.py
@@ -1,0 +1,193 @@
+"""Tests for `aethis review` — the Authoring Coach report render + flag plumbing.
+
+The command is a thin client over `POST /projects/{id}/review`; these tests mock
+the authed client so they exercise resolution, flag handling, and the human /
+JSON render without a network or a real key.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _report(**overrides) -> dict:
+    """A representative ReviewReport (mirrors aethis-core's response model)."""
+    base = {
+        "project_id": "proj_abc",
+        "rubric_version": "1.0.0",
+        "score": 72,
+        "data_completeness": "ok",
+        "checks": [
+            {
+                "id": "G1",
+                "group": "grounding",
+                "audience": "author",
+                "actionable_via": "sources",
+                "status": "pass",
+                "evidence": "3 sources cited",
+                "weight": 3,
+                "scored": True,
+                "why": "Rules trace back to source text.",
+                "docs_url": "https://docs.aethis.ai/authoring/review-checks#g1",
+            },
+            {
+                "id": "P2",
+                "group": "process",
+                "audience": "author",
+                "actionable_via": "tests",
+                "status": "warn",
+                "evidence": "4 test cases",
+                "weight": 2,
+                "scored": True,
+                "why": "More edge cases would raise confidence.",
+                "docs_url": "https://docs.aethis.ai/authoring/review-checks#p2",
+            },
+        ],
+        "strengths": ["Every rule cites a source", "Deterministic test suite is green"],
+        "next_skill": {
+            "check_id": "P2",
+            "message": "Add a few boundary test cases to pin the edges.",
+            "actionable_via": "tests",
+            "docs_url": "https://docs.aethis.ai/authoring/review-checks#p2",
+        },
+        "coaching": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _run(args, report, monkeypatch, tmp_path, *, capture_client=None):
+    """Invoke `aethis review` with a mocked authed client returning `report`."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AETHIS_API_KEY", "ak_test")
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.delenv("AETHIS_BASE_URL", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty_xdg"))
+
+    client = MagicMock()
+    client.review.return_value = report
+
+    def _fake_make_authed_client(api_key, base_url, **kwargs):
+        if capture_client is not None:
+            capture_client["api_key"] = api_key
+            capture_client["base_url"] = base_url
+            capture_client.update(kwargs)
+        return client
+
+    from aethis_cli.main import app
+
+    with patch("aethis_cli.commands.review_cmd.make_authed_client", _fake_make_authed_client):
+        runner = CliRunner()
+        result = runner.invoke(app, ["review"] + args, catch_exceptions=False)
+    return result, client
+
+
+def test_review_default_render(tmp_path, monkeypatch):
+    """Default render: score headline, strengths, and the single next step."""
+    result, client = _run(["proj_abc"], _report(), monkeypatch, tmp_path)
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "72/100" in out
+    # Strengths (2-3, evidence-cited).
+    assert "Every rule cites a source" in out
+    # The single next skill: its message + docs link.
+    assert "Add a few boundary test cases" in out
+    assert "docs.aethis.ai/authoring/review-checks#p2" in out
+    # Default (no --coach) sent coach=false.
+    client.review.assert_called_once_with("proj_abc", coach=False)
+
+
+def test_review_json_is_parseable(tmp_path, monkeypatch):
+    """--json emits the raw ReviewReport as valid, parseable JSON."""
+    result, _ = _run(["proj_abc", "--json"], _report(), monkeypatch, tmp_path)
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["project_id"] == "proj_abc"
+    assert payload["score"] == 72
+    assert payload["next_skill"]["check_id"] == "P2"
+
+
+def test_review_thin_project_empty_state(tmp_path, monkeypatch):
+    """A thin project degrades to a friendly 'just getting started' render with
+    no score and the server's 'add a source' next step — never a crash."""
+    thin = _report(
+        score=None,
+        data_completeness="thin",
+        strengths=[],
+        next_skill={
+            "check_id": "G1",
+            "message": "Add a source document to begin.",
+            "actionable_via": "sources",
+            "docs_url": "https://docs.aethis.ai/authoring/review-checks#g1",
+        },
+    )
+    result, _ = _run(["proj_abc"], thin, monkeypatch, tmp_path)
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "just getting started" in out
+    assert "Add a source document to begin." in out
+    assert "Traceback" not in out
+
+
+def test_review_low_score_still_exit_zero(tmp_path, monkeypatch):
+    """Advisory tool: even a low score exits 0 (never a merge gate)."""
+    result, _ = _run(["proj_abc"], _report(score=12), monkeypatch, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "12/100" in _strip(result.output)
+
+
+def test_review_verbose_shows_check_table(tmp_path, monkeypatch):
+    """--verbose renders the full per-check table (check ids + statuses)."""
+    result, _ = _run(["proj_abc", "--verbose"], _report(), monkeypatch, tmp_path)
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "G1" in out
+    assert "P2" in out
+    assert "PASS" in out
+    assert "WARN" in out
+
+
+def test_review_coach_plumbs_anthropic_key(tmp_path, monkeypatch):
+    """--coach with ANTHROPIC_API_KEY set builds the client with the key and
+    calls review(coach=True)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    captured: dict = {}
+    result, client = _run(
+        ["proj_abc", "--coach"],
+        _report(coaching="You're close — a couple of edge tests will seal it."),
+        monkeypatch,
+        tmp_path,
+        capture_client=captured,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured.get("anthropic_key") == "sk-ant-test"
+    client.review.assert_called_once_with("proj_abc", coach=True)
+    assert "You're close" in _strip(result.output)
+
+
+def test_review_coach_without_key_warns_but_proceeds(tmp_path, monkeypatch):
+    """--coach with no Anthropic key warns (internal keys still work) and still
+    issues the request rather than failing fast."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    captured: dict = {}
+    result, client = _run(["proj_abc", "--coach"], _report(), monkeypatch, tmp_path, capture_client=captured)
+
+    assert result.exit_code == 0, result.output
+    assert captured.get("anthropic_key") is None
+    client.review.assert_called_once_with("proj_abc", coach=True)
+    assert "Anthropic key" in _strip(result.output)


### PR DESCRIPTION
Implements **P2** of the Authoring Coach epic — Aethis-ai/aethis-workspace#514. Closes Aethis-ai/aethis-cli#78.

## What

`aethis review [<project>]` — a thin CLI over `POST /api/v1/public/projects/{id}/review`. It prints an authoring score, 2–3 evidence-cited strengths, and the single highest-leverage, author-actionable next step (with its docs link + the lever that fixes it). Defaults to the current project in `.aethis/state.json`; pass a `proj_…` id to review any of your projects from anywhere.

- `--verbose` renders the full per-check table.
- `--json` (and any piped / `--output json` invocation) emits the raw `ReviewReport`.
- `--coach` opts into LLM mentoring prose, billed to the author's own Anthropic key (`ANTHROPIC_API_KEY`); the deterministic report needs no key.
- Advisory only — the exit code is always `0` regardless of score (not a merge gate).

Every request now sends **`X-Aethis-Client: cli/<version>`** so the server can attribute per-surface telemetry (CLI vs MCP). It's set once at client construction, carries no credentials or PII, and rides every call — matching the server's `x_aethis_client` header (`parse_client`) on the `/review` route.

## Files

- `aethis_cli/commands/review_cmd.py` — the command + human render (follows `generate_cmd.py::generate` → `_run_generate`).
- `aethis_cli/client.py` — new `AethisClient.review()`; `X-Aethis-Client` header at construction.
- `aethis_cli/main.py` — `app.command()(review)`.
- Version bump `0.26.0 → 0.27.0` + CHANGELOG (additive feature → minor).

> Note: the CLI `CLAUDE.md` cites stale `api.py`/`state.py`; the real files are `client.py` + `config.py`, which is what this PR follows.

## Tests

`tests/test_review_cmd.py` (new) + additions to `tests/test_client.py` cover: default keyless render, `--json` parseable, thin-project empty state, low-score-still-exit-0, `--verbose` table, `--coach` plumbs the Anthropic key, coach-without-key warns-but-proceeds, and on the wire — `X-Aethis-Client: cli/<version>` sent on **every** request, `--coach` adds `X-Anthropic-Key`, and the deterministic body is `{"coach": false}`.

- `make lint` — clean.
- New + touched-module tests (`test_review_cmd.py`, `test_client.py`, `test_main.py`) — all green (32 new/client tests pass).
- Full `make test` — 334 passed; **6 pre-existing failures** in files this PR doesn't touch (`test_account_cmd`, `test_auth_providers`, `test_guidance_cli`, `test_id_utils`) — ANSI/terminal-width assertion flakes confirmed reproducing on pristine `origin/main`.

## Release gating

**Do not cut the public release of 0.27.0 until P1 (`/review`) is live on `api.aethis.ai`** — a released client calling a prod 404 is the failure this sequencing avoids. No tag/publish is done here (epic sequencing).

## Execution resolution

```
profile=build
runtime=claude-code
provider_model=claude-fable-5
selector=explicit
independence=different-session
escalations=none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)