### PR TITLE
ci: pin ruff's rule selection so a ruff release can't turn CI red

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pytest>=8.0.0",
     "respx>=0.21.0",
     "pytest-cov>=5.0.0",
-    "ruff>=0.8.0",
+    "ruff>=0.8.0,<0.17",
 ]
 
 [build-system]
@@ -57,3 +57,12 @@ addopts = "-m 'not manual and not staging' --cov=aethis_cli --cov-fail-under=45"
 [tool.ruff]
 target-version = "py311"
 line-length = 120
+
+[tool.ruff.lint]
+# Select the rule set explicitly rather than inheriting ruff's default.
+# The default selection is not stable across releases — 0.16 widened it, which
+# turned a clean tree into 215 errors on a tree nobody had touched. Naming the
+# rules here means a new ruff can add rules without silently changing what CI
+# enforces. These are the rules this project has been linted against to date;
+# widening them is a deliberate change, not a side effect of an upgrade.
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## The problem

`main` itself is red, so every PR opened against it starts red — including PRs that touch no Python at all (observed on #88, which changes only a workflow and the changelog).

## Root cause

Both CI jobs install ruff unpinned, so the rule set CI enforces is whichever set the newest ruff happens to default to. **ruff 0.16.0 widened that default.** On an unmodified checkout of `main` (`84c855c`):

```
uvx ruff@0.15.0 check aethis_cli/ tests/   # All checks passed!
uvx ruff@0.16.0 check aethis_cli/ tests/   # Found 215 errors
```

`uv.lock` is gitignored, so CI re-resolves on every run and always lands on the newest allowed ruff.

The failure cascades further than it looks: the `lint` job fails at `Ruff check`, and `test (3.11)` / `test (3.12)` fail at their *own* `Lint` step, which runs before `Test` — so **pytest never runs at all** on any PR.

## The fix

Name the rule set explicitly rather than inheriting ruff's default, and bound the dev dependency below the next minor.

Worth being clear about what these 215 errors are: they are **not** latent debt that crept in — they are rules this project never selected (pyupgrade, bugbear, blind-except, and friends). 172 are auto-fixable, but 43 need judgment, and several are deliberate here (the plugin loader's broad `except` is load-bearing — a bad plugin must warn, not crash the CLI). Mass-applying them would mix "unbreak CI" with "adopt a new lint policy" in one diff, during an incident. Widening the rule set is a good follow-up; it should be its own reviewable change, and now it can be one, because the selection is explicit.

## Verification

Fresh resolve (matching CI, since `uv.lock` is gitignored) picks up ruff 0.16.0, and all three CI steps pass:

```
uv sync --extra dev -U
uv run ruff --version                          # ruff 0.16.0
uv run ruff check aethis_cli/ tests/           # All checks passed!
uv run ruff format --check aethis_cli/ tests/  # 81 files already formatted
uv run pytest tests/ --ignore=tests/e2e        # 358 passed, 10 deselected
```

Also confirmed still clean under ruff 0.15.0, so this doesn't pin the project to one release.

## Release impact

None. No package code changes and no version bump — `auto-tag.yml` triggers only on `aethis_cli/_version.py`, so nothing is tagged or published by this PR.