### PR TITLE
ci(publish): sweep Aethis-ai/form-an when unsticking downstream PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -284,6 +284,7 @@ jobs:
           # added.
           REPOS = [
               "Aethis-ai/aethis-workspace",
+              "Aethis-ai/form-an",
               "Aethis-ai/aethis-examples",
               "Aethis-ai/aethis-examples-internal",
               "Aethis-ai/aethis-mcp",


### PR DESCRIPTION
form-an#150 carried `<!-- aethis-needs: aethis-cli >= 0.34.0 -->` and the v0.34.1 release's unstick sweep never matched it: `Aethis-ai/form-an` was absent from the job's declared `REPOS` list. One-line addition. Per `downstream-unstick.md`'s caveat, the canonical consumer enumeration is the workspace's `.gitmodules` (`scripts/workspace-repos`), which a published repo can't read — hence the literal list, kept in step here. Workflow-only diff: per gate-path-coverage rule 1, what goes unchecked by CI on this PR is the workflow itself; the change is a single string in a literal list, exercised on the next release's sweep. Found while running epic aethis-workspace#980 (its P8 canary depends on the form-an docs PR this stranded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789412482&installation_model_id=429844&pr_number=109&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F109&signature=6decf5b7384889b4edda488228f47f0fe330a11c209e90e735883a2ccd2e9201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->