### PR TITLE
ci(publish): sweep every consumer repo when unsticking downstream PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,8 +236,8 @@ jobs:
             -d "{\"event_type\":\"release-package-published\",\"client_payload\":{\"package\":\"aethis-cli\",\"version\":\"${RELEASE_TAG#v}\",\"tag\":\"$RELEASE_TAG\"}}"
 
   unstick-downstream:
-    # After a successful publish, find downstream PRs across the Aethis-ai org
-    # that declared a dependency on this aethis-cli release via the marker
+    # After a successful publish, find downstream PRs that declared a dependency
+    # on this aethis-cli release via the marker
     #   <!-- aethis-needs: aethis-cli >= X.Y.Z -->
     # in their PR body. For each PR whose constraint is satisfied by the just-
     # published version, post a comment and flip the PR from draft to ready.
@@ -252,7 +252,9 @@ jobs:
         env:
           # Cross-repo PR mutation needs a token with `pull-requests:write` on
           # the *target* repo, which the default GITHUB_TOKEN doesn't have.
-          # Reuses the same workspace dispatch token (PAT scoped to the org).
+          # Reuses the same workspace dispatch token. The consumer repos span
+          # two owners, so the token must reach both; any repo it cannot read is
+          # reported as a warning rather than failing the sweep.
           GH_TOKEN: ${{ secrets.WORKSPACE_SYNC_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
@@ -271,33 +273,71 @@ jobs:
               re.IGNORECASE,
           )
 
+          # Repos that may carry an `aethis-needs: aethis-cli` marker. They span
+          # two owners, so an owner-scoped query cannot see all of them; each is
+          # queried individually with `gh pr list --repo`, which is genuinely
+          # repo-scoped (unlike `gh search --repo`, whose filter is a query
+          # qualifier against the global search index). The canonical
+          # enumeration lives in the aethis-workspace registry
+          # (`scripts/workspace-repos`), which this repo cannot read, so the
+          # list is declared here; keep the two in step when a consumer is
+          # added.
+          REPOS = [
+              "Aethis-ai/aethis-workspace",
+              "Aethis-ai/aethis-examples",
+              "Aethis-ai/aethis-examples-internal",
+              "Aethis-ai/aethis-mcp",
+              "Aethis-ai/aethis-sdk-python",
+              "Aethis-ai/tda-server",
+              "Aethis-ai/docs",
+              "Paul-Simpson/ok_swift",
+              "Paul-Simpson/aethis.ai",
+              "Paul-Simpson/aethis.law",
+          ]
+
           def vtuple(v): return tuple(int(p) for p in v.split("."))
 
           def gh(*args):
               out = subprocess.check_output(["gh"] + list(args))
               return out.decode()
 
-          search = gh(
-              "search", "prs",
-              "--owner", "Aethis-ai",
-              "--state", "open",
-              "aethis-needs: aethis-cli",
-              "--json", "repository,number,title,isDraft,url",
-              "--limit", "100",
-          )
-          prs = json.loads(search)
+          prs = []
+          unreachable = []
+          for repo in REPOS:
+              try:
+                  out = gh(
+                      "pr", "list",
+                      "--repo", repo,
+                      "--state", "open",
+                      "--search", "aethis-needs",
+                      "--json", "number,title,isDraft,url,body",
+                      "--limit", "100",
+                  )
+              except subprocess.CalledProcessError as exc:
+                  # Never fail the whole sweep on one unreachable repo, but say
+                  # so loudly — a silent skip is how a consumer stops being
+                  # unstuck without anyone noticing.
+                  print(f"::warning::{repo}: could not be queried (rc={exc.returncode}); skipped")
+                  unreachable.append(repo)
+                  continue
+              for pr in json.loads(out):
+                  prs.append({**pr, "repo": repo})
+
           if not prs:
               print("No open PRs reference aethis-needs: aethis-cli — nothing to unstick.")
+              if unreachable:
+                  print(f"NOTE: {len(unreachable)} repo(s) were unreachable: {', '.join(unreachable)}")
               sys.exit(0)
 
           published = vtuple(version)
           for pr in prs:
-              repo = pr["repository"]["nameWithOwner"]
+              repo = pr["repo"]
               num = pr["number"]
-              body = gh("pr", "view", str(num), "-R", repo, "--json", "body", "-q", ".body") or ""
+              # The search term is a loose pre-filter; the marker regex over the
+              # body (fetched in the same call) is the real test.
+              body = pr.get("body") or ""
               m = marker.search(body)
               if not m:
-                  print(f"{repo}#{num}: marker not found in body (search false positive); skip")
                   continue
               op, required = m.group(1), m.group(2)
               required_t = vtuple(required)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **ci(publish): the downstream-unstick sweep now reaches every consumer repo.** The `unstick-downstream` job searched a single owner, so a PR carrying an `aethis-needs: aethis-cli` marker in a repo under a different owner was never found and sat as a draft indefinitely after the release it was waiting for went out. It now queries each consumer repo individually with `gh pr list --repo`, which is genuinely repo-scoped, and matches the marker against the PR body returned by that same call (one request per repo instead of a search plus a fetch per hit). A repo the token cannot read is reported as a warning instead of failing the whole sweep. No package or runtime change.
+
 ## 0.30.0 (2026-07-26)
 
 Safety and provenance for everything the CLI reads back from the API.


### PR DESCRIPTION
## The problem

The `unstick-downstream` job in `publish.yml` found dependent PRs with:

```python
search = gh(
    "search", "prs",
    "--owner", "Aethis-ai",
    ...
)
```

Several consumer repos live under a **different owner**, so that query could never see them. A PR in one of those carrying an `aethis-needs: aethis-cli` marker was silently never unstuck — it stayed a draft indefinitely after the release it was waiting for shipped. Nothing errored; the job just reported "nothing to unstick".

The arguments are split one per line, which is why a `grep 'owner Aethis-ai'` never matched this call and it survived earlier sweeps for this pattern.

## The change

- **Per-repo sweep.** Each consumer repo is queried individually with `gh pr list --repo`, which is genuinely repo-scoped. `gh search`'s `--repo` is a *qualifier against the global search index* and has been observed to be silently dropped, so it is deliberately not used here.
- **The repo list is declared in the workflow**, with a comment saying why: the canonical enumeration lives in a repository this one cannot read, so the two must be kept in step by hand when a consumer is added.
- **One request per repo instead of a search plus a fetch per hit.** `--json …,body` returns the PR body on the same call, so the marker regex runs on data already in hand rather than a follow-up `gh pr view` per candidate. The search term remains a loose pre-filter; the regex over the body is still the real test.
- **An unreachable repo warns and continues.** It is reported via `::warning::` and named in the summary rather than aborting — one inaccessible consumer must not stop the others being unstuck. (This matters here: the token needs to reach both owners.)

## Version

**No bump**, deliberately. The workflow is not part of the published distribution — an install of a bumped version would be byte-identical — and `auto-tag.yml` fires on `_version.py`, so a bump would auto-tag and publish a no-op release to PyPI. This matches the repo's own precedent for workflow-only changes (`513abdd`, which touched `publish.yml` alone with no bump). The note is recorded under `## Unreleased` and rolls into the next real version; verified the release-notes `awk` still slices `0.29.0` correctly with that heading present.

## Verification

**Observed — offline, against the real job body.** A harness extracts the inline python straight out of `publish.yml` (never a reimplementation) and runs it against a stubbed `gh` that records every call. The stub models the real API faithfully: an `--owner`-scoped search cannot return another owner's PRs.

*Fail → pass on the same fixture* (one open PR under the other owner, marker `>= 0.29.0`, publishing `0.30.0`):

```
=== OLD code ===
No open PRs reference aethis-needs: aethis-cli — nothing to unstick.
0 comments posted

=== NEW code ===
<other-owner>/ok_swift#473: marker satisfied (needs >= 0.29.0, got 0.30.0) — unsticking
  ok   queried the repo by --repo
  ok   never used 'gh search'
  ok   never used '--owner'
  ok   posted the unstick comment
  ok   flipped the draft to ready
```

Negative controls, all passing:

| scenario | expected | result |
|---|---|---|
| constraint not satisfied (`>= 9.9.9`, published `0.30.0`) | no mutation, explains why | ok |
| loose search hit whose body has no real marker | skipped, no mutation | ok |
| marker satisfied but PR already ready | comments, no redundant `ready` | ok |
| a repo the token cannot read | `::warning::` + named in summary, sweep exits 0 | ok |

**Observed — live API spot-checks** (read-only):

- `gh pr list --repo <r> --state all --search "aethis-needs"` is genuinely repo-scoped — three repos, three distinct result sets — and it does find real PRs carrying the marker (verified against a known marker-bearing PR body).
- The out-of-owner consumer **is** reachable this way, i.e. exactly the set the old query could not see.
- Historical `aethis-needs: aethis-cli` markers exist in 3 repos, all under `Aethis-ai`. **So no marker has demonstrably been missed yet** — this fix is preventive for the other-owner case, not remedial for an observed miss. Worth stating plainly rather than overselling it.

**Not observed / inferred.** The workflow itself has not been executed — it only runs on a publish, and triggering one would mean cutting a real PyPI release. The end-to-end behaviour in CI is therefore *inferred* from the offline run of the extracted job body plus the live query spot-checks. What remains genuinely unverified: whether `WORKSPACE_SYNC_TOKEN` actually has read access to the repos under the second owner. If it does not, those repos will surface as `::warning::` lines on the next publish — which is precisely why an unreachable repo is now loud instead of fatal. YAML validity confirmed by parse.

## Related

The marker-convention documentation lives in the workspace repo and is updated separately (per the one-PR-per-repo convention); it now records this caveat and warns against both owner-scoping and `gh search --repo`.
