### PR TITLE
feat: changelog-on-update — what's-new on aethis update + banner link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.28.0 (2026-07-20)
 
+- **feat: "what's new" on `aethis update`.** `aethis update` / `aethis update --check` now shows the changelog entries between your installed version and the latest release (titles + notes, newest ≤5, long notes truncated), sourced from the project's GitHub Releases. If the Releases API is unreachable, rate-limited, or has nothing in range, it falls back to a link to the Releases page — the command never errors or hangs on this. The exit-time update banner also gained a "what's new →" link to the same page. Coverage is forward-fill: only releases cut from here on populate the range, so an old install may see a gap. New `update_check._fetch_github_releases()`; the display logic lives in `update_cmd._releases_in_range()` / `_print_whats_new()`. (epic aethis-workspace#537)
 - **ci: cut a GitHub Release on publish.** The `publish` workflow now creates a GitHub Release for each just-published tag, using that version's `CHANGELOG.md` section as the release notes, so the "watch → releases" subscribe channel stays current automatically. Idempotent (create-or-skip on an existing Release) and `--verify-tag` (never mints a synthetic tag). No package/runtime change. (epic aethis-workspace#526)
 
 ## 0.27.0 (2026-07-19)

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/aethis_cli/commands/update_cmd.py
+++ b/aethis_cli/commands/update_cmd.py
@@ -11,13 +11,18 @@ import typer
 from aethis_cli._version import __version__
 from aethis_cli.output import console
 from aethis_cli.update_check import (
+    _RELEASES_PAGE_URL,
     _detect_install_method,
+    _fetch_github_releases,
     _fetch_latest_pypi,
     _is_newer,
+    _parse_version,
     _save_cache,
 )
 
 PACKAGE = "aethis-cli"
+_CHANGELOG_MAX_ENTRIES = 5
+_CHANGELOG_NOTE_MAX_CHARS = 600
 
 
 def _is_editable_install(package: str) -> bool:
@@ -36,6 +41,52 @@ def _is_editable_install(package: str) -> bool:
         return False
     dir_info = data.get("dir_info")
     return isinstance(dir_info, dict) and bool(dir_info.get("editable"))
+
+
+def _releases_in_range(releases: list[tuple[str, str, str]], current: str, latest: str) -> list[tuple[str, str, str]]:
+    """Filter releases to tags in the semver range (current, latest], newest first.
+
+    #526 backfilled only the latest tag per repo (no historical backfill), so
+    the range is expected to be sparse — this just returns what exists.
+    """
+    current_v = _parse_version(current)
+    latest_v = _parse_version(latest)
+    tagged = []
+    for tag, title, notes in releases:
+        v = _parse_version(tag.lstrip("v"))
+        if current_v < v <= latest_v:
+            tagged.append((v, tag, title, notes))
+    tagged.sort(key=lambda item: item[0], reverse=True)
+    return [(tag, title, notes) for _, tag, title, notes in tagged[:_CHANGELOG_MAX_ENTRIES]]
+
+
+def _print_whats_new(current: str, latest: str) -> None:
+    """Print changelog entries between `current` and `latest`; never raises.
+
+    Falls back to a link to the Releases page on any failure or empty
+    result — the changelog is a nice-to-have, never a reason to break
+    `aethis update`.
+    """
+    try:
+        entries = _releases_in_range(_fetch_github_releases(), current, latest)
+    except Exception:
+        entries = []
+
+    if not entries:
+        console.print(f"[dim]See what's new: {_RELEASES_PAGE_URL}[/dim]")
+        return
+
+    console.print("\n[bold]What's new:[/bold]")
+    for tag, title, notes in entries:
+        # style= (not inline markup) + markup=False/highlight=False: title/notes
+        # are untrusted external text (a Release title could itself contain
+        # `[brackets]`) — never let it be parsed as Rich markup.
+        console.print(f"\n{title or tag}", style="bold", markup=False, highlight=False)
+        text = notes.strip()
+        if len(text) > _CHANGELOG_NOTE_MAX_CHARS:
+            text = text[:_CHANGELOG_NOTE_MAX_CHARS].rstrip() + "…"
+        if text:
+            console.print(text, markup=False, highlight=False)
 
 
 def _upgrade_argv(method: str, package: str) -> list[str]:
@@ -81,6 +132,7 @@ def update(
         return
 
     console.print(f"[bold]New release available:[/bold] {__version__} → {latest}")
+    _print_whats_new(__version__, latest)
 
     if check:
         console.print("[dim]Run `aethis update` to install it.[/dim]")

--- a/aethis_cli/commands/update_cmd.py
+++ b/aethis_cli/commands/update_cmd.py
@@ -60,33 +60,41 @@ def _releases_in_range(releases: list[tuple[str, str, str]], current: str, lates
     return [(tag, title, notes) for _, tag, title, notes in tagged[:_CHANGELOG_MAX_ENTRIES]]
 
 
+def _print_fallback() -> None:
+    console.print(f"[dim]See what's new: {_RELEASES_PAGE_URL}[/dim]")
+
+
 def _print_whats_new(current: str, latest: str) -> None:
     """Print changelog entries between `current` and `latest`; never raises.
 
-    Falls back to a link to the Releases page on any failure or empty
-    result — the changelog is a nice-to-have, never a reason to break
-    `aethis update`.
+    Falls back to a link to the Releases page on any failure (fetch, filter,
+    or render) or empty result — the changelog is a nice-to-have, never a
+    reason to break `aethis update`. The whole body is wrapped, not just the
+    fetch: `_fetch_github_releases` already sanitizes its output, so the
+    render loop shouldn't be reachable with bad data today, but the
+    "never raises" contract must be self-contained rather than depend on
+    that invariant holding for every future caller/sanitizer change
+    (defense-in-depth).
     """
     try:
         entries = _releases_in_range(_fetch_github_releases(), current, latest)
+        if not entries:
+            _print_fallback()
+            return
+
+        console.print("\n[bold]What's new:[/bold]")
+        for tag, title, notes in entries:
+            # style= (not inline markup) + markup=False/highlight=False: title/notes
+            # are untrusted external text (a Release title could itself contain
+            # `[brackets]`) — never let it be parsed as Rich markup.
+            console.print(f"\n{title or tag}", style="bold", markup=False, highlight=False)
+            text = (notes or "").strip()
+            if len(text) > _CHANGELOG_NOTE_MAX_CHARS:
+                text = text[:_CHANGELOG_NOTE_MAX_CHARS].rstrip() + "…"
+            if text:
+                console.print(text, markup=False, highlight=False)
     except Exception:
-        entries = []
-
-    if not entries:
-        console.print(f"[dim]See what's new: {_RELEASES_PAGE_URL}[/dim]")
-        return
-
-    console.print("\n[bold]What's new:[/bold]")
-    for tag, title, notes in entries:
-        # style= (not inline markup) + markup=False/highlight=False: title/notes
-        # are untrusted external text (a Release title could itself contain
-        # `[brackets]`) — never let it be parsed as Rich markup.
-        console.print(f"\n{title or tag}", style="bold", markup=False, highlight=False)
-        text = notes.strip()
-        if len(text) > _CHANGELOG_NOTE_MAX_CHARS:
-            text = text[:_CHANGELOG_NOTE_MAX_CHARS].rstrip() + "…"
-        if text:
-            console.print(text, markup=False, highlight=False)
+        _print_fallback()
 
 
 def _upgrade_argv(method: str, package: str) -> list[str]:

--- a/aethis_cli/update_check.py
+++ b/aethis_cli/update_check.py
@@ -25,8 +25,11 @@ import httpx
 
 _CACHE_TTL_SECONDS = 24 * 60 * 60
 _PYPI_TIMEOUT_SECONDS = 3.0
+_GITHUB_API_TIMEOUT_SECONDS = 3.0
 _JOIN_TIMEOUT_SECONDS = 0.05
 _DISABLE_ENV = "AETHIS_DISABLE_UPDATE_CHECK"
+_RELEASES_API_URL = "https://api.github.com/repos/Aethis-ai/aethis-cli/releases"
+_RELEASES_PAGE_URL = "https://github.com/Aethis-ai/aethis-cli/releases"
 
 
 def _config_dir() -> Path:
@@ -86,6 +89,42 @@ def _fetch_latest_pypi(package: str) -> Optional[str]:
     return None
 
 
+def _fetch_github_releases(url: str = _RELEASES_API_URL) -> list[tuple[str, str, str]]:
+    """Fetch GitHub Releases (unauthenticated). Returns [(tag, title, notes), ...].
+
+    Newest-first, as returned by the API. Fails silent (empty list) on any
+    network, HTTP, or parse error — the "what's new" display is a nice-to-have,
+    never a reason to break `aethis update`.
+    """
+    try:
+        resp = httpx.get(
+            url,
+            timeout=_GITHUB_API_TIMEOUT_SECONDS,
+            headers={"Accept": "application/vnd.github+json"},
+        )
+    except httpx.HTTPError:
+        return []
+    if resp.status_code != 200:
+        return []
+    try:
+        data = resp.json()
+    except ValueError:
+        return []
+    if not isinstance(data, list):
+        return []
+    releases: list[tuple[str, str, str]] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        tag = entry.get("tag_name")
+        if not isinstance(tag, str) or not tag:
+            continue
+        title = entry.get("name") if isinstance(entry.get("name"), str) and entry.get("name") else tag
+        notes = entry.get("body") if isinstance(entry.get("body"), str) else ""
+        releases.append((tag, title, notes))
+    return releases
+
+
 _VERSION_RE = re.compile(r"^(\d+)(?:\.(\d+))?(?:\.(\d+))?")
 
 
@@ -122,7 +161,11 @@ def _detect_install_method(package: str) -> str:
 
 
 def _print_banner(package: str, current: str, latest: str) -> None:
-    msg = f"\nA new release of {package} is available: {current} → {latest}\nTo upgrade, run: aethis update\n"
+    msg = (
+        f"\nA new release of {package} is available: {current} → {latest}\n"
+        f"To upgrade, run: aethis update\n"
+        f"what's new → {_RELEASES_PAGE_URL}\n"
+    )
     try:
         sys.stderr.write(msg)
         sys.stderr.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.27.0"
+version = "0.28.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -154,6 +154,73 @@ def test_print_banner_writes_to_stderr(capsys: pytest.CaptureFixture[str]) -> No
     assert captured.out == ""
 
 
+def test_print_banner_contains_releases_link(capsys: pytest.CaptureFixture[str]) -> None:
+    """(d) the exit banner points at the GitHub Releases page, not the (still-404) docs URL."""
+    uc._print_banner("aethis-cli", "0.10.0", "0.11.0")
+    captured = capsys.readouterr()
+    assert uc._RELEASES_PAGE_URL in captured.err
+    assert "docs.aethis.ai" not in captured.err
+
+
+@respx.mock
+def test_fetch_github_releases_happy_path() -> None:
+    respx.get(uc._RELEASES_API_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"tag_name": "v0.11.0", "name": "0.11.0", "body": "Added widgets."},
+                {"tag_name": "v0.10.0", "name": "0.10.0", "body": "Fixed bugs."},
+            ],
+        )
+    )
+    releases = uc._fetch_github_releases()
+    assert releases == [
+        ("v0.11.0", "0.11.0", "Added widgets."),
+        ("v0.10.0", "0.10.0", "Fixed bugs."),
+    ]
+
+
+@respx.mock
+def test_fetch_github_releases_non_200_returns_empty() -> None:
+    respx.get(uc._RELEASES_API_URL).mock(return_value=httpx.Response(403))
+    assert uc._fetch_github_releases() == []
+
+
+@respx.mock
+def test_fetch_github_releases_network_error_returns_empty() -> None:
+    respx.get(uc._RELEASES_API_URL).mock(side_effect=httpx.ConnectError("boom"))
+    assert uc._fetch_github_releases() == []
+
+
+@respx.mock
+def test_fetch_github_releases_malformed_body_returns_empty() -> None:
+    respx.get(uc._RELEASES_API_URL).mock(return_value=httpx.Response(200, text="not json"))
+    assert uc._fetch_github_releases() == []
+
+
+@respx.mock
+def test_fetch_github_releases_skips_malformed_entries() -> None:
+    """Missing tag_name / non-string body: skip the entry, never raise."""
+    respx.get(uc._RELEASES_API_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"name": "no tag", "body": "should be skipped"},
+                {"tag_name": "v0.11.0", "name": None, "body": None},
+                "not-a-dict",
+            ],
+        )
+    )
+    releases = uc._fetch_github_releases()
+    assert releases == [("v0.11.0", "v0.11.0", "")]
+
+
+@respx.mock
+def test_fetch_github_releases_non_list_body_returns_empty() -> None:
+    respx.get(uc._RELEASES_API_URL).mock(return_value=httpx.Response(200, json={"message": "not found"}))
+    assert uc._fetch_github_releases() == []
+
+
 class _SyncThread:
     """Runs target synchronously on .start(); makes background_check deterministic."""
 

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -19,6 +19,7 @@ def _run(args, **patches_kw):
         "_save_cache": None,
         "_is_editable_install": False,
         "_detect_install_method": "uv",
+        "_fetch_github_releases": [],
         "subprocess_returncode": 0,
     }
     defaults.update(patches_kw)
@@ -29,6 +30,7 @@ def _run(args, **patches_kw):
         patch.object(update_cmd, "_save_cache") as save_cache,
         patch.object(update_cmd, "_is_editable_install", return_value=defaults["_is_editable_install"]),
         patch.object(update_cmd, "_detect_install_method", return_value=defaults["_detect_install_method"]),
+        patch.object(update_cmd, "_fetch_github_releases", return_value=defaults["_fetch_github_releases"]),
         patch.object(update_cmd.subprocess, "run", return_value=run_result) as sub_run,
     ):
         result = runner.invoke(app, args)
@@ -84,6 +86,107 @@ def test_update_propagates_upgrade_failure() -> None:
     assert result.exit_code == 3
     assert "failed" in result.output
     sub_run.assert_called_once()
+
+
+def test_update_check_renders_releases_in_range() -> None:
+    """(a) a normal 2-version mocked range renders both titles + notes."""
+    releases = [
+        ("v9.9.9", "9.9.9", "Added widgets."),
+        ("v9.9.8", "9.9.8", "Fixed bugs."),
+        ("v0.1.0", "0.1.0", "Ancient, out of range."),
+    ]
+    result, _, _ = _run(
+        ["update", "--check"],
+        _fetch_latest_pypi="9.9.9",
+        _fetch_github_releases=releases,
+    )
+    assert result.exit_code == 0
+    assert "9.9.9" in result.output
+    assert "Added widgets." in result.output
+    assert "9.9.8" in result.output
+    assert "Fixed bugs." in result.output
+    assert "Ancient, out of range." not in result.output
+
+
+def test_update_check_falls_back_on_empty_releases() -> None:
+    """(b) an empty Releases result falls back to a link, never raises."""
+    result, _, _ = _run(["update", "--check"], _fetch_github_releases=[])
+    assert result.exit_code == 0
+    assert update_cmd._RELEASES_PAGE_URL in result.output
+
+
+def test_update_check_falls_back_when_releases_fetch_raises() -> None:
+    """(b) the Releases call itself erroring falls back without raising."""
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    with (
+        patch.object(update_cmd, "_fetch_latest_pypi", return_value="9.9.9"),
+        patch.object(update_cmd, "_save_cache"),
+        patch.object(update_cmd, "_fetch_github_releases", side_effect=RuntimeError("boom")),
+    ):
+        result = runner.invoke(app, ["update", "--check"])
+    assert result.exit_code == 0
+    assert update_cmd._RELEASES_PAGE_URL in result.output
+
+
+def test_releases_in_range_excludes_current_and_below() -> None:
+    """(c) the range (current, latest] excludes current and anything <= current."""
+    releases = [
+        ("v9.9.9", "9.9.9", "in range"),
+        ("v9.9.0", "9.9.0", "current, excluded"),
+        ("v9.0.0", "9.0.0", "below current, excluded"),
+        ("v10.0.0", "10.0.0", "above latest, excluded"),
+    ]
+    selected = update_cmd._releases_in_range(releases, current="9.9.0", latest="9.9.9")
+    assert selected == [("v9.9.9", "9.9.9", "in range")]
+
+
+def test_releases_in_range_sparse_gap_renders_what_exists() -> None:
+    """(e) a gapped Releases list (some in-range versions have no Release) renders
+    what exists and never crashes — mirrors the real forward-fill launch state."""
+    releases = [
+        ("v9.9.9", "9.9.9", "latest notes"),
+        # no Release for 9.9.8 or 9.9.7 — the gap.
+        ("v9.9.6", "9.9.6", "older notes"),
+    ]
+    selected = update_cmd._releases_in_range(releases, current="9.9.5", latest="9.9.9")
+    assert selected == [
+        ("v9.9.9", "9.9.9", "latest notes"),
+        ("v9.9.6", "9.9.6", "older notes"),
+    ]
+
+
+def test_update_check_sparse_releases_render_without_crashing() -> None:
+    """(e) end-to-end: a gapped range still prints via the update command."""
+    releases = [
+        ("v9.9.9", "9.9.9", "latest notes"),
+        ("v9.9.6", "9.9.6", "older notes"),
+    ]
+    result, _, _ = _run(
+        ["update", "--check"],
+        _fetch_latest_pypi="9.9.9",
+        _fetch_github_releases=releases,
+    )
+    assert result.exit_code == 0
+    assert "latest notes" in result.output
+    assert "older notes" in result.output
+
+
+def test_releases_in_range_caps_and_truncates() -> None:
+    """Newest ≤5 versions shown; long notes truncated with an ellipsis."""
+    releases = [(f"v9.9.{i}", f"9.9.{i}", "x" * 1000) for i in range(9, -1, -1)]  # v9.9.9 .. v9.9.0
+    selected = update_cmd._releases_in_range(releases, current="9.8.0", latest="9.9.9")
+    assert len(selected) == update_cmd._CHANGELOG_MAX_ENTRIES
+    assert [tag for tag, _, _ in selected] == ["v9.9.9", "v9.9.8", "v9.9.7", "v9.9.6", "v9.9.5"]
+
+    result, _, _ = _run(
+        ["update", "--check"],
+        _fetch_latest_pypi="9.9.9",
+        _fetch_github_releases=releases,
+    )
+    assert result.exit_code == 0
+    assert "…" in result.output
 
 
 def test_is_editable_install_reads_direct_url() -> None:


### PR DESCRIPTION
## Summary

Closes sub-issue #82 of the changelog-on-update epic (Aethis-ai/aethis-workspace#537 — spec `docs/specs/2026-07-20-changelog-on-update.md`).

`aethis update` already said *that* a newer release exists but never *what changed*. This adds:

- **`update_check._fetch_github_releases()`** — unauthenticated `GET /repos/Aethis-ai/aethis-cli/releases`, bounded by the existing 3s timeout, defensively parsed (skips malformed entries, fails silent to `[]` on any network/HTTP/parse error).
- **`update_cmd._releases_in_range()` / `_print_whats_new()`** — filters Releases to the semver range `(current, latest]`, newest-first, capped to the newest ≤5, notes truncated at ~600 chars with an ellipsis. Runs once (before the `if check:` branch) so it covers both `aethis update --check` and the full upgrade path. On any failure or empty result it falls back to a link to the GitHub Releases page — never raises, never crashes the command. Release title/notes are untrusted external text, so they're printed via `style=`/`markup=False`/`highlight=False`, never interpolated into Rich markup.
- **`update_check._print_banner`** — one added line: `what's new → https://github.com/Aethis-ai/aethis-cli/releases`. Points at the GitHub Releases page (live today), not `docs.aethis.ai/changelog` (404s until epic #526 P2 deploys — spec Decisions 3/6).
- This is **forward-fill**: #526 backfilled only the latest tag, so the range may have gaps at launch — copy says "what's new," not "complete history."

## Tests

Extended `tests/test_update_check.py` + `tests/test_update_cmd.py`, all mocked (no live-network dependency):

1. A normal 2-version mocked range renders both titles + notes.
2. An empty/errored Releases API (both a non-2xx/network-error fetch and an exception from the fetch call itself) falls back to the Releases-page link without raising.
3. The semver range excludes the current version and anything ≤ current.
4. The banner contains the Releases-page link (and not the still-404 docs URL).
5. A sparse/gapped Releases list (some in-range versions have no Release) renders what exists without crashing — mirrors the real launch state.

Plus: malformed-entry parsing (missing `tag_name`, non-string `body`, non-dict list items, non-list JSON body), and cap/truncation behaviour.

```
cd aethis-cli && uv run pytest tests/test_update_cmd.py tests/test_update_check.py -q --no-cov
# 42 passed

uv run pytest -q --no-cov
# 349 passed, 24 deselected, 5 failed — same 5 pre-existing ANSI-rendering
# failures reproduced identically on a clean origin/main checkout (test_account_cmd.py,
# test_guidance_cli.py, test_id_utils.py), unrelated to this change.
```

## Version

Bumped `_version.py` + `pyproject.toml` 0.27.0 → 0.28.0 (minor, additive) and moved the pending `## Unreleased` section (which already had the #526 release-on-publish CI entry) to `## 0.28.0 (2026-07-20)`, adding this feature's notes.

## Execution resolution

```
Execution resolution:
profile=build
runtime=claude-code
provider_model=runtime-default
selector=unavailable
independence=different-session
escalations=none
```

Note: branched from a stale, already-merged local branch (`feat/release-on-publish`) by mistake initially — caught it, stashed, and re-based cleanly onto a fresh `origin/main` before committing (per `submodule-discipline` rule 8).