### PR TITLE
fix(fields): a section's pin is its own field contract — rulebook fields override, never extend (v0.35.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.35.1 (2026-08-16)
+
+A member section's field pin is its own contract, not the rulebook's.
+
+- **fix: rulebook-level fields no longer extend a section's pinned field spec.** The merge pinned every rulebook field onto every member section, demanding fields the section's rules never author — and the engine historically dropped them silently (every published `referees_identity` build was missing 3-5 of the rulebook's cross-section fields). With the engine's new loud pin-presence gate, such a generation now correctly fails — which surfaced the over-broad pin on the first live canary run of the named-value-spaces epic. The rulebook's definition still **wins** on keys the section declares itself (the canonical definition is unchanged); it just never adds keys. The drift report's comparison universe changes identically, so it now reports on exactly the section's own contract.
+
 ## 0.35.0 (2026-08-15)
 
 Named value spaces reach the wire (aethis-core#424, epic aethis-workspace#980 P3). Requires an engine exposing `/api/v1/public/value-spaces` for referenced fields; projects with no `value_space:` pins are unaffected.

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -268,19 +268,38 @@ def _write_fields_yaml(path: Path, field_map: dict) -> None:
 
 
 def _merged_field_map(project_dir: Path) -> dict:
-    """The effective field vocabulary for a project: enclosing rulebook merged
-    with the project's own fields, rulebook winning on shared keys."""
-    field_map: dict = {}
+    """The effective field vocabulary for a project.
+
+    For a member section of a rulebook, the universe of fields is the
+    section's OWN ``fields.yaml``; the enclosing rulebook's definitions
+    OVERRIDE its own on shared keys (the canonical definition wins) but a
+    rulebook-only field is never added to a section's pin. Pinning the
+    rulebook's cross-section fields onto every member demanded fields the
+    section's rules never author — historically the engine dropped them
+    silently (every published referees_identity build was missing 3-5 of
+    them), and the loud pin-presence gate (aethis-core#428) now correctly
+    fails such a generation. The pin must be the section's own contract.
+
+    For a standalone project or the rulebook project itself, the own file is
+    the whole universe, unchanged.
+    """
+    own_fields = project_dir / "fields" / "fields.yaml"
+    own = _parse_fields_yaml(own_fields) if own_fields.exists() else {}
+
+    rb_map: dict = {}
     rb_dir = _parent_rulebook_dir(project_dir)
     if rb_dir is not None:
         rb_fields = rb_dir / "fields" / "fields.yaml"
         if rb_fields.exists():
-            field_map.update(_parse_fields_yaml(rb_fields))
-    own_fields = project_dir / "fields" / "fields.yaml"
-    if own_fields.exists():
-        for key, field in _parse_fields_yaml(own_fields).items():
-            field_map.setdefault(key, field)  # rulebook wins: don't overwrite
-    return field_map
+            rb_map = _parse_fields_yaml(rb_fields)
+
+    if not own:
+        # No own declaration: a section relying on discovery pins nothing
+        # (pinning another layer's fields was never a real contract), while a
+        # rulebook-level project has no parent and falls through to {} anyway.
+        return rb_map if rb_dir is None else {}
+
+    return {key: rb_map.get(key, field) for key, field in own.items()}
 
 
 def _local_value_space_files(project_dir: Path) -> dict:

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -297,7 +297,7 @@ def _merged_field_map(project_dir: Path) -> dict:
         # No own declaration: a section relying on discovery pins nothing
         # (pinning another layer's fields was never a real contract), while a
         # rulebook-level project has no parent and falls through to {} anyway.
-        return rb_map if rb_dir is None else {}
+        return {}
 
     return {key: rb_map.get(key, field) for key, field in own.items()}
 
@@ -436,12 +436,14 @@ def _sync_value_spaces(client: AethisClient, project_dir: Path, referenced: set)
 
 
 def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) -> None:
-    """Push the field vocabulary for this project (rulebook-level fields win).
+    """Push the field vocabulary for this project.
 
-    Merges the enclosing rulebook's ``fields/fields.yaml`` (if any) with the
-    project's own — the rulebook definition wins on shared keys — then pins the
-    expected field keys/types via ``/fields/spec`` and routes each field's
-    label/question/hints through guidance so a shared field is defined once.
+    The pin universe is the project's OWN ``fields.yaml``; for a member
+    section the enclosing rulebook's definition overrides shared keys (the
+    canonical definition wins) but never adds keys — see
+    ``_merged_field_map``. Pins the expected field keys/types via
+    ``/fields/spec`` and routes each field's label/question/hints through
+    guidance.
     """
     # Fail fast on a malformed vocabulary before we mutate server state. Validate
     # each contributing file's RAW list so duplicate keys *within a file* surface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.35.0"
+version = "0.35.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_generate_fields.py
+++ b/tests/test_generate_fields.py
@@ -419,5 +419,4 @@ class TestSectionPinIsOwnFields:
         import yaml as _y
         (proj / "aethis.yaml").write_text("project: solo\n")
         (proj / "fields" / "fields.yaml").write_text(_y.safe_dump({"fields": [{"key": "a.b", "type": "Str"}]}))
-        from aethis_cli.commands.generate_cmd import _merged_field_map as m
-        assert set(m(proj).keys()) == {"a.b"}
+        assert set(_merged_field_map(proj).keys()) == {"a.b"}

--- a/tests/test_generate_fields.py
+++ b/tests/test_generate_fields.py
@@ -362,3 +362,62 @@ def test_report_field_diff_clean_when_member_sets_match(tmp_path, capsys):
     generate_cmd._report_field_diff(client, "rs_1", tmp_path)
     out = _flat(capsys)
     assert "all 1 pinned field(s) were produced" in out
+
+
+class TestSectionPinIsOwnFields:
+    """A member section's pin universe is its OWN fields.yaml; the rulebook
+    overrides shared keys but never extends the pin (found live: the ws#980 P8
+    canary — 5 rulebook-level app.* fields pinned onto referees_identity, which
+    no build ever authored; the loud pin-presence gate then failed every run)."""
+
+    def _tree(self, tmp_path, own_fields, rb_fields):
+        rb = tmp_path / "rb"
+        section = rb / "rulesets" / "sec"
+        (section / "fields").mkdir(parents=True)
+        (section / ".aethis").mkdir()
+        import yaml as _y
+        (rb / "aethis.yaml").write_text("project: rb\nkind: rulebook\n")
+        (section / "aethis.yaml").write_text("project: sec\nrulebook: ../..\n")
+        if rb_fields is not None:
+            (rb / "fields").mkdir()
+            (rb / "fields" / "fields.yaml").write_text(_y.safe_dump({"fields": rb_fields}))
+        (section / "fields" / "fields.yaml").write_text(_y.safe_dump({"fields": own_fields}))
+        return section
+
+    def test_rulebook_only_field_is_not_pinned_for_a_section(self, tmp_path):
+        from aethis_cli.commands.generate_cmd import _merged_field_map
+        section = self._tree(
+            tmp_path,
+            own_fields=[{"key": "ref.x", "type": "Bool"}],
+            rb_fields=[
+                {"key": "app.route", "type": "Enum", "enum_values": ["a", "b"]},
+                {"key": "ref.x", "type": "Bool"},
+            ],
+        )
+        keys = set(_merged_field_map(section).keys())
+        assert keys == {"ref.x"}, keys
+
+    def test_rulebook_definition_still_wins_on_a_shared_key(self, tmp_path):
+        from aethis_cli.commands.generate_cmd import _merged_field_map
+        section = self._tree(
+            tmp_path,
+            own_fields=[{"key": "pi.nat", "type": "Enum", "enum_values": ["stale"]}],
+            rb_fields=[{"key": "pi.nat", "type": "Enum", "enum_values": ["canonical"]}],
+        )
+        m = _merged_field_map(section)
+        assert m["pi.nat"].get("enum_values") == ["canonical"], m
+
+    def test_section_without_own_fields_pins_nothing(self, tmp_path):
+        from aethis_cli.commands.generate_cmd import _merged_field_map
+        section = self._tree(tmp_path, own_fields=[], rb_fields=[{"key": "app.route", "type": "Str"}])
+        assert _merged_field_map(section) == {}
+
+    def test_standalone_project_unchanged(self, tmp_path):
+        from aethis_cli.commands.generate_cmd import _merged_field_map
+        proj = tmp_path / "solo"
+        (proj / "fields").mkdir(parents=True)
+        import yaml as _y
+        (proj / "aethis.yaml").write_text("project: solo\n")
+        (proj / "fields" / "fields.yaml").write_text(_y.safe_dump({"fields": [{"key": "a.b", "type": "Str"}]}))
+        from aethis_cli.commands.generate_cmd import _merged_field_map as m
+        assert set(m(proj).keys()) == {"a.b"}

--- a/tests/test_generate_fields.py
+++ b/tests/test_generate_fields.py
@@ -376,6 +376,7 @@ class TestSectionPinIsOwnFields:
         (section / "fields").mkdir(parents=True)
         (section / ".aethis").mkdir()
         import yaml as _y
+
         (rb / "aethis.yaml").write_text("project: rb\nkind: rulebook\n")
         (section / "aethis.yaml").write_text("project: sec\nrulebook: ../..\n")
         if rb_fields is not None:
@@ -386,6 +387,7 @@ class TestSectionPinIsOwnFields:
 
     def test_rulebook_only_field_is_not_pinned_for_a_section(self, tmp_path):
         from aethis_cli.commands.generate_cmd import _merged_field_map
+
         section = self._tree(
             tmp_path,
             own_fields=[{"key": "ref.x", "type": "Bool"}],
@@ -399,6 +401,7 @@ class TestSectionPinIsOwnFields:
 
     def test_rulebook_definition_still_wins_on_a_shared_key(self, tmp_path):
         from aethis_cli.commands.generate_cmd import _merged_field_map
+
         section = self._tree(
             tmp_path,
             own_fields=[{"key": "pi.nat", "type": "Enum", "enum_values": ["stale"]}],
@@ -409,14 +412,17 @@ class TestSectionPinIsOwnFields:
 
     def test_section_without_own_fields_pins_nothing(self, tmp_path):
         from aethis_cli.commands.generate_cmd import _merged_field_map
+
         section = self._tree(tmp_path, own_fields=[], rb_fields=[{"key": "app.route", "type": "Str"}])
         assert _merged_field_map(section) == {}
 
     def test_standalone_project_unchanged(self, tmp_path):
         from aethis_cli.commands.generate_cmd import _merged_field_map
+
         proj = tmp_path / "solo"
         (proj / "fields").mkdir(parents=True)
         import yaml as _y
+
         (proj / "aethis.yaml").write_text("project: solo\n")
         (proj / "fields" / "fields.yaml").write_text(_y.safe_dump({"fields": [{"key": "a.b", "type": "Str"}]}))
         assert set(_merged_field_map(proj).keys()) == {"a.b"}


### PR DESCRIPTION
Found live by the ws#980 P8 canary, first run: `_merged_field_map` pinned every rulebook-level field onto every member section — demanding fields the section's rules never author. The evidence that this was never a real contract: v7, the canary section's last successful build, silently lacked 3 of the 5 rulebook fields (the pre-epic engine dropped pinned-but-absent fields silently); the new loud pin-presence gate (aethis-core#428, by design) then failed every canary run on exactly those 5 phantom fields, twice consecutively, same fields.

**Semantics after:** the pin universe = the section's own fields.yaml; the rulebook's definition still WINS on keys the section declares itself (canonical definition unchanged); rulebook-only keys are never pinned onto a section. Standalone + rulebook-level projects unchanged. The drift report's universe changes identically.

**⚠ Migration requirement (review F1 — sequenced, not optional):** form-an's sections deliberately rely on rulebook-scope pins for shared `app.*` fields their rules DO author (the "NOT repeated here" headers). This PR must land AFTER the companion form-an change in which each section re-declares the shared keys it actually uses (content-identical, so it is a no-op under the current CLI — the rulebook overrides it — and becomes the pin carrier under this one). Companion PR: form-an (sequenced first). Note the old behaviour is equally dead under the engine's loud gate: english_language pins 3 rulebook fields it never authors and would fail its next generate regardless — this pair of changes is what makes any section generable again.

**Review status:** independent adversarial review returned HOLD with two blockers, both addressed: F1 = the migration above (companion PR sequenced first); F2 = an F401 in the new test file that gated CI's pytest (fixed in `971eea4` — the suite now actually runs in CI). F3 (the body's earlier pi.nationality example was wrong — that field is section-declared only, deliberately) and F4 (stale docstring, vacuous return arm) also fixed.

Evidence: 4 new tests; producer-only mutation (revert `_merged_field_map` alone) turns the two behaviour-changing tests red while the invariant pair stays green; full suite green bare.

Epic ws#980; unblocks the P8 canary + control batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
