### PR TITLE
feat: generate replaces a project's test cases instead of adding a copy (v0.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.32.0 (2026-08-05)
+
+Re-uploading a test suite no longer leaves a second copy of it.
+
+- **fix: `aethis generate` replaces the project's test cases instead of adding another copy of them.** `tests/scenarios.yaml` is the authoritative suite and it was uploaded in full on every run, while the API only ever appended — so N authoring cycles left N copies of every case. Nothing errored: duplicates inflate the denominator of every pass rate, so a run reported a total that looked like a result and was partly copies of itself. Two real projects were found holding 185 and 96 cases against files of 42 and 14. The upload now asks the engine to replace, which makes it idempotent.
+- **feat: the count of cases the upload overwrote is reported.** Replacing is destructive — it removes what was on the project — so `aethis generate` prints how many cases went and how many arrived (`Uploaded 42 test case(s) from scenarios.yaml — 42 replaced`) rather than performing it silently.
+- **feat: an engine that cannot replace is named, not worked around quietly.** Replacing needs an engine that offers it, and one that does not offer it does not reject the request — it ignores the member and appends, so sending it blindly would restore the duplication with nothing to notice. The CLI reads the engine's own published schema, sends the flag only where it is advertised, and where it is not — or where the schema could not be read at all, which is a different answer and says so — prints that the upload APPENDED, that running again adds another copy, and what to do about it. Nothing is dropped silently in either direction.
+
 ## 0.31.0 (2026-07-27)
 
 Publish with citations — and be able to cite a document you hold, not just one

--- a/README.md
+++ b/README.md
@@ -400,6 +400,13 @@ tests:
       outcome: not_eligible
 ```
 
+This file is the authoritative suite: `aethis generate` uploads it in full and
+**replaces** the project's test cases with it, so running generate twice leaves
+one copy, not two. The upload reports how many existing cases it overwrote. An
+older API host may not offer replacement — where that is so, `aethis generate`
+says the cases were appended and that running again will add another copy,
+rather than leaving you to discover it in an inflated pass-rate total.
+
 ## Environment variables
 
 | Variable | Description | Required | Default |

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -17,6 +17,11 @@ from aethis_cli.errors import AethisAPIError
 # returns a fresh API key, or raises :class:`AuthRequired` to abort cleanly.
 KeyRefreshCallback = Callable[..., str]
 
+# Marker for "this client has not asked the engine yet". Distinct from both
+# True/False (asked, got an answer) and None (asked, could not tell) — the
+# three states a capability probe genuinely has.
+_UNPROBED = object()
+
 
 class AethisClient:
     """Synchronous client wrapping all Aethis API endpoints."""
@@ -72,6 +77,9 @@ class AethisClient:
         # meaningful joined to the host it was published on — so renderers
         # need to be able to ask.
         self.base_url = base_url
+        # Cached answer to "does this engine accept `replace` on a test-case
+        # upload?" — one probe per client, not one per call.
+        self._test_replace_support: Any = _UNPROBED
 
     def close(self) -> None:
         self._client.close()
@@ -251,14 +259,61 @@ class AethisClient:
         """
         return self._request("GET", f"/api/v1/public/projects/{project_id}/sources")
 
-    def add_tests(self, project_id: str, test_cases: list[dict]) -> dict:
+    def add_tests(self, project_id: str, test_cases: list[dict], replace: bool = False) -> dict:
+        """Upload golden test cases to a project.
+
+        ``replace=True`` makes the upload idempotent: the supplied list becomes
+        the project's test cases instead of being added to whatever is already
+        there, and the response reports ``replaced`` — how many existing cases
+        were overwritten — alongside ``added``.
+
+        Only send it to an engine that advertises it (see
+        :meth:`supports_test_replace`). An engine without the member does not
+        reject the request; it ignores it and appends, which is the silent
+        duplication this flag exists to stop. The member is therefore omitted
+        entirely rather than sent as ``false``, so an engine's own default
+        decides — and so nothing is ever sent that could be quietly dropped.
+        """
+        body: dict = {"test_cases": test_cases}
+        if replace:
+            body["replace"] = True
         return self._request(
             "POST",
             f"/api/v1/public/projects/{project_id}/tests",
-            json={
-                "test_cases": test_cases,
-            },
+            json=body,
         )
+
+    def supports_test_replace(self) -> Optional[bool]:
+        """Does the engine this client talks to accept ``replace`` on a test upload?
+
+        Answered from the engine's own published schema — ``replace`` under
+        ``components.schemas.AddTestCaseRequest.properties`` — rather than from
+        the CLI's version, because the two are deployed independently and the
+        same CLI is pointed at engines of different vintages.
+
+        Returns ``True``/``False`` when the schema answered, and ``None`` when
+        it could not be read at all. **Unknown is not unsupported**: the caller
+        must say which of the two it got, because both mean the upload appends
+        and only one of them means the engine is old.
+        """
+        if self._test_replace_support is not _UNPROBED:
+            return self._test_replace_support  # type: ignore[return-value]
+        answer: Optional[bool]
+        try:
+            resp = self._client.get("/openapi.json", timeout=15.0)
+            if resp.status_code >= 400:
+                answer = None
+            else:
+                schemas = resp.json()["components"]["schemas"]
+                properties = schemas["AddTestCaseRequest"]["properties"]
+                answer = "replace" in properties
+        except (httpx.HTTPError, ValueError, KeyError, TypeError):
+            # Unreachable, non-JSON (an intermediary's error page), or a schema
+            # shaped differently than expected. None of those is evidence about
+            # the engine's behaviour, so none of them may read as an answer.
+            answer = None
+        self._test_replace_support = answer
+        return answer
 
     def set_field_spec(self, project_id: str, expected_fields: list[dict]) -> dict:
         """Pin the project's expected field vocabulary (key + type + enum values).

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -20,7 +20,7 @@ from aethis_cli.config import (
     write_state,
 )
 from aethis_cli.errors import AethisAPIError, ConfigError
-from aethis_cli.output import console, error_panel, info, success
+from aethis_cli.output import console, error_panel, info, success, warn
 
 
 def _chunks(lst: list, n: int):
@@ -441,28 +441,7 @@ def _run_generate(
         _upload_field_vocabulary(client, pid, project_dir)
 
         # Upload test cases
-        tests_path = project_dir / "tests" / "scenarios.yaml"
-        if tests_path.exists():
-            if tests_path.stat().st_size > 1_000_000:
-                console.print(f"[red]{tests_path} exceeds 1 MB limit[/red]")
-                raise typer.Exit(code=1)
-            try:
-                raw = yaml.safe_load(tests_path.read_text()) or {}
-            except yaml.YAMLError as e:
-                console.print(f"[red]Invalid YAML in {tests_path}: {e}[/red]")
-                raise typer.Exit(code=1)
-            test_cases = raw.get("tests", [])
-            if test_cases:
-                normalised = [
-                    {
-                        "name": tc["name"],
-                        "field_values": tc.get("inputs", {}),
-                        "expected_outcome": tc.get("expect", {}).get("outcome", "eligible"),
-                    }
-                    for tc in test_cases
-                ]
-                client.add_tests(pid, normalised)
-                info(f"Added {len(test_cases)} test case(s)")
+        _upload_test_cases(client, pid, project_dir)
 
         # Trigger generation
         if mode == "refine":
@@ -495,6 +474,71 @@ def _run_generate(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+
+
+def _upload_test_cases(client: AethisClient, pid: str, project_dir: Path) -> None:
+    """Upload `tests/scenarios.yaml` as the project's test cases.
+
+    The file is the authoritative suite, so the upload replaces what is on the
+    project rather than adding to it. That is not free: uploading the same file
+    twice used to leave two copies of every case, and duplicates do not error —
+    they inflate the denominator of every pass rate, so a run reports a total
+    that looks like a result and is partly copies of itself.
+
+    Replacing needs an engine that supports it. Ask the engine rather than
+    assuming, because an engine that does not support it does not say so: it
+    ignores the unknown member and appends, which would restore the duplication
+    with nothing to notice. Where the answer is no — or cannot be read — the
+    upload still happens, and says so.
+    """
+    tests_path = project_dir / "tests" / "scenarios.yaml"
+    if not tests_path.exists():
+        return
+    if tests_path.stat().st_size > 1_000_000:
+        console.print(f"[red]{tests_path} exceeds 1 MB limit[/red]")
+        raise typer.Exit(code=1)
+    try:
+        raw = yaml.safe_load(tests_path.read_text()) or {}
+    except yaml.YAMLError as e:
+        console.print(f"[red]Invalid YAML in {tests_path}: {e}[/red]")
+        raise typer.Exit(code=1)
+    test_cases = raw.get("tests", [])
+    if not test_cases:
+        return
+    normalised = [
+        {
+            "name": tc["name"],
+            "field_values": tc.get("inputs", {}),
+            "expected_outcome": tc.get("expect", {}).get("outcome", "eligible"),
+        }
+        for tc in test_cases
+    ]
+
+    supported = client.supports_test_replace()
+    if supported:
+        result = client.add_tests(pid, normalised, replace=True) or {}
+        added = result.get("added", len(normalised))
+        replaced = result.get("replaced", 0)
+        # The replaced count is the destructive half of an idempotent upload:
+        # it is how many cases this run removed from the project. Printed
+        # always, including the reassuring zero of a first upload.
+        info(f"Uploaded {added} test case(s) from {tests_path.name} — {replaced} replaced")
+        return
+
+    client.add_tests(pid, normalised)
+    info(f"Added {len(normalised)} test case(s)")
+    reason = (
+        "this engine does not offer it"
+        if supported is False
+        else "the engine's API schema could not be read, so its support could not be confirmed"
+    )
+    warn(
+        f"Test cases were APPENDED, not replaced — {reason}. "
+        f"Any cases already on the project are still there, so running this again adds "
+        f"another copy of all {len(normalised)}. Duplicates do not fail: they inflate the "
+        f"total every pass rate is measured against. Remove the extra copies on the "
+        f"project, or point at an engine that supports replacing them."
+    )
 
 
 def _report_field_diff(client: AethisClient, ruleset_id: Optional[str], project_dir: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.31.0"
+version = "0.32.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/mutation-check.py
+++ b/scripts/mutation-check.py
@@ -174,6 +174,56 @@ MUTATIONS: List[Mutation] = [
         "    keep = list(fields)",
         "--json <fields> loses the enforcement record",
     ),
+    # -- the test-case upload is idempotent, or says it is not -------------
+    Mutation(
+        "tests-upload-appends-again",
+        "aethis_cli/commands/generate_cmd.py",
+        "        result = client.add_tests(pid, normalised, replace=True) or {}",
+        "        result = client.add_tests(pid, normalised) or {}",
+        "every generate run duplicates the whole test suite again",
+    ),
+    Mutation(
+        "capability-gate-bypassed",
+        "aethis_cli/commands/generate_cmd.py",
+        "    supported = client.supports_test_replace()",
+        "    supported = True",
+        "the flag is sent to an engine that would silently ignore it",
+    ),
+    Mutation(
+        "append-warning-silenced",
+        "aethis_cli/commands/generate_cmd.py",
+        '    warn(\n        f"Test cases were APPENDED, not replaced',
+        '    _ = (\n        f"Test cases were APPENDED, not replaced',
+        "an appending upload goes back to being silent",
+    ),
+    Mutation(
+        "replaced-count-hidden",
+        "aethis_cli/commands/generate_cmd.py",
+        'info(f"Uploaded {added} test case(s) from {tests_path.name} — {replaced} replaced")',
+        'info(f"Uploaded {added} test case(s) from {tests_path.name}")',
+        "a destructive overwrite stops being visible",
+    ),
+    Mutation(
+        "unknown-schema-reads-as-supported",
+        "aethis_cli/client.py",
+        "            answer = None\n        self._test_replace_support = answer",
+        "            answer = True\n        self._test_replace_support = answer",
+        "an unreadable schema is treated as a capability the engine may not have",
+    ),
+    Mutation(
+        "capability-probe-matches-substring",
+        "aethis_cli/client.py",
+        'answer = "replace" in properties',
+        'answer = "replace" in str(properties)',
+        "a member merely containing the word reads as the member",
+    ),
+    Mutation(
+        "add-tests-always-replaces",
+        "aethis_cli/client.py",
+        "        if replace:\n            body[\"replace\"] = True",
+        "        if True:\n            body[\"replace\"] = True",
+        "the client sends a destructive flag nobody asked for",
+    ),
 ]
 
 

--- a/tests/test_generate_replace_tests.py
+++ b/tests/test_generate_replace_tests.py
@@ -1,0 +1,319 @@
+"""Uploading `tests/scenarios.yaml` must be idempotent, or say that it is not.
+
+`aethis generate` uploads the whole of `tests/scenarios.yaml` on every run.
+The API only ever appended, so N authoring cycles left N copies of every test
+case — silently, because duplicates do not error: they inflate the denominator
+of every pass rate. A run reporting `151/185 passed` looked like a legitimate
+result while a third of the suite was copies of itself.
+
+The engine now accepts `replace`, which makes the upload idempotent. Not every
+engine carries it yet, and an engine that does not carry it **ignores the
+member rather than rejecting it** — so sending the flag blindly would restore
+the duplication without a single error to notice. The upload therefore asks the
+engine what it supports, and says out loud when the answer is "append".
+
+The fake engine below is stateful on purpose: these tests assert what is left
+on the server after three runs, which is the thing the bug was about.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import httpx
+import pytest
+import respx
+import typer
+
+from aethis_cli.client import AethisClient
+from aethis_cli.commands import generate_cmd
+
+BASE = "http://engine.test"
+
+SCENARIOS = """\
+tests:
+  - name: eligible adult
+    inputs:
+      applicant.age: 25
+    expect:
+      outcome: eligible
+  - name: too young
+    inputs:
+      applicant.age: 10
+    expect:
+      outcome: not_eligible
+  - name: unknown age
+    inputs: {}
+    expect:
+      outcome: undetermined
+"""
+
+N_CASES = 3
+
+
+class FakeEngine:
+    """An in-memory stand-in for the project's test-case store.
+
+    Mirrors the engine: `replace=true` -> `$set` (and reports how many were
+    removed); anything else -> `$push`. An engine WITHOUT the capability
+    ignores an unknown body member rather than rejecting it, exactly as an
+    unconfigured pydantic model does — which is why `bodies` is recorded and
+    asserted on: a 422 would never arrive to warn anyone.
+    """
+
+    def __init__(
+        self,
+        *,
+        supports_replace: bool,
+        openapi_status: int = 200,
+        extra_properties: tuple[str, ...] = (),
+    ) -> None:
+        self.store: list[dict] = []
+        self.supports_replace = supports_replace
+        self.openapi_status = openapi_status
+        self.extra_properties = extra_properties
+        self.bodies: list[dict] = []
+        self.openapi_calls = 0
+
+    def openapi(self, request: httpx.Request) -> httpx.Response:
+        self.openapi_calls += 1
+        if self.openapi_status != 200:
+            return httpx.Response(self.openapi_status, json={"detail": "unavailable"})
+        properties: dict = {"test_cases": {"type": "array"}}
+        for name in self.extra_properties:
+            properties[name] = {"type": "boolean", "default": False}
+        if self.supports_replace:
+            properties["replace"] = {"type": "boolean", "default": False}
+        return httpx.Response(
+            200,
+            json={
+                "info": {"version": "0.0.0-test"},
+                "components": {"schemas": {"AddTestCaseRequest": {"properties": properties}}},
+            },
+        )
+
+    def add_tests(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        self.bodies.append(body)
+        cases = body["test_cases"]
+        if body.get("replace") and self.supports_replace:
+            removed = len(self.store)
+            self.store = list(cases)
+            return httpx.Response(201, json={"added": len(cases), "replaced": removed})
+        # No capability, or replace not asked for: append, like the old engine.
+        self.store.extend(cases)
+        return httpx.Response(201, json={"added": len(cases), "replaced": 0})
+
+
+def _mount(engine: FakeEngine, router) -> None:
+    _mount_schema(engine, router)
+    router.post("/api/v1/public/projects/proj_abc/tests").mock(side_effect=engine.add_tests)
+
+
+def _mount_schema(engine: FakeEngine, router) -> None:
+    router.get("/openapi.json").mock(side_effect=engine.openapi)
+
+
+def _mount_uploads(engine: FakeEngine, router) -> None:
+    router.post("/api/v1/public/projects/proj_abc/tests").mock(side_effect=engine.add_tests)
+
+
+def _project(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    (tests_dir / "scenarios.yaml").write_text(SCENARIOS)
+    return tmp_path
+
+
+def _flat(capsys) -> str:
+    """Rich wraps at the terminal width; assert on content, not on wrapping."""
+    return re.sub(r"\s+", " ", capsys.readouterr().out)
+
+
+# ---------------------------------------------------------------------------
+# The originating problem: three runs, three copies
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE)
+def test_three_runs_leave_one_copy_when_the_engine_supports_replace(respx_mock, tmp_path):
+    engine = FakeEngine(supports_replace=True)
+    _mount(engine, respx_mock)
+    project_dir = _project(tmp_path)
+
+    for _ in range(3):
+        with AethisClient("ak", BASE) as client:
+            generate_cmd._upload_test_cases(client, "proj_abc", project_dir)
+
+    assert len(engine.store) == N_CASES, "three runs must leave one copy of the file, not three"
+    assert all(body.get("replace") is True for body in engine.bodies)
+
+
+@respx.mock(base_url=BASE)
+def test_the_replaced_count_is_reported_so_an_overwrite_is_visible(respx_mock, tmp_path, capsys):
+    engine = FakeEngine(supports_replace=True)
+    _mount(engine, respx_mock)
+    project_dir = _project(tmp_path)
+
+    with AethisClient("ak", BASE) as client:
+        generate_cmd._upload_test_cases(client, "proj_abc", project_dir)
+    first = _flat(capsys)
+    # Nothing was there to overwrite on the first run.
+    assert "0 replaced" in first
+
+    with AethisClient("ak", BASE) as client:
+        generate_cmd._upload_test_cases(client, "proj_abc", project_dir)
+    second = _flat(capsys)
+    assert f"{N_CASES} replaced" in second, "the count of overwritten cases must be shown, not just the word"
+
+
+# ---------------------------------------------------------------------------
+# An engine without the capability: append, but never silently
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE)
+def test_the_flag_is_not_sent_to_an_engine_that_does_not_advertise_it(respx_mock, tmp_path):
+    engine = FakeEngine(supports_replace=False)
+    _mount(engine, respx_mock)
+    project_dir = _project(tmp_path)
+
+    with AethisClient("ak", BASE) as client:
+        generate_cmd._upload_test_cases(client, "proj_abc", project_dir)
+
+    assert engine.bodies, "the upload must still happen"
+    assert "replace" not in engine.bodies[0], (
+        "an engine without the capability IGNORES the member rather than rejecting it, "
+        "so sending it would restore the duplication with nothing to notice"
+    )
+
+
+@respx.mock(base_url=BASE)
+def test_an_appending_engine_is_warned_about_in_words(respx_mock, tmp_path, capsys):
+    engine = FakeEngine(supports_replace=False)
+    _mount(engine, respx_mock)
+    project_dir = _project(tmp_path)
+
+    for _ in range(3):
+        with AethisClient("ak", BASE) as client:
+            generate_cmd._upload_test_cases(client, "proj_abc", project_dir)
+    out = _flat(capsys).lower()
+
+    # The duplication genuinely happens here — that is the engine's behaviour,
+    # not something the CLI can fix. What the CLI must not do is hide it.
+    assert len(engine.store) == 3 * N_CASES
+    assert "append" in out
+    assert "duplicate" in out or "copy" in out or "copies" in out
+
+
+@respx.mock(base_url=BASE)
+def test_an_unreadable_schema_is_unknown_not_supported(respx_mock, tmp_path, capsys):
+    engine = FakeEngine(supports_replace=True, openapi_status=500)
+    _mount(engine, respx_mock)
+    project_dir = _project(tmp_path)
+
+    with AethisClient("ak", BASE) as client:
+        assert client.supports_test_replace() is None
+        generate_cmd._upload_test_cases(client, "proj_abc", project_dir)
+
+    out = _flat(capsys).lower()
+    assert "replace" not in engine.bodies[0], "unknown is not supported"
+    assert "append" in out
+
+
+# ---------------------------------------------------------------------------
+# The capability probe itself
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE)
+def test_capability_probe_reads_the_engines_own_schema(respx_mock):
+    engine = FakeEngine(supports_replace=True)
+    _mount_schema(engine, respx_mock)
+    with AethisClient("ak", BASE) as client:
+        assert client.supports_test_replace() is True
+
+
+@respx.mock(base_url=BASE)
+def test_capability_probe_says_false_when_the_schema_lacks_the_member(respx_mock):
+    engine = FakeEngine(supports_replace=False)
+    _mount_schema(engine, respx_mock)
+    with AethisClient("ak", BASE) as client:
+        assert client.supports_test_replace() is False
+
+
+@respx.mock(base_url=BASE)
+def test_a_member_merely_containing_the_word_is_not_the_member(respx_mock):
+    """Schemas grow. A future engine gaining `replace_all` (or any member the
+    word `replace` is a substring of) must not read as this capability — the
+    probe asks for the member, never for the word appearing somewhere."""
+    engine = FakeEngine(supports_replace=False, extra_properties=("replace_all", "replacement_policy"))
+    _mount_schema(engine, respx_mock)
+    with AethisClient("ak", BASE) as client:
+        assert client.supports_test_replace() is False
+
+
+@respx.mock(base_url=BASE)
+def test_capability_probe_is_asked_once_per_client(respx_mock):
+    engine = FakeEngine(supports_replace=True)
+    _mount_schema(engine, respx_mock)
+    with AethisClient("ak", BASE) as client:
+        client.supports_test_replace()
+        client.supports_test_replace()
+        client.supports_test_replace()
+    assert engine.openapi_calls == 1
+
+
+@respx.mock(base_url=BASE)
+def test_a_malformed_schema_is_unknown_rather_than_a_crash(respx_mock):
+    respx_mock.get("/openapi.json").mock(return_value=httpx.Response(200, json={"components": "not-a-dict"}))
+    with AethisClient("ak", BASE) as client:
+        assert client.supports_test_replace() is None
+
+
+@respx.mock(base_url=BASE)
+def test_a_non_json_schema_response_is_unknown_rather_than_a_crash(respx_mock):
+    respx_mock.get("/openapi.json").mock(return_value=httpx.Response(200, text="<html>proxy error</html>"))
+    with AethisClient("ak", BASE) as client:
+        assert client.supports_test_replace() is None
+
+
+# ---------------------------------------------------------------------------
+# The client method
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE)
+def test_add_tests_omits_replace_unless_asked(respx_mock):
+    engine = FakeEngine(supports_replace=True)
+    _mount_uploads(engine, respx_mock)
+    cases = [{"name": "a", "field_values": {}, "expected_outcome": "eligible"}]
+    with AethisClient("ak", BASE) as client:
+        client.add_tests("proj_abc", cases)
+        assert "replace" not in engine.bodies[-1]
+        client.add_tests("proj_abc", cases, replace=True)
+        assert engine.bodies[-1]["replace"] is True
+
+
+# ---------------------------------------------------------------------------
+# Existing behaviour that must survive
+# ---------------------------------------------------------------------------
+
+
+def test_no_scenarios_file_is_not_an_error(tmp_path):
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    generate_cmd._upload_test_cases(client, "proj_abc", tmp_path)
+    client.add_tests.assert_not_called()
+
+
+def test_invalid_yaml_still_exits_one(tmp_path):
+    from unittest.mock import MagicMock
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "scenarios.yaml").write_text("tests: [\n  - unclosed")
+    with pytest.raises(typer.Exit) as exc:
+        generate_cmd._upload_test_cases(MagicMock(), "proj_abc", tmp_path)
+    assert exc.value.exit_code == 1


### PR DESCRIPTION
Closes #99.

## The problem, restated from the reporter's seat

`tests/scenarios.yaml` is the authoritative suite, and `aethis generate` uploaded it **in full on every run** while the API only ever appended. N authoring cycles left N copies of every case, and nothing errored — duplicates inflate the denominator of every pass rate, so a run reported `151/185 passed` and read like a legitimate result while a third of the suite was copies of itself.

## The fix

- `client.add_tests(..., replace=True)` where the engine offers it: the upload becomes idempotent.
- The `replaced` count is printed — `Uploaded 42 test case(s) from scenarios.yaml — 42 replaced` — because replacing removes what was there, and a destructive operation should not be silent.
- **The flag is capability-gated on the engine's published schema**, not on the CLI's version.

## Why the gate is the schema and not a 422 fallback

The issue offered two options: gate on `openapi`, or accept the 422 and fall back. **The 422 never arrives.** `AddTestCaseRequest` is an ordinary pydantic model with no `extra="forbid"`, so an engine without aethis-core#404 *ignores* the unknown member and appends. A fallback keyed on the rejection would sit there never firing while the duplication continued — the exact silent failure this issue is about. So:

```python
supported = client.supports_test_replace()   # reads components.schemas.AddTestCaseRequest.properties
```

Three states, kept distinct: `True` (advertised → send it), `False` (not advertised → append, and say so), `None` (schema unreadable → **unknown is not unsupported** → append, and say *that*, with a different sentence). One probe per client, cached.

When the answer is not `True` the upload still happens and the CLI warns in words:

> Test cases were APPENDED, not replaced — this engine does not offer it. Any cases already on the project are still there, so running this again adds another copy of all 42. Duplicates do not fail: they inflate the total every pass rate is measured against. Remove the extra copies on the project, or point at an engine that supports replacing them.

## Evidence

**Red → green (TDD).** The tests were written first against a *stateful* fake engine (`$set` vs `$push`, and — importantly — one that **ignores** an unknown member rather than rejecting it), so the assertion is what is left on the server after three runs, not what the CLI intended.

```
$ uv run python -m pytest tests/test_generate_replace_tests.py -q      # before implementation
13 failed in 0.82s

$ uv run python -m pytest tests/test_generate_replace_tests.py -q      # after
14 passed in 1.14s

$ uv run python -m pytest tests/ -q
516 passed, 24 deselected in 8.75s
```

**Against the real hosts** (the gate, not a mock):

```
$ uv run python -c "..."
https://api.aethis.ai         -> False   # warns and appends
https://staging.api.aethis.ai -> True    # replaces
```

**Mutation battery** — seven mutations added to `scripts/mutation-check.py` (the durable harness), each run as a whole-suite kill check. Every one killed:

| mutation | what it breaks | result |
|---|---|---|
| `tests-upload-appends-again` | reverts the fix (`replace=True` dropped) | killed |
| `capability-gate-bypassed` | sends the flag to an engine that would ignore it | killed |
| `append-warning-silenced` | the appending upload goes quiet again | killed |
| `replaced-count-hidden` | the overwrite stops being visible | killed |
| `unknown-schema-reads-as-supported` | `None` treated as `True` | killed |
| `capability-probe-matches-substring` | `"replace" in str(properties)` instead of the member | killed |
| `add-tests-always-replaces` | client sends a destructive flag nobody asked for | killed |

The sixth is the growth-direction case: a future engine gaining `replace_all` must not read as this capability, so the fixture advertises `replace_all` + `replacement_policy` and asserts the probe still says `False`.

## Also in this PR

- Version `0.31.0 → 0.32.0` (minor — additive behaviour) in `pyproject.toml` + `_version.py`, with the `## Unreleased` heading renamed to `## 0.32.0 (2026-08-05)`, same commit.
- The upload block moved out of `_run_generate` into `_upload_test_cases(client, pid, project_dir)` — it is the unit the tests drive, and the existing size/YAML/exit-1 behaviour is pinned by tests unchanged.
- README documents the replace semantics and the append warning.

## Residual

`aethis generate` now makes one extra unauthenticated `GET /openapi.json` per run (cached per client). Against a prod engine the upload still appends — that is the engine's behaviour and the CLI can only report it; the duplication stops there once aethis-core#404 reaches `api.aethis.ai`.
