### PR TITLE
fix(packaging): explicit package discovery — releases reach PyPI again (v0.34.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.34.1 (2026-08-15)
+
+The releases start reaching PyPI again.
+
+- **fix(packaging): explicit package discovery.** Every release from v0.30.0 to v0.34.0 was tagged and never published: the publish workflow's own integrity step creates a top-level `evidence/` directory *before* building, and setuptools flat-layout auto-discovery aborts the build the moment any second top-level directory exists (#94). Discovery is now explicit (`include = ["aethis_cli*"]`), so a stray directory — the workflow's or anyone else's — can no longer poison the build. Proven both ways: with `evidence/` present the build failed before this change and succeeds after it. This release supersedes v0.30.0–v0.34.0, none of which reached PyPI; it is the first PyPI release to carry everything since v0.29.0, including `--no-publish` and the member-set drift report.
+
 ## 0.34.0 (2026-08-15)
 
 Generating a ruleset no longer has to activate it.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.34.0"
+__version__ = "0.34.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.34.0"
+version = "0.34.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -45,6 +45,12 @@ dev = [
 [build-system]
 requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+# Explicit discovery: auto-discovery aborts the build whenever any other
+# top-level directory exists (the publish workflow itself creates evidence/
+# before building — every release v0.30.0-v0.34.0 failed this way, #94).
+include = ["aethis_cli*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Every release from v0.30.0 to v0.34.0 was tagged and **never reached PyPI** (latest published is 0.29.0). Root cause, from the failed run logs: the publish workflow's "Release integrity tuple" step runs `mkdir -p evidence` *before* `uv run` builds the package, and setuptools flat-layout auto-discovery aborts the build whenever a second top-level directory exists — so the workflow poisons its own build, every time. This is #94's exact shape; the earlier cleanup removed the directory from the repo but never made discovery explicit, so the class recurred from inside the workflow itself.

## The fix (class, not instance)

`[tool.setuptools.packages.find] include = ["aethis_cli*"]` — any stray top-level directory (the workflow's `evidence/`, or anyone else's) is now harmless. Version 0.34.1 + CHANGELOG in the same commit.

## Evidence (both directions, per gate-path-coverage rule 7)

- `mkdir -p evidence && uv build` on origin/main: **fails** (`Multiple top-level packages discovered in a flat-layout: ['evidence', 'aethis_cli']`).
- Same command with this change: **succeeds** (sdist + wheel at 0.34.1).
- Full suite: 546 passed, 24 deselected.

## After merge

Tag `v0.34.1` and re-dispatch "Publish to PyPI" — this will be the first PyPI release since 0.29.0 and carries everything in between, including the member-set drift report (#102) and `--no-publish` (#106), which the named-value-spaces canary (aethis-workspace#980 P8) and the form-an#150 unstick marker depend on.

Found while running epic aethis-workspace#980 (P6 close-out).

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789410323&installation_model_id=429844&pr_number=108&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F108&signature=968b036ffa48c0379fe2b9eed54d3146fe9b1ea1aa0577b8934b109541fec7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->