### PR TITLE
feat: aethis usage + remaining generate budget (#552 P2 propagation, v0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.29.0 (2026-07-21)
+
+- **feat: `aethis usage`** — show your rate-limit budget per operation class (decide / generate / author / read / keys / admin) as a table: used / limit / remaining / reset, over the rolling 24h window. `generate` (LLM rule generation) is the scarce class; browsing and status polling (`read`) are effectively unlimited. `--json`/piped emits the raw `/usage` payload. New `AethisClient.usage()`.
+- **feat: remaining generate budget after `aethis generate`.** The CLI now reads the `X-RateLimit-*` response headers (captured on every request as `AethisClient.last_rate_limit`) and, after a generation is queued, prints "N generations left in the current 24h window" — so a 429 is never the first signal. The line turns yellow at ≤5 remaining.
+- Requires aethis-core with the `GET /api/v1/public/usage` endpoint + `X-RateLimit-*` headers live (epic aethis-workspace#552, P2). The public release of this version is held until that surface is live on `api.aethis.ai`.
+
 ## 0.28.0 (2026-07-20)
 
 - **feat: "what's new" on `aethis update`.** `aethis update` / `aethis update --check` now shows the changelog entries between your installed version and the latest release (titles + notes, newest ≤5, long notes truncated), sourced from the project's GitHub Releases. If the Releases API is unreachable, rate-limited, or has nothing in range, it falls back to a link to the Releases page — the command never errors or hangs on this. The exit-time update banner also gained a "what's new →" link to the same page. Coverage is forward-fill: only releases cut from here on populate the range, so an old install may see a gap. New `update_check._fetch_github_releases()`; the display logic lives in `update_cmd._releases_in_range()` / `_print_whats_new()`. (epic aethis-workspace#537)

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -63,6 +63,9 @@ class AethisClient:
         # a second 401 surfaces the original error so we never loop. Disabled
         # for unsigned clients — there's no key to refresh.
         self._on_auth_required = None if unsigned else on_auth_required
+        # Latest X-RateLimit-* budget seen on a response (epic #552 P2). None
+        # until the first metered, authenticated call.
+        self.last_rate_limit: Optional[dict] = None
 
     def close(self) -> None:
         self._client.close()
@@ -72,6 +75,24 @@ class AethisClient:
 
     def __exit__(self, *args: Any) -> None:
         self.close()
+
+    def _capture_rate_limit(self, resp: httpx.Response) -> None:
+        """Stash the X-RateLimit-* headers (epic #552 P2) from the latest
+        response so command code can surface remaining budget. None when the
+        server didn't send them (unauthenticated / non-metered response)."""
+        h = resp.headers
+        cls = h.get("X-RateLimit-Class")
+        if cls is None:
+            return
+        try:
+            self.last_rate_limit = {
+                "class": cls,
+                "limit": int(h["X-RateLimit-Limit"]),
+                "remaining": int(h["X-RateLimit-Remaining"]),
+                "reset": int(h["X-RateLimit-Reset"]),
+            }
+        except (KeyError, ValueError):
+            self.last_rate_limit = None
 
     def _request(self, method: str, path: str, **kwargs: Any) -> Any:
         resp = self._client.request(method, path, **kwargs)
@@ -87,6 +108,7 @@ class AethisClient:
             new_key = refresh(force_browser=True)
             self._client.headers["X-API-Key"] = new_key
             resp = self._client.request(method, path, **kwargs)
+        self._capture_rate_limit(resp)
         if resp.status_code >= 400:
             self._raise_for_status(resp)
         if resp.status_code == 204:
@@ -113,6 +135,10 @@ class AethisClient:
                 **opts,
             },
         )
+
+    def usage(self) -> dict:
+        """Per-operation-class rate-limit budget for the calling key (epic #552)."""
+        return self._request("GET", "/api/v1/public/usage")
 
     def whoami(self) -> dict:
         """Return metadata for the current API key."""

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -470,6 +470,15 @@ def _run_generate(
         job = client.generate(pid, mode=mode, seed_ruleset_id=seed_ruleset_id)
         write_state(project_dir, {"project_id": pid, "job_id": job["job_id"]})
         info(f"Generation queued (job={job['job_id']})")
+        # Surface the remaining generate budget from the POST's X-RateLimit-*
+        # headers (epic #552) — captured now, before polling /status overwrites
+        # it with the `read` class. `aethis usage` shows the full picture.
+        _rl = client.last_rate_limit
+        if _rl and _rl.get("class") == "generate":
+            _rem = _rl.get("remaining", 0)
+            _noun = "generation" if _rem == 1 else "generations"
+            _style = "yellow" if _rem <= 5 else "dim"
+            console.print(f"[{_style}]{_rem} {_noun} left in the current 24h window.[/{_style}]")
 
         if not poll:
             console.print("Use 'aethis status' to check progress.")

--- a/aethis_cli/commands/usage_cmd.py
+++ b/aethis_cli/commands/usage_cmd.py
@@ -1,0 +1,71 @@
+"""aethis usage — show your per-operation-class rate-limit budget (epic #552)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import typer
+from rich.table import Table
+
+from aethis_cli.auth_helpers import resolve_cached_key
+from aethis_cli.client import AethisClient
+from aethis_cli.config import resolve_base_url_with_source
+from aethis_cli.errors import AethisAPIError
+from aethis_cli.output import console, error_panel
+from aethis_cli.render import emit, is_json_requested
+
+
+def _fmt_reset(ts: object) -> str:
+    if not ts:
+        return "-"
+    try:
+        return datetime.fromtimestamp(int(ts), tz=timezone.utc).strftime("%H:%M UTC")  # type: ignore[arg-type]
+    except (ValueError, TypeError, OSError):
+        return "-"
+
+
+def usage() -> None:
+    """Show your rate-limit budget per operation class (rolling 24h window).
+
+    Each class — decide / generate / author / read / keys / admin — has its own
+    budget. `generate` (LLM rule generation) is the scarce one; browsing and
+    status polling (`read`) are effectively unlimited. Check here before a big
+    authoring run so a 429 is never the first signal.
+    """
+    api_key = resolve_cached_key()
+    base_url, _ = resolve_base_url_with_source()
+    if api_key is None:
+        console.print(
+            "[yellow]No Aethis API key configured.[/yellow]\n[dim]Run 'aethis login' or set AETHIS_API_KEY.[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    client = AethisClient(api_key, base_url)
+    try:
+        data = client.usage()
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    if is_json_requested():
+        emit(data)
+        return
+
+    console.print(f"[bold]Tier:[/bold] {data.get('tier')}")
+    table = Table(title="Rate-limit budget (rolling 24h)")
+    table.add_column("Class", style="bold")
+    table.add_column("Used", justify="right")
+    table.add_column("Limit", justify="right")
+    table.add_column("Remaining", justify="right")
+    table.add_column("Resets", justify="right")
+    for c in data.get("classes", []):
+        rem = c.get("remaining", 0)
+        rem_style = "green" if rem > 0 else "red"
+        table.add_row(
+            str(c.get("class", "")),
+            str(c.get("used", 0)),
+            str(c.get("limit", 0)),
+            f"[{rem_style}]{rem}[/{rem_style}]",
+            _fmt_reset(c.get("reset")),
+        )
+    console.print(table)

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -33,6 +33,7 @@ from aethis_cli.commands.review_cmd import review
 from aethis_cli.commands.fields_cmd import fields_app
 from aethis_cli.commands.explain_cmd import explain
 from aethis_cli.commands.decide_cmd import decide
+from aethis_cli.commands.usage_cmd import usage
 from aethis_cli.commands.whoami_cmd import whoami
 from aethis_cli.commands.update_cmd import update
 
@@ -186,6 +187,7 @@ app.command()(review)
 app.command()(explain)
 app.command()(decide)
 app.command()(whoami)
+app.command()(usage)
 app.command()(update)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.28.0"
+version = "0.29.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,93 @@
+"""Tests for `aethis usage` + X-RateLimit header capture (epic aethis-workspace#552)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import respx
+from typer.testing import CliRunner
+
+BASE = "http://localhost:8080"
+
+
+@respx.mock(base_url=BASE)
+def test_client_captures_ratelimit_headers(respx_mock):
+    from aethis_cli.client import AethisClient
+
+    respx_mock.get("/api/v1/public/usage").mock(
+        return_value=httpx.Response(
+            200,
+            json={"tier": "free", "classes": [], "rolling": {}},
+            headers={
+                "X-RateLimit-Class": "read",
+                "X-RateLimit-Limit": "100000",
+                "X-RateLimit-Remaining": "99997",
+                "X-RateLimit-Reset": "1800000000",
+            },
+        )
+    )
+    c = AethisClient("ak_test", BASE)
+    c.usage()
+    assert c.last_rate_limit == {
+        "class": "read",
+        "limit": 100000,
+        "remaining": 99997,
+        "reset": 1800000000,
+    }
+
+
+@respx.mock(base_url=BASE)
+def test_client_without_ratelimit_headers_leaves_none(respx_mock):
+    from aethis_cli.client import AethisClient
+
+    respx_mock.get("/api/v1/public/me").mock(return_value=httpx.Response(200, json={"key_id": "ak"}))
+    c = AethisClient("ak_test", BASE)
+    c.whoami()
+    assert c.last_rate_limit is None
+
+
+def _run_usage(client_mock, api_key="ak_test"):
+    from aethis_cli.main import app
+
+    runner = CliRunner()
+    patches = [
+        patch("aethis_cli.commands.usage_cmd.AethisClient", return_value=client_mock),
+        patch("aethis_cli.commands.usage_cmd.resolve_cached_key", return_value=api_key),
+        patch(
+            "aethis_cli.commands.usage_cmd.resolve_base_url_with_source",
+            return_value=(BASE, "default"),
+        ),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        return runner.invoke(app, ["usage"], catch_exceptions=False)
+    finally:
+        for p in reversed(patches):
+            p.stop()
+
+
+def test_usage_command_renders_per_class():
+    client = MagicMock()
+    client.usage.return_value = {
+        "tier": "free",
+        "classes": [
+            {"class": "generate", "used": 3, "limit": 200, "remaining": 197, "reset": 1800000000},
+            {"class": "read", "used": 50, "limit": 100000, "remaining": 99950, "reset": 1800000000},
+        ],
+        "rolling": {"last_7_days": {}, "last_30_days": {}},
+    }
+    result = _run_usage(client)
+    assert result.exit_code == 0
+    # Content present whether rendered as the Rich table or the non-TTY JSON.
+    assert "generate" in result.output
+    assert "197" in result.output
+
+
+def test_usage_command_requires_key():
+    with patch("aethis_cli.commands.usage_cmd.resolve_cached_key", return_value=None):
+        from aethis_cli.main import app
+
+        result = CliRunner().invoke(app, ["usage"], catch_exceptions=False)
+    assert result.exit_code == 1


### PR DESCRIPTION
**Epic:** Aethis-ai/aethis-workspace#552 · **P2-propagation** (aethis-cli #85) · *Execution profile: build.*
Depends on aethis-core P1/P2 (`/usage` + `X-RateLimit-*`) — live on staging; the public **release is held until it's live on `api.aethis.ai`** (same coordination as v0.27.0's `/review`).

## What

- **`aethis usage`** — renders the per-operation-class budget (used / limit / remaining / reset over the rolling 24h window) from `GET /api/v1/public/usage`. `generate` is the scarce class; `read` is effectively unlimited. `--json`/piped emits the raw payload. New `AethisClient.usage()`.
- **Remaining generate budget after `aethis generate`** — every request now captures `X-RateLimit-*` into `AethisClient.last_rate_limit`; after a generation queues, the CLI prints "N generations left in the current 24h window" (yellow at ≤5), captured *before* polling `/status` overwrites it with the `read` class. So a 429 is never the first signal.

## Verification
- End-to-end against `staging.api.aethis.ai` — `aethis usage` returns the live per-class payload.
- Tests: header capture (present → dict, absent → None) via respx; `usage` renders per-class + requires a key. Full suite **353 pass**, coverage 73.5%. (The 5 `test_account`/`test_guidance`/`test_id_utils` failures are the known local ANSI-escape flake — pre-existing on `origin/main`, green in CI.)

Version bumped 0.28.0 → **0.29.0** + CHANGELOG.