### PR TITLE
ci: cut a GitHub Release on publish (+ backfill v0.27.0) (epic #526 P4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,7 @@ jobs:
       url: https://pypi.org/p/aethis-cli
     permissions:
       id-token: write  # trusted publishing via OIDC — no token needed
+      contents: write  # cut a GitHub Release (gh release create) after publish
 
     steps:
       - uses: actions/download-artifact@v8
@@ -91,6 +92,44 @@ jobs:
             sleep 10
           done
           exit 1
+
+      - name: Check out repo at the published tag (for CHANGELOG.md)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Cut GitHub Release from CHANGELOG
+        # Revive the subscribe-able GitHub Releases channel: on every publish,
+        # create a Release for the just-published tag with the matching
+        # CHANGELOG section as its notes. Idempotent create-or-skip so a re-run
+        # or workflow_dispatch never fails the publish. `--verify-tag` refuses to
+        # mint a synthetic tag at HEAD — the Release only ever attaches to the
+        # real published tag (epic aethis-workspace#526, sub-issue #80).
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG="$RELEASE_TAG"
+          VERSION="${TAG#v}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping (idempotent)."
+            exit 0
+          fi
+          NOTES_FILE="$(mktemp)"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## " ver "([ (]|$)" { inblock=1; next }
+            inblock && /^## / { exit }
+            inblock { print }
+          ' CHANGELOG.md | sed '/./,$!d' > "$NOTES_FILE"  # drop leading blank line(s)
+          if [[ ! -s "$NOTES_FILE" ]]; then
+            echo "No CHANGELOG.md section found for version $VERSION; cannot cut a Release." >&2
+            exit 1
+          fi
+          gh release create "$TAG" --title "$TAG" --notes-file "$NOTES_FILE" --verify-tag
+          echo "Created GitHub Release $TAG."
 
       - name: Trigger workspace release sync
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **ci: cut a GitHub Release on publish.** The `publish` workflow now creates a GitHub Release for each just-published tag, using that version's `CHANGELOG.md` section as the release notes, so the "watch → releases" subscribe channel stays current automatically. Idempotent (create-or-skip on an existing Release) and `--verify-tag` (never mints a synthetic tag). No package/runtime change. (epic aethis-workspace#526)
+
 ## 0.27.0 (2026-07-19)
 
 - **feat: `aethis review [<project>]`** — the Authoring Coach report for a project. Runs the server-side rubric and prints an authoring score, 2–3 evidence-cited strengths, and the single highest-leverage next improvement (with its docs link and the lever that fixes it). Defaults to the current project in `.aethis/state.json`; pass a `proj_…` id to review any of your projects from anywhere. `--verbose` shows the full per-check table; `--json` (and any piped/`--output json` invocation) emits the raw `ReviewReport`. The deterministic report needs only your API key; `--coach` opts into LLM mentoring prose billed to your own Anthropic key (`ANTHROPIC_API_KEY`). Advisory only — the exit code is always 0 regardless of score. New `AethisClient.review()`.


### PR DESCRIPTION
Part of the unified developer changelog epic **Aethis-ai/aethis-workspace#526** (P4), sub-issue **#80**.

## What & why

GitHub Releases are the one channel developers already know how to *watch*, but `aethis-cli`'s were 22 tags stale — the last Release was `v0.4.1` (April 2026) while the latest tag is `v0.27.0`. None of the publish workflow cut a Release; it only pushed to PyPI and fired the workspace release-sync dispatch.

This revives the channel: on every publish, `publish.yml` now cuts a GitHub Release for the just-published tag, using that version's `CHANGELOG.md` section as the release notes. The result is a subscribe-able "what's new" feed (the repo Releases tab + its Atom feed) fed automatically by machinery that already runs on tag.

## Changes

- **`.github/workflows/publish.yml`** — in the `publish` job, after "Verify PyPI received release" and before "Trigger workspace release sync":
  - a scoped `actions/checkout` of the published tag (the publish job previously only downloaded the dist artifact — `CHANGELOG.md` was not present), then
  - a **Cut GitHub Release** step: extracts the `## <version> …` block from `CHANGELOG.md` and runs `gh release create v<version> --title v<version> --notes-file <block>`.
  - **Idempotent** — create-or-skip via `gh release view "$TAG" || gh release create …`, so a re-run / `workflow_dispatch` against an already-released tag never fails the publish.
  - **`--verify-tag`** — the Release only ever attaches to the real published tag; it can never mint a synthetic tag at HEAD (guards the DS-5 build-race / Decision-7 concern).
  - Adds **`contents: write`** to the `publish` job's permissions (kept `id-token: write`).
- **`CHANGELOG.md`** — `## Unreleased` note recording the CI change. No version bump: this is a CI-workflow-only change, nothing ships in the package (per `.claude/rules/public-repos.md`).

## Backfill

Cut **one** backfill Release for the current latest **released** tag, read dynamically at build time (`gh api …/tags | sort -V | tail -1`, cross-checked against PyPI) — **v0.27.0** (PyPI `aethis-cli==0.27.0` published; tag `v0.27.0` exists). Not the CHANGELOG tip trick and not a loop over history.

> Note: the epic spec text names `v0.26.0` as the backfill target — that was written before `0.27.0` published. The design principle is "latest *released* tag, read dynamically", which is now `v0.27.0`; verified live before cutting.

Verified:
```
$ gh release view v0.27.0 --repo Aethis-ai/aethis-cli
title:  v0.27.0
tag:    v0.27.0
url:    https://github.com/Aethis-ai/aethis-cli/releases/tag/v0.27.0
(non-empty notes = the 0.27.0 CHANGELOG section)
```

## Extraction logic verified

An awk extractor pulls the `## <version> …` block (heading exclusive) up to the next `## ` heading. Proven against the real CHANGELOG for `0.27.0`: non-empty (1210 chars), stops before `0.26.0` (grep count 0). The workflow additionally strips leading blank lines and fails loudly if the extracted section is empty.

## Execution record

```
profile=build
runtime=claude-code
provider_model=runtime-default
selector=unavailable
independence=different-session
escalations=none
```

## Not done here (per instructions)

Do **not** merge — opened for review. This is a YAML-workflow change; the publish workflow cannot be run locally, so it is validated by `python3 -c 'yaml.safe_load(...)'` (OK), careful step-placement/permission reasoning, and the live backfill Release above proving the extraction + `gh release create` path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
