### PR TITLE
feat(fields): named value-space references on the wire — sync, transmit, verify (aethis-core#424, v0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.35.0 (2026-08-15)
+
+Named value spaces reach the wire (aethis-core#424, epic aethis-workspace#980 P3). Requires an engine exposing `/api/v1/public/value-spaces` for referenced fields; projects with no `value_space:` pins are unaffected.
+
+- **feat(fields): `value_space:` on a field pin.** `fields.yaml` enum fields may reference a named, versioned value space (e.g. `value_space: form-an/countries`) instead of inlining `enum_values` — the engine expands the members deterministically and the model never authors them. The two are mutually exclusive per field, validated locally; reference-form enums no longer fail the "enum needs enum_values" check.
+- **feat(generate): registry sync before spec-set.** Locally-authored space files (`value_spaces/` or `shared/value_spaces/*.yaml`, wire-form `name/members/provenance`) are PUT to the engine registry before the field spec is pushed, carrying the sync-state base version so a stale checkout gets the engine's 409 ("space moved under you — pull first") instead of silently regressing the shared vocabulary. Any non-2xx aborts before spec-set naming the missing engine capability — an older engine ignores unknown pin keys and would otherwise silently drop the reference.
+- **feat(generate): registry-aware drift report.** A referenced field is verified against the registry at the exact version the generation resolved (from the job result), printing `<key> ← <space>@vN (M members verified)` — never the old "pins no enum_values ⇒ opts out" silence on exactly the migrated fields. A space that advanced between sync and generation is flagged. An unverifiable referenced field is reported, never skipped.
+- **feat(fields): `pull` preserves the migration.** A local field declaring `value_space:` keeps the reference; the server's expanded members are never written back into `fields.yaml`.
 
 ## 0.34.1 (2026-08-15)
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.34.1"
+__version__ = "0.35.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -318,7 +318,7 @@ class AethisClient:
     def set_field_spec(self, project_id: str, expected_fields: list[dict]) -> dict:
         """Pin the project's expected field vocabulary (key + type + enum values).
 
-        Each entry is ``{key, sort, enum_values?}``. This constrains generation
+        Each entry is ``{key, sort, enum_values?, value_space?}``. This constrains generation
         to the declared field keys so the same field (e.g. date of birth) is not
         re-invented under a different key. Field hints / questions are carried as
         guidance, not here — this endpoint only fixes the vocabulary.
@@ -328,6 +328,39 @@ class AethisClient:
             f"/api/v1/public/projects/{project_id}/fields/spec",
             json={"expected_fields": expected_fields},
         )
+
+    def put_value_space(
+        self,
+        *,
+        name: str,
+        members: list[str],
+        provenance: dict,
+        base_version: Optional[int] = None,
+        force: bool = False,
+    ) -> dict:
+        """Register (or supersede) a named value space on the engine registry.
+
+        Idempotent version-upsert: an identical member list is a no-op echoing
+        the current version; any change mints a new immutable version.
+        ``base_version`` is the version this checkout last synced against —
+        the engine 409s ("space moved under you — pull first") on a mismatch
+        rather than last-writer-wins. ``force`` is required for a
+        member-removing or provenance-regressing supersession.
+        """
+        payload: dict = {"members": members, "provenance": provenance, "force": force}
+        if base_version is not None:
+            payload["base_version"] = base_version
+        return self._request("PUT", f"/api/v1/public/value-spaces/{name}", json=payload)
+
+    def get_value_space(self, name: str, *, version: Optional[int] = None) -> dict:
+        """Read one version of a named value space (the active head by default).
+
+        Historical versions are immutable and therefore servable — pass
+        ``version`` to inspect exactly what a generation's stamped resolution
+        expanded (the drift report does).
+        """
+        params = {"version": version} if version is not None else None
+        return self._request("GET", f"/api/v1/public/value-spaces/{name}", params=params)
 
     def discover_fields(self, project_id: str) -> dict:
         """Run server-side field discovery over the project's uploaded sources.

--- a/aethis_cli/commands/fields_cmd.py
+++ b/aethis_cli/commands/fields_cmd.py
@@ -235,7 +235,13 @@ def pull(
         existed = key in field_map
         entry["key"] = key
         entry["type"] = _safe_field_type(sf.get("field_type"), sf.get("enum_values"))
-        if entry["type"] == "enum" and sf.get("enum_values"):
+        if entry.get("value_space"):
+            # A field pinned to a named value space keeps the reference and
+            # NEVER materialises members locally — writing the server's
+            # expanded enum_values back would silently un-migrate the field
+            # to inline form on first pull (aethis-core#424, C3).
+            entry.pop("enum_values", None)
+        elif entry["type"] == "enum" and sf.get("enum_values"):
             entry["enum_values"] = sf["enum_values"]
         else:
             entry.pop("enum_values", None)

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -289,14 +289,16 @@ def _local_value_space_files(project_dir: Path) -> dict:
     A registry file is the wire-form upsert payload (``name``, ``members``,
     ``provenance`` — extra generator keys like ``derived_from`` are ignored),
     found under a ``value_spaces/`` or ``shared/value_spaces/`` directory of
-    the project, its enclosing rulebook, or any ancestor directory (form-an
-    keeps them at the repo root's ``shared/value_spaces/``). Nearest wins.
+    the project, its enclosing rulebook, or any ancestor directory UP TO THE
+    REPO ROOT (form-an keeps them at the repo root's ``shared/value_spaces/``).
+    The walk stops at the first ancestor containing ``.git`` — a same-named
+    yaml lying above the repo must never be silently PUT. Nearest wins.
     """
     search_dirs: list[Path] = []
     current = project_dir.resolve()
     while True:
         search_dirs.append(current)
-        if current.parent == current:
+        if (current / ".git").exists() or current.parent == current:
             break
         current = current.parent
     rb_dir = _parent_rulebook_dir(project_dir)
@@ -316,6 +318,18 @@ def _local_value_space_files(project_dir: Path) -> dict:
     return spaces
 
 
+def _api_error_message(e: AethisAPIError) -> str:
+    """A human-readable line from an API error whose detail may be structured.
+
+    The engine's value-space conflicts carry a dict detail (reason_code +
+    message + versions); printing the dict repr buries the one sentence the
+    author needs (review advisory, PR #110).
+    """
+    if isinstance(e.detail, dict):
+        return str(e.detail.get("message") or e.detail)
+    return str(e.detail)
+
+
 def _sync_value_spaces(client: AethisClient, project_dir: Path, referenced: set) -> None:
     """PUT every locally-authored space a pin references, before spec-set.
 
@@ -333,11 +347,37 @@ def _sync_value_spaces(client: AethisClient, project_dir: Path, referenced: set)
     for name in sorted(referenced):
         space = local.get(name)
         if space is None:
-            warn(
-                f"No local registry file found for value space '{name}' "
-                f"(looked for a value_spaces/ or shared/value_spaces/ yaml declaring it). "
-                f"Assuming it is already registered on the engine — the field spec push "
-                f"will fail loudly if it is not."
+            # No local file: the space may be registered by another project —
+            # but the abort guarantee must not go vacuous on exactly this
+            # lane, so PROBE the engine rather than proceed on hope. A 2xx
+            # proves both the registry capability and tenant resolution; any
+            # non-2xx (route missing, unknown/foreign space, outage) aborts —
+            # a pre-#424 engine would 200 the spec-set and silently drop the
+            # pin (review fix, PR #110).
+            try:
+                probe = client.get_value_space(name)
+            except AethisAPIError as e:
+                if e.status_code == 404:
+                    console.print(
+                        f"[red]Value space '{name}' is not resolvable on the engine "
+                        f"(GET /api/v1/public/value-spaces/{name} returned 404): either it is "
+                        f"not registered for this tenant, or the engine lacks the "
+                        f"value-spaces registry entirely.[/red]"
+                    )
+                    console.print(
+                        "[red]Stopping before the field spec push. Add a local registry "
+                        "file (value_spaces/ or shared/value_spaces/*.yaml declaring it) "
+                        "so this run can register it, or upgrade the engine.[/red]"
+                    )
+                else:
+                    console.print(
+                        f"[red]Could not verify value space '{name}' on the engine: {_api_error_message(e)}[/red]"
+                    )
+                    console.print("[red]Stopping before the field spec push.[/red]")
+                raise typer.Exit(code=1)
+            info(
+                f"Value space '{name}': no local registry file; engine serves it at "
+                f"v{probe.get('version')} — proceeding."
             )
             continue
         try:
@@ -360,17 +400,20 @@ def _sync_value_spaces(client: AethisClient, project_dir: Path, referenced: set)
                     "value_space reference from fields.yaml.[/red]"
                 )
             else:
-                console.print(f"[red]Could not sync value space '{name}': {e.detail}[/red]")
+                console.print(f"[red]Could not sync value space '{name}': {_api_error_message(e)}[/red]")
                 console.print(
                     "[red]Stopping before the field spec push — a pin referencing an "
                     "unsynced space would fail, or bind to stale members.[/red]"
                 )
             raise typer.Exit(code=1)
+        # Record each synced version the moment its PUT lands — a later
+        # space's abort must not lose this one's base version (review
+        # advisory, PR #110: the retry would otherwise 409 against the
+        # author's own successful write).
         sync_state[name] = result.get("version")
+        write_state(project_dir, {"value_space_sync": dict(sync_state)})
         verb = "synced" if result.get("created") else "already current at"
         info(f"Value space '{name}' {verb} v{result.get('version')} ({len(space.get('members') or [])} members)")
-
-    write_state(project_dir, {"value_space_sync": sync_state})
 
 
 def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) -> None:

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -174,7 +174,7 @@ _SERVER_TYPE_TO_YAML = {
 
 # Field-key order written back to ``fields.yaml`` so machine-written files read
 # the same as the hand-authored template.
-_FIELD_KEY_ORDER = ("key", "type", "label", "question", "enum_values", "hints")
+_FIELD_KEY_ORDER = ("key", "type", "label", "question", "enum_values", "value_space", "hints")
 
 
 def _normalise_field_type(t: Optional[str]) -> str:
@@ -204,8 +204,9 @@ def validate_fields_list(fields: list) -> list[str]:
     """Return human-readable validation errors for a ``fields.yaml`` field list.
 
     Checks: every entry has a key, no duplicate keys, the ``type`` is one of
-    :data:`VALID_FIELD_TYPES`, and ``enum`` types declare ``enum_values``. An
-    empty return means the list is valid.
+    :data:`VALID_FIELD_TYPES`, and ``enum`` types declare exactly one member
+    source — inline ``enum_values`` XOR a named ``value_space`` reference
+    (aethis-core#424). An empty return means the list is valid.
     """
     errors: list[str] = []
     seen: set[str] = set()
@@ -226,8 +227,16 @@ def validate_fields_list(fields: list) -> list[str]:
                 f"Field {key!r} has invalid type {f.get('type') or f.get('sort')!r} "
                 f"(must be one of: {', '.join(sorted(VALID_FIELD_TYPES))})."
             )
-        if ftype == "enum" and not f.get("enum_values"):
-            errors.append(f"Field {key!r} is type 'enum' but declares no enum_values.")
+        if f.get("value_space") and f.get("enum_values"):
+            errors.append(
+                f"Field {key!r} declares both value_space and enum_values — they are "
+                f"mutually exclusive; the named reference is authoritative, so drop the "
+                f"inline members."
+            )
+        if f.get("value_space") and ftype != "enum":
+            errors.append(f"Field {key!r} declares value_space but is type {ftype!r} — only enum fields may.")
+        if ftype == "enum" and not f.get("enum_values") and not f.get("value_space"):
+            errors.append(f"Field {key!r} is type 'enum' but declares no enum_values (or value_space).")
     return errors
 
 
@@ -274,6 +283,96 @@ def _merged_field_map(project_dir: Path) -> dict:
     return field_map
 
 
+def _local_value_space_files(project_dir: Path) -> dict:
+    """Locally-authored value-space registry files, indexed by declared name.
+
+    A registry file is the wire-form upsert payload (``name``, ``members``,
+    ``provenance`` — extra generator keys like ``derived_from`` are ignored),
+    found under a ``value_spaces/`` or ``shared/value_spaces/`` directory of
+    the project, its enclosing rulebook, or any ancestor directory (form-an
+    keeps them at the repo root's ``shared/value_spaces/``). Nearest wins.
+    """
+    search_dirs: list[Path] = []
+    current = project_dir.resolve()
+    while True:
+        search_dirs.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    rb_dir = _parent_rulebook_dir(project_dir)
+    if rb_dir is not None and rb_dir not in search_dirs:
+        search_dirs.insert(1, rb_dir)
+
+    spaces: dict = {}
+    for d in search_dirs:
+        for sub in (d / "value_spaces", d / "shared" / "value_spaces"):
+            if not sub.is_dir():
+                continue
+            for path in sorted(sub.glob("*.yaml")):
+                raw = _load_yaml_file(path)
+                name = raw.get("name")
+                if name and name not in spaces:
+                    spaces[name] = raw
+    return spaces
+
+
+def _sync_value_spaces(client: AethisClient, project_dir: Path, referenced: set) -> None:
+    """PUT every locally-authored space a pin references, before spec-set.
+
+    The base version comes from the sync state (``.aethis/state.json`` →
+    ``value_space_sync``), so a stale checkout gets the engine's 409 ("space
+    moved under you — pull first") instead of silently regressing the shared
+    vocabulary. ANY non-2xx aborts before ``set_field_spec`` (design note
+    DX-6): a pre-#424 engine is extra-ignore on ExpectedFieldSpec, so
+    proceeding would drop the pin and the model would free-author the
+    members — the exact failure the reference exists to remove.
+    """
+    local = _local_value_space_files(project_dir)
+    sync_state = dict(read_state(project_dir).get("value_space_sync") or {})
+
+    for name in sorted(referenced):
+        space = local.get(name)
+        if space is None:
+            warn(
+                f"No local registry file found for value space '{name}' "
+                f"(looked for a value_spaces/ or shared/value_spaces/ yaml declaring it). "
+                f"Assuming it is already registered on the engine — the field spec push "
+                f"will fail loudly if it is not."
+            )
+            continue
+        try:
+            result = client.put_value_space(
+                name=name,
+                members=list(space.get("members") or []),
+                provenance=space.get("provenance") or {},
+                base_version=sync_state.get(name),
+            )
+        except AethisAPIError as e:
+            if e.status_code == 404:
+                console.print(
+                    f"[red]The engine does not expose the value-spaces registry "
+                    f"(PUT /api/v1/public/value-spaces/{name} returned 404).[/red]"
+                )
+                console.print(
+                    "[red]Stopping before the field spec push: an engine without this "
+                    "capability silently drops the value_space pin, and the model would "
+                    "free-author the field's members. Upgrade the engine, or remove the "
+                    "value_space reference from fields.yaml.[/red]"
+                )
+            else:
+                console.print(f"[red]Could not sync value space '{name}': {e.detail}[/red]")
+                console.print(
+                    "[red]Stopping before the field spec push — a pin referencing an "
+                    "unsynced space would fail, or bind to stale members.[/red]"
+                )
+            raise typer.Exit(code=1)
+        sync_state[name] = result.get("version")
+        verb = "synced" if result.get("created") else "already current at"
+        info(f"Value space '{name}' {verb} v{result.get('version')} ({len(space.get('members') or [])} members)")
+
+    write_state(project_dir, {"value_space_sync": sync_state})
+
+
 def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) -> None:
     """Push the field vocabulary for this project (rulebook-level fields win).
 
@@ -310,8 +409,20 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
         spec = {"key": key, "sort": field.get("type") or field.get("sort")}
         if field.get("enum_values"):
             spec["enum_values"] = field["enum_values"]
+        if field.get("value_space"):
+            spec["value_space"] = field["value_space"]
         expected_fields.append(spec)
         guidance_lines.extend(_field_guidance_lines(key, field))
+
+    # Registry sync BEFORE spec-set (aethis-core#424, design note DX-6): the
+    # engine resolves a value_space reference at the spec-set boundary, so
+    # every locally-authored space must exist there first — and a pre-#424
+    # engine, which ignores unknown ExpectedFieldSpec keys, must be caught
+    # HERE rather than silently dropping the pin and letting the model
+    # free-author the vocabulary. Any non-2xx aborts before set_field_spec.
+    referenced = {f["value_space"] for f in field_map.values() if f.get("value_space")}
+    if referenced:
+        _sync_value_spaces(client, project_dir, referenced)
 
     client.set_field_spec(pid, expected_fields)
     for line in guidance_lines:
@@ -483,7 +594,7 @@ def _run_generate(
         # against the artefact THIS run produced — never whatever id happens to
         # be on disk, which after an unsuccessful run names an earlier
         # generation and would make a stale schema read as this one's.
-        _report_field_diff(client, outcome.ruleset_id, project_dir)
+        _report_field_diff(client, outcome.ruleset_id, project_dir, value_spaces_resolved=outcome.value_spaces_resolved)
 
         if outcome.status != "success":
             _invalidate_stale_pointer(project_dir, outcome.status)
@@ -565,8 +676,21 @@ def _upload_test_cases(client: AethisClient, pid: str, project_dir: Path) -> Non
     )
 
 
-def _report_field_diff(client: AethisClient, ruleset_id: Optional[str], project_dir: Path) -> None:
+def _report_field_diff(
+    client: AethisClient,
+    ruleset_id: Optional[str],
+    project_dir: Path,
+    value_spaces_resolved: Optional[dict] = None,
+) -> None:
     """After a generate, print pinned-vs-produced field drift loudly.
+
+    For a field pinned to a named ``value_space`` (aethis-core#424) the
+    expected members come from the engine registry AT THE VERSION THE JOB
+    RESULT STAMPED (``value_spaces_resolved``) — never the "pins no
+    enum_values ⇒ opts out" path, which on exactly the migrated fields would
+    print success with zero member verification. An unverifiable referenced
+    field is said out loud, and a version advance between sync and generation
+    is flagged, never invisible (design note C3, C5(d)).
 
     Compares the fields pinned locally (``fields.yaml`` + any enclosing
     rulebook) against the fields the engine actually produced in the ruleset
@@ -617,8 +741,10 @@ def _report_field_diff(client: AethisClient, ruleset_id: Optional[str], project_
     missing = sorted(pinned - produced)
     extra = sorted(produced - pinned)
 
-    # Member-set drift, per field, by exact equality in both directions. A
-    # field that pins no enum_values opts out — that is the only opt-out.
+    # Member-set drift, per field, by exact equality in both directions.
+    # An INLINE field that pins no enum_values opts out — that is the only
+    # opt-out; a field pinned to a value_space is verified against the
+    # registry below, never opted out.
     #
     # A produced field carrying NO members is the loudest case, not an exempt
     # one: every pinned member was dropped, or the field came back as something
@@ -626,7 +752,49 @@ def _report_field_diff(client: AethisClient, ruleset_id: Optional[str], project_
     # empty set as "nothing to compare") reported the worst possible outcome as
     # "all N pinned field(s) were produced".
     member_drift: list[tuple[str, list[str], list[str]]] = []
+    verified_lines: list[str] = []
+    ref_problems: list[str] = []
+    sync_state = read_state(project_dir).get("value_space_sync") or {}
     for key, field in sorted(pinned_map.items()):
+        space_name = field.get("value_space")
+        if space_name:
+            if key not in produced_members:
+                continue  # already reported under `missing`
+            resolution = (value_spaces_resolved or {}).get(key)
+            if not resolution:
+                ref_problems.append(
+                    f"{key} ← {space_name}: NOT verified — the job result carries no "
+                    f"resolved version for it (the engine may predate the value-spaces "
+                    f"registry, or the run failed before resolution)."
+                )
+                continue
+            resolved_version = resolution.get("version")
+            try:
+                space = client.get_value_space(space_name, version=resolved_version)
+            except AethisAPIError as e:
+                ref_problems.append(
+                    f"{key} ← {space_name}@v{resolved_version}: NOT verified — could not "
+                    f"read the space at that version ({e.detail})."
+                )
+                continue
+            expected_members = set(space.get("members") or [])
+            actual_members = produced_members[key]
+            synced_version = sync_state.get(space_name)
+            if synced_version is not None and synced_version != resolved_version:
+                warn(
+                    f"Value space '{space_name}' advanced to v{resolved_version} during "
+                    f"generation (this checkout synced against v{synced_version}). Legal — "
+                    f"the generation snapshot resolved the newer head — but check the delta."
+                )
+            if actual_members == expected_members:
+                verified_lines.append(
+                    f"{key} ← {space_name}@v{resolved_version} ({len(expected_members)} members verified)"
+                )
+            else:
+                member_drift.append(
+                    (key, sorted(actual_members - expected_members), sorted(expected_members - actual_members))
+                )
+            continue
         pinned_members = set(field.get("enum_values") or [])
         if not pinned_members or key not in produced_members:
             continue
@@ -635,7 +803,12 @@ def _report_field_diff(client: AethisClient, ruleset_id: Optional[str], project_
             continue
         member_drift.append((key, sorted(actual_members - pinned_members), sorted(pinned_members - actual_members)))
 
-    if not missing and not extra and not member_drift:
+    for line in verified_lines:
+        console.print(f"[dim]{line}[/dim]")
+    for problem in ref_problems:
+        warn(problem)
+
+    if not missing and not extra and not member_drift and not ref_problems:
         success(f"Fields: all {len(pinned)} pinned field(s) were produced.")
         return
 
@@ -680,6 +853,10 @@ class GenerationOutcome(NamedTuple):
 
     status: str  # "success" | "failed" | "timeout"
     ruleset_id: Optional[str]
+    # Per-field resolved {space, version, space_id} the job stamped at
+    # generation start (aethis-core#424) — what makes the drift report's
+    # registry-aware verification possible. None from engines that predate it.
+    value_spaces_resolved: Optional[dict] = None
 
 
 def _resolved_ruleset_id(status_payload: dict) -> Optional[str]:
@@ -812,7 +989,7 @@ def _poll_until_done(
                             "Done! Ruleset generated and left unpublished (--no-publish) — run "
                             "'aethis status' to get its id, then 'aethis publish' to activate it."
                         )
-                    return GenerationOutcome("success", ruleset_id)
+                    return GenerationOutcome("success", ruleset_id, job.get("value_spaces_resolved"))
                 # Auto-publish so the ruleset is immediately usable
                 try:
                     client.publish(pid)
@@ -825,7 +1002,7 @@ def _poll_until_done(
                         success(f"Done! Ruleset: {ruleset_id} (run 'aethis publish' to activate)")
                     else:
                         success("Done! Ruleset generated (run 'aethis publish' to activate).")
-                return GenerationOutcome("success", ruleset_id)
+                return GenerationOutcome("success", ruleset_id, job.get("value_spaces_resolved"))
 
             if job_status == "failed":
                 console.print()
@@ -835,7 +1012,7 @@ def _poll_until_done(
                 # its success paths. Read it rather than assume: if the engine
                 # ever does attach one, the diff below becomes useful for free,
                 # and there is no other id that could honestly stand in.
-                return GenerationOutcome("failed", job.get("result_ruleset_id"))
+                return GenerationOutcome("failed", job.get("result_ruleset_id"), job.get("value_spaces_resolved"))
 
             time.sleep(3)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.34.1"
+version = "0.35.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_value_space_transport.py
+++ b/tests/test_value_space_transport.py
@@ -1,0 +1,400 @@
+"""Named value-space transport in the CLI (aethis-core#424, design note §10/§13-P3).
+
+Covers the four CLI obligations of the transport phase:
+
+1. `fields.yaml` may declare `value_space:` (XOR `enum_values` per field), and
+   `_upload_field_vocabulary` transmits it on the pin.
+2. Registry sync runs BEFORE spec-set, PUTs each locally-authored space with
+   the sync-state base version, and any non-2xx ABORTS before `set_field_spec`
+   naming the missing engine capability (DX-6 — an old engine is extra-ignore
+   on ExpectedFieldSpec and would otherwise silently drop the pin).
+3. The post-generation drift report is registry-aware for referenced fields:
+   expected members resolve from the engine registry at the version the job
+   result stamped — never the silent "pins no enum_values ⇒ opts out" path —
+   and a version advance during generation is flagged, never invisible (C3,
+   C5(d)).
+4. `aethis fields pull` preserves `value_space:` and never writes members back
+   for a referenced field (un-migration guard, C3).
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+import yaml
+
+from aethis_cli.client import AethisAPIError
+from aethis_cli.commands import generate_cmd
+from aethis_cli.config import read_state, write_state
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _flat(capsys) -> str:
+    return re.sub(r"\s+", " ", _ANSI.sub("", capsys.readouterr().out))
+
+
+REFERENCED_FIELDS = """\
+fields:
+  - key: pi.nationality
+    type: enum
+    value_space: form-an/countries
+    question: "What is your nationality?"
+  - key: applicant.income
+    type: int
+"""
+
+SPACE_FILE = """\
+name: form-an/countries
+provenance:
+  source:
+    package: pycountry
+    version: 26.2.16
+    standard: ISO 3166-1 alpha-3
+derived_from:
+  file: shared/countries.yaml
+  sha256: abc123
+members:
+  - united_kingdom
+  - france
+  - germany
+"""
+
+
+def _write(path, body: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def _project_with_reference(tmp_path, space_file: bool = True):
+    _write(tmp_path / "fields" / "fields.yaml", REFERENCED_FIELDS)
+    if space_file:
+        _write(tmp_path / "shared" / "value_spaces" / "form-an__countries.yaml", SPACE_FILE)
+    return tmp_path
+
+
+# --- validation: value_space XOR enum_values --------------------------------
+
+
+def test_validate_rejects_both_value_space_and_enum_values():
+    errors = generate_cmd.validate_fields_list(
+        [{"key": "pi.nationality", "type": "enum", "value_space": "form-an/countries", "enum_values": ["x"]}]
+    )
+    assert any("mutually exclusive" in e for e in errors)
+
+
+def test_validate_accepts_reference_form_enum():
+    """P5's flagged defect: today the CLI actively rejects an enum field that
+    carries value_space instead of enum_values. Reference-form must be valid."""
+    errors = generate_cmd.validate_fields_list(
+        [{"key": "pi.nationality", "type": "enum", "value_space": "form-an/countries"}]
+    )
+    assert errors == []
+
+
+def test_validate_still_rejects_bare_enum():
+    errors = generate_cmd.validate_fields_list([{"key": "pi.nationality", "type": "enum"}])
+    assert any("enum_values" in e for e in errors)
+
+
+def test_validate_rejects_value_space_on_non_enum():
+    errors = generate_cmd.validate_fields_list(
+        [{"key": "applicant.income", "type": "int", "value_space": "form-an/countries"}]
+    )
+    assert any("value_space" in e for e in errors)
+
+
+# --- transmission + registry sync ordering ----------------------------------
+
+
+def test_upload_transmits_value_space_on_the_pin(tmp_path):
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.put_value_space.return_value = {"name": "form-an/countries", "version": 1, "created": True}
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    by_key = {f["key"]: f for f in expected_fields}
+    assert by_key["pi.nationality"]["value_space"] == "form-an/countries"
+    assert "enum_values" not in by_key["pi.nationality"]
+    assert "value_space" not in by_key["applicant.income"]
+
+
+def test_registry_sync_puts_before_spec_set(tmp_path):
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.put_value_space.return_value = {"name": "form-an/countries", "version": 1, "created": True}
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.put_value_space.assert_called_once()
+    kwargs = client.put_value_space.call_args.kwargs
+    assert kwargs["name"] == "form-an/countries"
+    assert kwargs["members"] == ["united_kingdom", "france", "germany"]
+    assert kwargs["provenance"] == {
+        "source": {"package": "pycountry", "version": "26.2.16", "standard": "ISO 3166-1 alpha-3"}
+    }
+    # The upsert happens BEFORE the pin is set — a spec-set against an
+    # unsynced registry would 422 on a space the author has on disk.
+    calls = [c[0] for c in client.method_calls]
+    assert calls.index("put_value_space") < calls.index("set_field_spec")
+
+
+def test_registry_sync_failure_aborts_before_spec_set(tmp_path, capsys):
+    """DX-6: any non-2xx on the value-spaces routes is a HARD STOP before
+    set_field_spec — a pre-#424 engine ignores unknown ExpectedFieldSpec keys,
+    so proceeding would silently drop the pin and let the model free-author
+    the vocabulary."""
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.put_value_space.side_effect = AethisAPIError(404, "Not Found")
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()
+    out = _flat(capsys)
+    assert "value-spaces" in out  # names the missing capability
+    assert "value_space" in out or "pin" in out
+
+
+def test_registry_sync_conflict_aborts_with_engine_detail(tmp_path, capsys):
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.put_value_space.side_effect = AethisAPIError(
+        409, "Space 'form-an/countries' moved under you (current version 3, you based on 1) — pull first"
+    )
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()
+    assert "moved under you" in _flat(capsys)
+
+
+def test_registry_sync_uses_and_records_base_version(tmp_path):
+    project = _project_with_reference(tmp_path)
+    write_state(project, {"value_space_sync": {"form-an/countries": 3}})
+    client = MagicMock()
+    client.put_value_space.return_value = {"name": "form-an/countries", "version": 4, "created": True}
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    assert client.put_value_space.call_args.kwargs["base_version"] == 3
+    assert read_state(project)["value_space_sync"]["form-an/countries"] == 4
+
+
+def test_reference_without_local_file_warns_but_proceeds(tmp_path, capsys):
+    """A reference with no local registry file may already be registered
+    server-side (another project authored it). The sync says so out loud and
+    lets spec-set's 422 be the loud gate for a genuinely unknown space."""
+    project = _project_with_reference(tmp_path, space_file=False)
+    client = MagicMock()
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.put_value_space.assert_not_called()
+    client.set_field_spec.assert_called_once()
+    assert "form-an/countries" in _flat(capsys)
+
+
+# --- registry-aware drift report (C3 / C5(d)) --------------------------------
+
+
+def _schema(fields):
+    return {"fields": fields}
+
+
+def test_drift_report_verifies_referenced_field_against_registry(tmp_path, capsys):
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.get_schema.return_value = _schema(
+        [
+            {"field_id": "pi.nationality", "enum_values": ["united_kingdom", "france", "germany"]},
+            {"field_id": "applicant.income"},
+        ]
+    )
+    client.get_value_space.return_value = {
+        "name": "form-an/countries",
+        "version": 5,
+        "members": ["united_kingdom", "france", "germany"],
+    }
+
+    generate_cmd._report_field_diff(
+        client,
+        "rs_1",
+        project,
+        value_spaces_resolved={"pi.nationality": {"space": "form-an/countries", "version": 5, "space_id": "vs_x"}},
+    )
+
+    out = _flat(capsys)
+    # The verified line names the space, the resolved version, and the count.
+    assert "pi.nationality ← form-an/countries@v5 (3 members verified)" in out
+    # Resolution happened at the job-stamped version, not the head.
+    assert client.get_value_space.call_args.kwargs.get("version") == 5
+
+
+def test_drift_report_flags_mismatch_on_referenced_field(tmp_path, capsys):
+    """The blind spot this exists to close: a referenced field pins no
+    enum_values, so the old diff opted out and printed success with ZERO
+    member verification on exactly the migrated fields. Mutating the
+    registry-aware branch back to the opt-out turns this red."""
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.get_schema.return_value = _schema(
+        [{"field_id": "pi.nationality", "enum_values": ["united_kingdom", "narnia"]}, {"field_id": "applicant.income"}]
+    )
+    client.get_value_space.return_value = {
+        "name": "form-an/countries",
+        "version": 5,
+        "members": ["united_kingdom", "france", "germany"],
+    }
+
+    generate_cmd._report_field_diff(
+        client,
+        "rs_1",
+        project,
+        value_spaces_resolved={"pi.nationality": {"space": "form-an/countries", "version": 5, "space_id": "vs_x"}},
+    )
+
+    out = _flat(capsys)
+    assert "narnia" in out  # produced-but-not-in-space is named
+    assert "france" in out or "dropped" in out
+    assert "all 2 pinned field(s) were produced" not in out
+
+
+def test_drift_report_never_silently_skips_unverifiable_reference(tmp_path, capsys):
+    """No stamped resolution (job predates the engine capability, or the run
+    failed pre-resolution): the report says the field was NOT verified —
+    silence here is the exact defect class this phase exists to kill."""
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.get_schema.return_value = _schema(
+        [{"field_id": "pi.nationality", "enum_values": ["united_kingdom"]}, {"field_id": "applicant.income"}]
+    )
+
+    generate_cmd._report_field_diff(client, "rs_1", project, value_spaces_resolved=None)
+
+    out = _flat(capsys)
+    assert "not verified" in out.lower() or "could not" in out.lower()
+    assert "all 2 pinned field(s) were produced" not in out
+
+
+def test_drift_report_flags_version_advance(tmp_path, capsys):
+    """C5(d): the space advanced between sync and generation — legal (the
+    snapshot resolves the new head), but never invisible."""
+    project = _project_with_reference(tmp_path)
+    write_state(project, {"value_space_sync": {"form-an/countries": 4}})
+    client = MagicMock()
+    client.get_schema.return_value = _schema(
+        [
+            {"field_id": "pi.nationality", "enum_values": ["united_kingdom", "france", "germany"]},
+            {"field_id": "applicant.income"},
+        ]
+    )
+    client.get_value_space.return_value = {
+        "name": "form-an/countries",
+        "version": 5,
+        "members": ["united_kingdom", "france", "germany"],
+    }
+
+    generate_cmd._report_field_diff(
+        client,
+        "rs_1",
+        project,
+        value_spaces_resolved={"pi.nationality": {"space": "form-an/countries", "version": 5, "space_id": "vs_x"}},
+    )
+
+    out = _flat(capsys)
+    assert "advanced" in out
+    assert "v5" in out and "v4" in out
+
+
+# --- GenerationOutcome carries the job's resolution --------------------------
+
+
+def test_poll_threads_value_spaces_resolved_into_outcome(monkeypatch, tmp_path):
+    resolved = {"pi.nationality": {"space": "form-an/countries", "version": 5, "space_id": "vs_x"}}
+    client = MagicMock()
+    client.get_status.return_value = {
+        "job": {
+            "job_id": "job_1",
+            "status": "success",
+            "progress_percent": 100,
+            "result_ruleset_id": "rs_1",
+            "value_spaces_resolved": resolved,
+        },
+        "latest_ruleset_id": "rs_1",
+    }
+
+    outcome = generate_cmd._poll_until_done(client, "proj_1", tmp_path, timeout=10, no_publish=True)
+
+    assert outcome.status == "success"
+    assert outcome.ruleset_id == "rs_1"
+    assert outcome.value_spaces_resolved == resolved
+
+
+# --- fields pull preserves the migration --------------------------------------
+
+
+def test_fields_pull_preserves_value_space_and_never_writes_members(tmp_path, monkeypatch):
+    from aethis_cli.commands import fields_cmd
+
+    _write(tmp_path / "fields" / "fields.yaml", REFERENCED_FIELDS)
+    _write(tmp_path / "aethis.yaml", "project: {name: t, section_id: s, domain: d}\n")
+    write_state(tmp_path, {"ruleset_id": "rs_1"})
+
+    client = MagicMock()
+    client.get_schema.return_value = _schema(
+        [
+            {
+                "field_id": "pi.nationality",
+                "field_type": "enum",
+                "enum_values": ["united_kingdom", "france", "germany"],
+                "question": "What is your nationality?",
+            },
+            {"field_id": "applicant.income", "field_type": "int"},
+        ]
+    )
+
+    cfg = MagicMock()
+    cfg.config_path = tmp_path
+    cfg.base_url = "http://test"
+    monkeypatch.setattr(fields_cmd, "load_project_config", lambda: cfg)
+    monkeypatch.setattr(fields_cmd, "resolve_api_key", lambda _cfg: "key")
+    monkeypatch.setattr(fields_cmd, "make_authed_client", lambda *a, **k: client)
+
+    fields_cmd.pull(ruleset_id=None)
+
+    written = yaml.safe_load((tmp_path / "fields" / "fields.yaml").read_text())
+    by_key = {f["key"]: f for f in written["fields"]}
+    nat = by_key["pi.nationality"]
+    assert nat["value_space"] == "form-an/countries"
+    assert "enum_values" not in nat  # never materialised for a referenced field
+    assert by_key["applicant.income"]["type"] == "int"
+
+
+def test_poll_threads_resolution_on_the_publish_path_too(tmp_path):
+    """The auto-publish success return is a SECOND exit — the mutation battery
+    caught it dropping the resolution while the no-publish path carried it."""
+    resolved = {"pi.nationality": {"space": "form-an/countries", "version": 5, "space_id": "vs_x"}}
+    client = MagicMock()
+    client.get_status.return_value = {
+        "job": {
+            "job_id": "job_1",
+            "status": "success",
+            "progress_percent": 100,
+            "result_ruleset_id": "rs_1",
+            "value_spaces_resolved": resolved,
+        },
+        "latest_ruleset_id": "rs_1",
+    }
+
+    outcome = generate_cmd._poll_until_done(client, "proj_1", tmp_path, timeout=10, no_publish=False)
+
+    client.publish.assert_called_once()  # publish behaviour itself untouched
+    assert outcome.value_spaces_resolved == resolved

--- a/tests/test_value_space_transport.py
+++ b/tests/test_value_space_transport.py
@@ -188,18 +188,124 @@ def test_registry_sync_uses_and_records_base_version(tmp_path):
     assert read_state(project)["value_space_sync"]["form-an/countries"] == 4
 
 
-def test_reference_without_local_file_warns_but_proceeds(tmp_path, capsys):
-    """A reference with no local registry file may already be registered
-    server-side (another project authored it). The sync says so out loud and
-    lets spec-set's 422 be the loud gate for a genuinely unknown space."""
+def test_reference_without_local_file_probes_the_engine_then_proceeds(tmp_path, capsys):
+    """Review fix (PR #110): a reference with no local registry file may be
+    registered by another project — but the DX-6 abort guarantee must not be
+    vacuous on exactly this lane. The sync PROBES the engine
+    (GET /value-spaces/{name}); a 2xx proves both the capability and tenant
+    resolution, and only then does spec-set proceed."""
     project = _project_with_reference(tmp_path, space_file=False)
     client = MagicMock()
+    client.get_value_space.return_value = {
+        "name": "form-an/countries",
+        "version": 3,
+        "members": ["united_kingdom"],
+    }
 
     generate_cmd._upload_field_vocabulary(client, "proj_1", project)
 
     client.put_value_space.assert_not_called()
+    client.get_value_space.assert_called_once_with("form-an/countries")
     client.set_field_spec.assert_called_once()
     assert "form-an/countries" in _flat(capsys)
+
+
+def test_reference_without_local_file_aborts_when_engine_lacks_it(tmp_path, capsys):
+    """The 404 abort shape: unknown space OR missing registry capability —
+    either way, proceeding would let a pre-#424 engine silently drop the pin."""
+    project = _project_with_reference(tmp_path, space_file=False)
+    client = MagicMock()
+    client.get_value_space.side_effect = AethisAPIError(404, "Not Found")
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()
+    out = _flat(capsys)
+    assert "form-an/countries" in out
+    assert "value-spaces" in out or "registry" in out
+
+
+def test_reference_without_local_file_aborts_on_any_non_2xx(tmp_path, capsys):
+    """The non-404 abort shape: a 5xx probe failure is not evidence the
+    reference will survive spec-set — abort rather than guess."""
+    project = _project_with_reference(tmp_path, space_file=False)
+    client = MagicMock()
+    client.get_value_space.side_effect = AethisAPIError(503, "Service Unavailable")
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()
+
+
+def test_sync_state_is_written_incrementally_per_space(tmp_path):
+    """Review advisory (PR #110): a partial-sync abort must not lose the
+    versions already recorded — space A's PUT succeeded, so its version is
+    on disk even though space B's PUT aborted the run."""
+    fields = REFERENCED_FIELDS + "  - key: res.country\n    type: enum\n    value_space: form-an/regions\n"
+    _write(tmp_path / "fields" / "fields.yaml", fields)
+    _write(tmp_path / "shared" / "value_spaces" / "form-an__countries.yaml", SPACE_FILE)
+    _write(
+        tmp_path / "shared" / "value_spaces" / "form-an__regions.yaml",
+        SPACE_FILE.replace("form-an/countries", "form-an/regions"),
+    )
+    client = MagicMock()
+
+    def _put(*, name, **kwargs):
+        if name == "form-an/regions":
+            raise AethisAPIError(409, "moved under you — pull first")
+        return {"name": name, "version": 7, "created": True}
+
+    client.put_value_space.side_effect = _put
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", tmp_path)
+
+    # countries sorts before regions, so its successful PUT preceded the
+    # abort — and its recorded version must have survived it.
+    assert read_state(tmp_path)["value_space_sync"]["form-an/countries"] == 7
+
+
+def test_local_registry_walk_is_bounded_at_the_repo_root(tmp_path):
+    """Review advisory (PR #110): the ancestor walk stops at the repo root —
+    a same-named yaml lying above it must never be silently PUT."""
+    repo = tmp_path / "outside" / "repo"
+    project = repo / "rulesets" / "child"
+    project.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    # The poisoned file sits ABOVE the repo root.
+    _write(tmp_path / "outside" / "shared" / "value_spaces" / "form-an__countries.yaml", SPACE_FILE)
+
+    spaces = generate_cmd._local_value_space_files(project)
+    assert "form-an/countries" not in spaces
+
+    # The same file INSIDE the repo root is found.
+    _write(repo / "shared" / "value_spaces" / "form-an__countries.yaml", SPACE_FILE)
+    spaces = generate_cmd._local_value_space_files(project)
+    assert "form-an/countries" in spaces
+
+
+def test_sync_abort_prints_the_engine_message_not_a_dict_repr(tmp_path, capsys):
+    """Review advisory (PR #110): a structured 409 detail is rendered by its
+    message, never as a raw dict repr."""
+    project = _project_with_reference(tmp_path)
+    client = MagicMock()
+    client.put_value_space.side_effect = AethisAPIError(
+        409,
+        {
+            "reason_code": "value_space_moved",
+            "message": "Space 'form-an/countries' moved under you (current version 3, you based on 1) — pull first",
+            "current_version": 3,
+        },
+    )
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    out = _flat(capsys)
+    assert "moved under you" in out
+    assert "reason_code" not in out  # no raw dict repr
 
 
 # --- registry-aware drift report (C3 / C5(d)) --------------------------------


### PR DESCRIPTION
The CLI half of [aethis-core#424](https://github.com/Aethis-ai/aethis-core/issues/424) (epic [aethis-workspace#980](https://github.com/Aethis-ai/aethis-workspace/issues/980), P3 transport). The engine half is merged and **live on staging** — see the capability probe below. **v0.35.0**, version + CHANGELOG in the same commit.

Engine dependency: not a registry package — the gate is the capability live on the engine (per `submodule-discipline.md` §6 as amended for internal-only content: the engine this work actually runs against is `staging.api.aethis.ai`). No `aethis-needs` marker applies.

## Capability probe (verified before this PR opened — never `info.version`)

```
$ curl -sf https://staging.api.aethis.ai/openapi.json | python3 -c '...paths + ExpectedFieldSpec...'
{"/api/v1/public/value-spaces": ["get"], "/api/v1/public/value-spaces/{name}": ["get", "put"]}
ExpectedFieldSpec has value_space: True
```

(Engine PR aethis-core#429, merged as `76d8dd3`.)

## What this ships

1. **`value_space:` on a `fields.yaml` pin** — enum fields may reference a named, versioned value space instead of inlining members; `set_field_spec` transmits it. `validate_fields_list` mirrors the engine's mutual exclusion (`value_space` XOR `enum_values` per field, `value_space` only on enum sorts) and **drops the enum-members-required rejection for reference-form** (the P5-flagged defect: the CLI used to actively reject exactly the form this epic ships).
2. **Registry sync before spec-set (DX-6)** — locally-authored space files (`value_spaces/` or `shared/value_spaces/*.yaml`, the form-an wire-form `name/members/provenance`; extra generator keys ignored) are `PUT` with the sync-state base version (`.aethis/state.json` → `value_space_sync`), and the returned version is recorded back. **Any non-2xx aborts before `set_field_spec`**, naming the missing capability: a pre-#424 engine is extra-ignore on `ExpectedFieldSpec`, so proceeding would silently drop the pin and the model would free-author the vocabulary. A 409 surfaces the engine's "space moved under you — pull first" detail. A referenced space with no local file warns and proceeds (it may be registered by another project; the engine's spec-set 422 is the loud gate).
3. **Registry-aware drift report (C3)** — a referenced field pins no members, so the existing diff's "pins no enum_values ⇒ opts out" would print success with zero member verification on exactly the migrated fields. Instead the report resolves expected members from the registry **at the version the job result stamped** (`value_spaces_resolved`, threaded through `GenerationOutcome`), prints `<key> ← <space>@vN (M members verified)`, diffs mismatches loudly, and reports an unverifiable referenced field rather than skipping it. **Version advance is flagged, never silent (C5(d))**: if the resolved version differs from the sync-state version, the report says so.
4. **`aethis fields pull` preserves the migration (C3)** — a local field declaring `value_space:` keeps the reference and never has members written back (the silent un-migrate-on-first-pull defect).
5. **`--no-publish` and publish behaviour untouched** — pinned by the existing `test_generate_no_publish.py` suite plus a new assertion that `client.publish` still fires exactly once on the publish path.

## Mutation evidence (gate-path-coverage rule 7 — each patch asserted applied at the expected count, restored after)

| Leg | Mutation (producer) | Guarding test | Result |
|---|---|---|---|
| C-M1 | XOR validation disabled | mutually-exclusive test | RED |
| C-M2 | `value_space` not transmitted on the pin | transmission test | RED |
| C-M3 | sync failure made non-fatal (warn + continue) | abort-before-spec-set test | RED |
| C-M4 | drift report blind spot restored (referenced fields opt out) | mismatch-flagged test | RED |
| C-M5 | `fields pull` writes members back | un-migration guard test | RED |
| C-M6 | version-advance flag removed | advance-flagged test | RED |
| C-M7 | poll drops the job's resolution (both success returns) | outcome-threading tests | RED |
| — | restore | full new-test file + generate/fields/no-publish suites | GREEN |

C-M7 earned its keep during development: it caught the auto-publish success path silently dropping `value_spaces_resolved` while the `--no-publish` path carried it — fixed and now guarded by a dedicated publish-path test.

Suites (run bare, `FORCE_COLOR` cleared per aethis-cli#105; ANSI stripped in output assertions): **full suite 563 passed**, coverage 78.5% (gate 45%), ruff clean.

## Surface-propagation audit (per-surface decision, none silent)

| Surface | Decision |
|---|---|
| aethis-core OpenAPI | **Changed in aethis-core#429** — field + routes under `/api/v1/public/*`, kept by the prefix-allowlist filter; `public-api-contract.json` regenerated there. |
| aethis-cli | **This PR** (v0.35.0 + CHANGELOG same commit). |
| aethis-mcp | **Deferred change — real gap, not blocking**: `aethis_set_field_spec`'s zod schema types `{key, sort, enum_values?}` (`src/index.ts:1895,1914`; `src/client.ts:479,511`), so an MCP author cannot send a reference yet. Additive follow-up (optional param + tool description + version/CHANGELOG), gated on the capability reaching the engine the MCP targets (`api.aethis.ai` prod). Needs an epic checklist item on #980. |
| aethis-sdk-python | **No change** — authoring is out of beta scope (skill default); the SDK is `extra="allow"`, so responses carrying new keys parse today. |
| aethis-sdk-typescript | **No change** — scaffold at v0.0.0; types regen when wired. |
| Mintlify docs | **Deferred** — `authoring/field-vocabulary.mdx` + `api-reference/openapi.json` stay correct for inline pins (field is optional); documenting the new capability waits for the engine **prod** deploy, since every docs curl must run against live prod before merge (`mintlify-docs/CLAUDE.md`). Follow-up alongside the MCP item. |
| aethis-examples | **No change** — no example pins a field spec (repo-wide grep for `set_field_spec` / `fields/spec` / `expected_fields`: empty). |
| tda-server | **No change** — `RemoteSchemaField` is extra-ignore and `/schema` still serves post-expansion members (design note §4 sweep). |
| `/schema` space-provenance metadata (design note §4 optional) | **Deferred decision (recorded per review)**: `/schema` carries no space provenance today, so `aethis fields pull` of a referenced field **not yet in local `fields.yaml`** materialises inline members — the preserve-the-reference guard only fires when the local file already declares `value_space:`. Correct behaviour needs the §4 optional `/schema` metadata (or equivalent) so pull can recognise a referenced field it has never seen. Follow-up to be filed on #980 alongside the MCP gap. |

## Review fixes (second commit, `77cc294`)

- **BLOCKING — the no-local-file lane now probes the engine**: `GET /value-spaces/{name}` before proceeding; 2xx proves both the registry capability and tenant resolution, any non-2xx aborts before `set_field_spec` (the DX-6 guarantee was vacuous exactly on this lane: another project's space + a pre-#424 engine ⇒ silent pin drop).
- Sync state written incrementally per space (a partial-sync abort keeps recorded versions; no 409 against your own write on retry).
- The local-registry ancestor walk is bounded at the repo root (`.git` boundary).
- Structured 409 details render `detail["message"]`, never a raw dict repr.

Battery extended to **11 legs, all RED, restore GREEN**: C-M8 probe removed ⇒ red; C-M9 incremental write removed ⇒ red; C-M10 walk unbounded ⇒ red; C-M11 dict repr restored ⇒ red. Suites after fixes: **568 passed**, ruff clean.

```
Execution resolution:
profile=assure
runtime=claude
provider_model=fable
selector=explicit
independence=different-session (review); different-provider unavailable (codex usage limit, resets 2026-08-20)
escalations=none
```
