### PR TITLE
feat(generate): --no-publish leaves the ruleset an unpublished draft (v0.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.34.0 (2026-08-15)
+
+Generating a ruleset no longer has to activate it.
+
+- **feat: `aethis generate --no-publish` leaves the ruleset an unpublished draft.** A successful `aethis generate --poll` publishes what it produced, and publishing *activates* it. For authoring that must leave a draft behind — a ruleset that only ever activates somewhere else, after promotion — there was no way to opt out, and the only workaround was to archive it immediately afterwards, which leaves a real window where it is live. The flag suppresses the publish and nothing else: the poll, its timeout, and the post-generation field diff are untouched, because those are what make the run worth doing.
+- **feat: the ending says which one it was.** A run that was told not to publish reads differently from one whose publish failed. Both leave a draft and both point at `aethis publish`, so collapsing them would tell an author who never passed the flag that everything went to plan — precisely when they most need to know it did not. The deliberate ending names the flag; the failure ending is unchanged.
+- **Unchanged without the flag.** It defaults off, and `aethis refine`, which shares the same machinery, was not asked to change and does not: the publish still happens on the same call with the same argument.
+
 ## 0.33.0 (2026-08-15)
 
 A pinned enum's members are checked, not just its name — and the check survives

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ The same contract and the same exit codes apply to
 | Command | Description |
 |---------|-------------|
 | `aethis init` | Initialise a new project in the current directory |
-| `aethis generate [--poll]` | Upload sources + guidance, trigger generation |
+| `aethis generate [--poll]` | Upload sources + guidance, trigger generation. A successful `--poll` run publishes the ruleset, making it active |
+| `aethis generate --no-publish` | The same run, leaving the ruleset an unpublished draft — for workflows where activation is separately gated |
 | `aethis status` | Check generation job progress |
 | `aethis test` | Run test cases against the latest ruleset |
 | `aethis publish [--force]` | Set the latest ruleset as active |

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -354,6 +354,11 @@ def generate(
         "--seed-ruleset-id",
         help="Ruleset to seed a refine from (defaults to the section's active ruleset)",
     ),
+    no_publish: bool = typer.Option(
+        False,
+        "--no-publish",
+        help="Leave the generated ruleset unpublished (a draft) instead of activating it",
+    ),
 ) -> None:
     """Upload sources + guidance, trigger ruleset generation, and poll until done."""
     _run_generate(
@@ -362,6 +367,7 @@ def generate(
         timeout=timeout,
         mode=mode,
         seed_ruleset_id=seed_ruleset_id,
+        no_publish=no_publish,
     )
 
 
@@ -373,8 +379,14 @@ def _run_generate(
     mode: str = "fresh",
     seed_ruleset_id: Optional[str] = None,
     extra_hint: Optional[str] = None,
+    no_publish: bool = False,
 ) -> None:
-    """Shared machinery for ``aethis generate`` and ``aethis refine``."""
+    """Shared machinery for ``aethis generate`` and ``aethis refine``.
+
+    ``no_publish`` defaults off, and ``aethis refine`` does not pass it: this
+    is the plumbing for one flag on one command, not a change of default for
+    everything that shares the machinery.
+    """
     try:
         cfg = load_project_config()
         api_key = resolve_api_key(cfg)
@@ -464,7 +476,7 @@ def _run_generate(
             return
 
         # Poll with progress spinner
-        outcome = _poll_until_done(client, pid, project_dir, timeout)
+        outcome = _poll_until_done(client, pid, project_dir, timeout, no_publish=no_publish)
 
         # Surface how the produced field vocabulary compares to what was pinned,
         # rather than letting any drift pass silently. The comparison is always
@@ -726,7 +738,14 @@ def _invalidate_stale_pointer(project_dir: Path, status: str) -> None:
     )
 
 
-def _poll_until_done(client: AethisClient, pid: str, project_dir: Path, timeout: int = 600) -> GenerationOutcome:
+def _poll_until_done(
+    client: AethisClient,
+    pid: str,
+    project_dir: Path,
+    timeout: int = 600,
+    *,
+    no_publish: bool = False,
+) -> GenerationOutcome:
     """Poll a generation to completion and report how it ended.
 
     Returns rather than raising on failure. Raising here is what made the
@@ -735,6 +754,11 @@ def _poll_until_done(client: AethisClient, pid: str, project_dir: Path, timeout:
     prints the diff, so a failed generation said "Generation failed" and
     nothing about what the model had actually produced. Exiting is the
     caller's job, after it has reported.
+
+    ``no_publish`` suppresses the publish on success and nothing else. It is
+    threaded down to here rather than handled by the caller because this is
+    where the publish happens, and a caller that published afterwards would
+    reintroduce the activation the flag exists to prevent.
     """
     deadline = time.monotonic() + timeout
     with Progress(
@@ -772,6 +796,23 @@ def _poll_until_done(client: AethisClient, pid: str, project_dir: Path, timeout:
                 if ruleset_id:
                     write_state(project_dir, {"ruleset_id": ruleset_id})
                 console.print()
+                if no_publish:
+                    # Publishing ACTIVATES the ruleset, which is the wrong
+                    # ending for authoring that must leave a draft behind. Say
+                    # the flag's name: this reads much like the publish-failed
+                    # message below, and an author needs to tell the ending
+                    # they chose from the one that happened to them.
+                    if ruleset_id:
+                        success(
+                            f"Done! Ruleset: {ruleset_id} — left unpublished (--no-publish); "
+                            f"run 'aethis publish' to activate it."
+                        )
+                    else:
+                        success(
+                            "Done! Ruleset generated and left unpublished (--no-publish) — run "
+                            "'aethis status' to get its id, then 'aethis publish' to activate it."
+                        )
+                    return GenerationOutcome("success", ruleset_id)
                 # Auto-publish so the ruleset is immediately usable
                 try:
                     client.publish(pid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.33.0"
+version = "0.34.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_generate_no_publish.py
+++ b/tests/test_generate_no_publish.py
@@ -1,0 +1,227 @@
+"""`aethis generate --no-publish` generates without activating anything.
+
+`aethis generate --poll` publishes on success, and publishing *activates* the
+ruleset. For a class of authoring work that is the wrong default and can be a
+policy breach in itself: a ruleset that must stay a draft on the engine it was
+authored against, and only ever activate somewhere else after promotion. The
+workaround was to archive it immediately afterwards, which leaves a real window
+where it is live.
+
+The flag is deliberately narrow. It suppresses the publish call and says so;
+everything else about the run is untouched — the poll, its timeout, and the
+post-generation field diff all behave exactly as they do without it, because
+those are what make the run worth doing at all. And absent the flag nothing
+changes: the publish still happens on the same call with the same argument.
+
+What each test pins down, and what breaks it, is stated per test — an assertion
+nobody has watched fail is not evidence that it discriminates.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from aethis_cli.commands import generate_cmd
+
+# One pinned field the stand-in engine will not produce, so the drift report
+# has something to say. A diff that finds nothing prints a clean line either
+# way, which would not distinguish "the diff ran" from "the diff was skipped".
+PINNED_FIELDS = "fields:\n  - key: applicant.date_of_birth\n    type: date\n"
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _flat(capsys) -> str:
+    """Content, not presentation — rich wraps and colourises captured output."""
+    return re.sub(r"\s+", " ", _ANSI.sub("", capsys.readouterr().out))
+
+
+def _project(tmp_path):
+    (tmp_path / "sources").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "sources" / "a.md").write_text("the source document")
+    (tmp_path / "fields").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "fields" / "fields.yaml").write_text(PINNED_FIELDS)
+    return tmp_path
+
+
+def _wire(monkeypatch, tmp_path, client) -> None:
+    cfg = SimpleNamespace(
+        config_path=tmp_path,
+        base_url="http://engine.test",
+        project_id="proj_abc",
+        project="p",
+    )
+    monkeypatch.setattr(generate_cmd, "load_project_config", lambda: cfg)
+    monkeypatch.setattr(generate_cmd, "resolve_api_key", lambda _cfg: "ak")
+    monkeypatch.setattr(generate_cmd, "resolve_anthropic_key", lambda _cfg: None)
+    monkeypatch.setattr(generate_cmd, "make_authed_client", lambda *_a, **_k: client)
+    monkeypatch.setattr(generate_cmd.time, "sleep", lambda *_a, **_k: None)
+
+
+def _engine(status_payload: dict, schema: dict | None = None) -> MagicMock:
+    client = MagicMock()
+    client.generate.return_value = {"job_id": "job_1"}
+    client.last_rate_limit = None
+    client.get_status.return_value = status_payload
+    client.get_schema.return_value = schema or {"fields": []}
+    return client
+
+
+SUCCESS = {"job": {"status": "success", "progress_percent": 100}, "latest_ruleset_id": "rs_new"}
+
+
+# ---------------------------------------------------------------------------
+# The publish call itself — the producer these tests exist to mutate
+# ---------------------------------------------------------------------------
+
+
+def test_no_publish_never_publishes(tmp_path, monkeypatch):
+    """The whole point: a successful generation that activates nothing.
+
+    Mutation: leave `client.publish(pid)` in place on the flagged path and this
+    goes red. It is the only assertion here that does, which is why it is the
+    one the acceptance names.
+    """
+    _project(tmp_path)
+    client = _engine(SUCCESS)
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30, no_publish=True)
+
+    client.publish.assert_not_called()
+
+
+def test_without_the_flag_the_publish_is_unchanged(tmp_path, monkeypatch):
+    """Absent the flag, the same call with the same argument as before.
+
+    This is the half that catches the *growth* direction: a later branch that
+    reaches publish by some other route, or one that stops reaching it at all,
+    both show up here rather than in the flagged test.
+    """
+    _project(tmp_path)
+    client = _engine(SUCCESS)
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30)
+
+    client.publish.assert_called_once_with("proj_abc")
+
+
+def test_the_flag_defaults_off_for_every_caller(tmp_path, monkeypatch):
+    """`aethis refine` shares this machinery and was not asked to change.
+
+    `_run_generate` is called by refine_cmd without the keyword, so a default
+    of True — or a required parameter — would silently change a command this
+    work never touched.
+    """
+    _project(tmp_path)
+    client = _engine(SUCCESS)
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30, mode="refine")
+
+    client.publish.assert_called_once_with("proj_abc")
+
+
+# ---------------------------------------------------------------------------
+# Saying so — an unpublished ruleset the author does not know about is worse
+# ---------------------------------------------------------------------------
+
+
+def test_no_publish_says_the_ruleset_was_left_unpublished(tmp_path, monkeypatch, capsys):
+    """Name the artefact, say it is not live, and say how to make it live."""
+    _project(tmp_path)
+    client = _engine(SUCCESS)
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30, no_publish=True)
+
+    out = _flat(capsys)
+    assert "rs_new" in out
+    assert "unpublished" in out
+    assert "aethis publish" in out
+
+
+def test_no_publish_says_so_even_when_no_ruleset_id_surfaces(tmp_path, monkeypatch, capsys):
+    """The engine can report success before either id lands; still say it.
+
+    The pre-existing success message for this case does not mention publishing
+    at all, so inheriting it would leave the one run whose state is hardest to
+    guess as the one the CLI says least about.
+    """
+    _project(tmp_path)
+    client = _engine({"job": {"status": "success", "progress_percent": 100}})
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30, no_publish=True)
+
+    out = _flat(capsys)
+    assert "unpublished" in out
+    assert "aethis publish" in out
+
+
+def test_the_deliberate_message_is_not_the_publish_failure_message(tmp_path, monkeypatch, capsys):
+    """A choice and a failed publish are different endings and must read so.
+
+    Both leave a draft and both point at `aethis publish`. Collapsing them
+    would tell an author who did not pass the flag that everything went to
+    plan, which is the case where they most need to know it did not.
+    """
+    _project(tmp_path)
+    client = _engine(SUCCESS)
+    client.publish.side_effect = generate_cmd.AethisAPIError(409, "publish refused")
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30)
+
+    assert "unpublished" not in _flat(capsys)
+
+
+# ---------------------------------------------------------------------------
+# Everything else about the run is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_no_publish_still_reports_the_field_diff(tmp_path, monkeypatch, capsys):
+    """The diff is the reason to poll at all; suppressing publish must not cost it."""
+    _project(tmp_path)
+    client = _engine(SUCCESS, schema={"fields": [{"field_id": "applicant.surprise"}]})
+    _wire(monkeypatch, tmp_path, client)
+
+    generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=30, no_publish=True)
+
+    out = _flat(capsys)
+    assert "applicant.date_of_birth" in out  # pinned, not produced
+    assert "applicant.surprise" in out  # produced, not pinned
+
+
+def test_no_publish_still_honours_the_polling_timeout(tmp_path, monkeypatch, capsys):
+    """A job that never finishes still ends the run, and still publishes nothing."""
+    _project(tmp_path)
+    client = _engine({"job": {"status": "running", "progress_percent": 10}})
+    _wire(monkeypatch, tmp_path, client)
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._run_generate(project_id="proj_abc", poll=True, timeout=0, no_publish=True)
+
+    assert "Timed out" in _flat(capsys)
+    client.publish.assert_not_called()
+
+
+def test_no_publish_is_reachable_from_the_command_surface():
+    """The flag exists on `aethis generate` and is off by default.
+
+    On its own this proves only that an option parses, which is why it is the
+    least of these tests — the behaviour is pinned above. It is here because
+    wiring the plumbing and forgetting the option is a real way to ship a flag
+    that every behavioural test passes without.
+    """
+    option = inspect.signature(generate_cmd.generate).parameters["no_publish"].default
+    assert "--no-publish" in option.param_decls
+    assert option.default is False


### PR DESCRIPTION
## What this changes

`aethis generate --poll` publishes the ruleset it produced, and publishing **activates** it. There was no way to opt out. `--no-publish` adds one: the run generates and polls exactly as before and leaves an unpublished draft behind.

The flag suppresses the publish call and nothing else. The poll, its timeout, and the post-generation field diff all behave as they do without it — those are what make polling worth doing, and a flag that quietly cost the drift report would be a worse trade than the problem it solves.

The deliberate ending names the flag rather than reusing the publish-failed wording. Both endings leave a draft and both point at `aethis publish`, so collapsing them would tell an author who never passed the flag that everything went to plan, which is the case where they most need to know it did not.

Absent the flag nothing changes: it defaults off, and `aethis refine` — which shares `_run_generate` — was not asked to change and does not pass it.

## Why now

Form AN authoring runs against the public **staging** engine as a private draft. Publishing there would set the ruleset `status=active`, which [`immigration-internal-only.md`](https://github.com/Aethis-ai/aethis-workspace/blob/main/.claude/rules/immigration-internal-only.md) rule 2 forbids outright. form-an's own `DEVELOPER_GUIDE.md` records the gap and the workaround — archive immediately after promotion — which leaves a genuine window where the ruleset is live. The canary phase of the named-value-spaces epic ([aethis-workspace#980](https://github.com/Aethis-ai/aethis-workspace/issues/980)) needs five runs that never publish, so building it on an archive-afterwards mitigation was not an option. A companion PR on `form-an` points the guide at the flag.

The second half of #62 — a completion banner reading `Ruleset published: None` when the publish returned nothing — is already fixed on `main`: the success message is guarded by `if ruleset_id`, and a failed publish raises `AethisAPIError` into the fallback branch. Nothing further was needed for it here.

## Mutation evidence

Per [`gate-path-coverage.md`](https://github.com/Aethis-ai/aethis-workspace/blob/main/.claude/rules/gate-path-coverage.md) rule 7 — an assertion nobody has watched fail is not a gate. The producer mutated is the **publish call**, not the flag parsing. Each patch was asserted to apply exactly once, the suite run bare, then the tree restored (script: applied and reverted locally, tree verified clean against HEAD afterwards).

| # | Mutation | Direction | Result |
|---|---|---|---|
| baseline | unmutated | — | green |
| M1 | no-publish branch falls through to `client.publish(pid)` — flag wired, publish left in place | contraction | **red** — `test_no_publish_never_publishes` |
| M2 | a **new** `client.publish(pid)` added after the field diff | growth | **red** — 5 tests |
| M3 | `_run_generate` defaults `no_publish=True` (draft becomes the default for refine too) | growth | **red** — 3 tests |
| M4 | flag not threaded into `_poll_until_done` | contraction | **red** — 3 tests |
| M5 | field diff skipped when nothing was published | growth | **red** — `test_no_publish_still_reports_the_field_diff` |
| M6 | deliberate ending reuses the publish-**failed** message | contraction | **red** — `test_no_publish_says_the_ruleset_was_left_unpublished` |
| M7 | option renamed `--no-publish` → `--draft` | growth | **red** — `test_no_publish_is_reachable_from_the_command_surface` |
| M8 | id-less success drops the unpublished wording | contraction | **red** — `test_no_publish_says_so_even_when_no_ruleset_id_surfaces` |

8/8 killed. M2, M3, M5 and M7 mutate in the direction the file actually evolves — a later commit adding a publish site, changing a default, adding a shortcut, renaming a flag — rather than only deleting what is there.

## Verification

- `pytest tests/` — **546 passed**, 24 deselected, coverage 78.24% (gate 45%). 9 of those are new.
- Red proven before implementing: the new file failed 7/9 against unmodified `main` (the 2 that passed are the ones asserting today's unchanged behaviour, which is correct).
- `ruff check` + `ruff format --check` clean.
- `uv build` — sdist + wheel build at 0.34.0 (rule 3: exercise the artifact on the PR that could break it).
- Rendered layer: `aethis generate --help` lists `--no-publish` with its help text.

## Version

**0.34.0**, not a fold into 0.33.0. `v0.33.0` is tagged on origin at `e4b174c` — the base of this branch — and its CHANGELOG section carries a release date, so it is released, not unreleased. Additive feature ⇒ minor.

Closes #62
Closes #104

---

```
Execution resolution:
profile=build
runtime=claude
provider_model=opus
selector=explicit
independence=different-session
escalations=none
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789409694&installation_model_id=429844&pr_number=106&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F106&signature=403df79b90952c7cdefbb6cd9741f79fd4c930e4c1190f5bd5c6b9ad643a889b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->