### PR TITLE
fix: make auth-provider tests hermetic and stop the callback-thread traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **fix: no spurious traceback when a login callback is cancelled or times out.** The OAuth callback server closed its socket while its background thread was still waiting on it, so the thread died on `ValueError: Invalid file descriptor: -1` and printed an unhandled-exception traceback after `aethis login` timed out. The serving thread is now signalled before the socket closes, and treats a closed socket as its exit condition rather than an error.
+
 ## 0.29.0 (2026-07-21)
 
 - **feat: `aethis usage`** — show your rate-limit budget per operation class (decide / generate / author / read / keys / admin) as a table: used / limit / remaining / reset, over the rolling 24h window. `generate` (LLM rule generation) is the scarce class; browsing and status polling (`read`) are effectively unlimited. `--json`/piped emits the raw `/usage` payload. New `AethisClient.usage()`.

--- a/aethis_cli/auth.py
+++ b/aethis_cli/auth.py
@@ -73,13 +73,22 @@ class OAuthCallbackServer:
 
     def __init__(self) -> None:
         self._server: Optional[_AuthHTTPServer] = None
+        self._stop = threading.Event()
         self.port: int = 0
 
     def _serve_until_auth(self) -> None:
-        """Handle requests until we get the auth callback or server is closed."""
+        """Handle requests until we get the auth callback or the server closes."""
         assert self._server is not None
-        while not (self._server.auth_code or self._server.auth_error):
-            self._server.handle_request()
+        while not self._stop.is_set() and not (self._server.auth_code or self._server.auth_error):
+            try:
+                self._server.handle_request()
+            except (OSError, ValueError):
+                # shutdown() closed the socket out from under this thread. That
+                # is how this loop is meant to end, not a failure -- without
+                # this, the closed descriptor surfaces as an unhandled
+                # exception in a background thread ("Invalid file descriptor:
+                # -1"), printing a spurious traceback after a login times out.
+                return
 
     def start(self) -> int:
         """Bind to port 9876 and start serving in a background thread.
@@ -92,6 +101,7 @@ class OAuthCallbackServer:
             self._server = _AuthHTTPServer(("127.0.0.1", port), _CallbackHandler)
             self._server.timeout = 5.0  # Per-request timeout for the loop
             self.port = port
+            self._stop.clear()
             thread = threading.Thread(target=self._serve_until_auth, daemon=True)
             thread.start()
             return port
@@ -114,6 +124,9 @@ class OAuthCallbackServer:
         return None, None, None
 
     def shutdown(self) -> None:
+        # Signal the serving thread before closing the socket, so it can leave
+        # via the loop condition rather than by tripping over a dead descriptor.
+        self._stop.set()
         if self._server:
             self._server.server_close()
 

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from aethis_cli import auth_providers
 from aethis_cli.auth_providers import (
     ProviderContext,
     UnknownAuthMode,
@@ -11,6 +12,25 @@ from aethis_cli.auth_providers import (
     known_modes,
     register_provider,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_registry():
+    """Give each test its own view of the process-global provider registry.
+
+    The registry is filled from two directions, and both can leak into a test:
+    this module registers stubs, and ``aethis_cli.main`` registers every
+    installed plugin *at import time*. On a machine with the staff plugin
+    installed, merely importing the CLI in some other test registers extra auth
+    modes for the rest of the session -- which is why tests here could pass in
+    isolation and fail in the full suite. Snapshot and restore closes both.
+    """
+    saved = dict(auth_providers._PROVIDERS)
+    try:
+        yield
+    finally:
+        auth_providers._PROVIDERS.clear()
+        auth_providers._PROVIDERS.update(saved)
 
 
 def _ctx(api_key: str | None = None, audience: str | None = None) -> ProviderContext:
@@ -38,6 +58,11 @@ def test_none_provider_always_empty() -> None:
 
 
 def test_unknown_mode_raises_with_helpful_message() -> None:
+    # The staff plugin ships this mode, so on a machine that has it installed it
+    # may already be registered. This test is about how an *unregistered* mode
+    # is reported, so drop it first; the autouse fixture puts it back.
+    auth_providers._PROVIDERS.pop("gcloud_id_token", None)
+
     with pytest.raises(UnknownAuthMode) as exc_info:
         get_provider("gcloud_id_token")
     msg = str(exc_info.value)
@@ -46,28 +71,29 @@ def test_unknown_mode_raises_with_helpful_message() -> None:
     assert "aethis-cli-internal" in msg
 
 
+def test_unknown_mode_message_lists_plugin_registered_modes() -> None:
+    # The inverse of the test above, and the regression guard for it: with a
+    # plugin's mode present, an unknown mode must still report correctly and
+    # advertise the plugin mode as available.
+    register_provider("gcloud_id_token", lambda ctx: {"Authorization": "Bearer x"})
+
+    with pytest.raises(UnknownAuthMode) as exc_info:
+        get_provider("no_plugin_registers_this")
+    msg = str(exc_info.value)
+    assert "no_plugin_registers_this" in msg
+    assert "gcloud_id_token" in msg
+
+
 def test_register_and_lookup_plugin_provider() -> None:
     def stub_provider(ctx: ProviderContext) -> dict[str, str]:
         return {"Authorization": f"Bearer fake-token-for-{ctx.profile.get('audience')}"}
 
     register_provider("test_provider", stub_provider)
-    try:
-        assert "test_provider" in known_modes()
-        headers = get_provider("test_provider")(_ctx(audience="aud-1"))
-        assert headers == {"Authorization": "Bearer fake-token-for-aud-1"}
-    finally:
-        # Don't leak the test provider into other test modules.
-        from aethis_cli import auth_providers
-
-        auth_providers._PROVIDERS.pop("test_provider", None)
+    assert "test_provider" in known_modes()
+    headers = get_provider("test_provider")(_ctx(audience="aud-1"))
+    assert headers == {"Authorization": "Bearer fake-token-for-aud-1"}
 
 
 def test_re_register_replaces_provider() -> None:
-    from aethis_cli import auth_providers
-
-    original = auth_providers._PROVIDERS["api_key"]
-    try:
-        register_provider("api_key", lambda ctx: {"X-Other": "x"})
-        assert get_provider("api_key")(_ctx()) == {"X-Other": "x"}
-    finally:
-        auth_providers._PROVIDERS["api_key"] = original
+    register_provider("api_key", lambda ctx: {"X-Other": "x"})
+    assert get_provider("api_key")(_ctx()) == {"X-Other": "x"}


### PR DESCRIPTION
Supersedes #91, which GitHub auto-closed when its base branch was deleted on the #90 merge. Same commit, rebased onto `main`, now targeting `main` so CI actually runs on it.

## Correcting the diagnosis

This was reported as "an earlier test mutates the shared auth-provider registry without restoring it". That isn't what's happening — the existing tests already restore correctly in `finally` blocks, and nothing in the suite registers the mode in question. The leak comes from the *other* direction.

`aethis_cli/main.py` runs its plugin loader **at import time**. On a machine with the staff plugin installed, the moment any test imports the CLI, that plugin has registered its auth modes for the rest of the session — including the one `test_unknown_mode_raises_with_helpful_message` asserts is absent. `tests/test_auth_providers.py` never imports the CLI itself, which is exactly why the test passes in isolation and fails in the full suite.

**This is therefore not a CI blocker.** CI runs `uv sync --extra dev` into a fresh environment with no staff plugin, so this test passes there — it would have passed all along, had the lint step ever let pytest run. It is a real defect all the same: the test depends on ambient environment state, so it fails for every developer who has the staff plugin installed, which is the people most likely to be running the suite.

## What changed

1. **Registry isolation** (`tests/test_auth_providers.py`) — an autouse fixture snapshots and restores the process-global registry around every test, closing both leak directions. The unknown-mode test drops the mode it asserts is absent. The existing per-test `try/finally` cleanup becomes redundant and is removed. Added the inverse test as the regression guard: with a plugin mode registered, an unknown mode must still report correctly *and* list the plugin mode as available.

2. **Callback-thread traceback** (`aethis_cli/auth.py`) — this one is a production bug, not just test noise. `shutdown()` closed the server socket while the background thread was still waiting on it, so the thread died on `ValueError: Invalid file descriptor: -1`. Under pytest that surfaced as `PytestUnhandledThreadExceptionWarning`; in real use, the same path runs whenever `aethis login` times out or is cancelled, printing an unhandled-exception traceback at the user. The thread is now signalled before the socket closes and treats a closed socket as its exit condition.

## Verification

Reproduced the actual failure condition by installing the staff plugin into a pristine checkout of `main`, then applying this change:

```
before:  1 failed, 357 passed   + PytestUnhandledThreadExceptionWarning
after:   359 passed             + no warning
```

Clean environment (what CI has): `359 passed, 10 deselected`; `ruff check` and `ruff format --check` both clean.

## Release impact

Touches package code (`aethis_cli/auth.py`) but **deliberately does not bump the version** — `auto-tag.yml` fires on `aethis_cli/_version.py` and would tag and publish to PyPI, and 0.29.0 is currently being held pending its server-side dependency. The fix is recorded under `## Unreleased` for whoever cuts the next release.