### PR TITLE
fix(generate): replace edited sources safely (v0.36.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.36.1 (2026-08-20)
+
+- **fix(generate): source upload results are truthful.** Generation reports the
+  engine's exact new and reused counts instead of calling every attempted file
+  newly uploaded.
+- **fix(generate): edited sources remain regenerable.** Before uploading changed
+  content under an existing filename, the CLI supersedes the prior active source,
+  uploads and links its replacement, and reactivates the prior source if the
+  replacement upload fails. This avoids both a hard-blocked edit loop and duplicate
+  active source text in the authoring prompt.
+
 ## 0.36.0 (2026-08-19)
 
 A field can now say what its members are *called*, and which stored key its

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.36.0"
+__version__ = "0.36.1"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -256,11 +256,27 @@ class AethisClient:
         """List the project's uploaded sources (metadata only, no bodies).
 
         Each entry carries ``raw_sha256`` — the digest of the exact bytes the
-        engine retained — which is what lets a caller cite an already-uploaded
-        file instead of uploading a second identical copy. The engine never
-        dedupes on upload, so this is the only guard against duplicates.
+        engine retained — which lets a caller distinguish an exact replay from
+        changed content and drive the explicit source lifecycle.
         """
         return self._request("GET", f"/api/v1/public/projects/{project_id}/sources")
+
+    def update_source(
+        self,
+        project_id: str,
+        source_id: str,
+        *,
+        status: str,
+        superseded_by: Optional[str] = None,
+    ) -> dict:
+        body = {"status": status}
+        if superseded_by is not None:
+            body["superseded_by"] = superseded_by
+        return self._request(
+            "PATCH",
+            f"/api/v1/public/projects/{project_id}/sources/{source_id}",
+            json=body,
+        )
 
     def add_tests(self, project_id: str, test_cases: list[dict], replace: bool = False) -> dict:
         """Upload golden test cases to a project.

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import time
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -26,6 +27,20 @@ from aethis_cli.output import console, error_panel, info, success, warn
 def _chunks(lst: list, n: int):
     for i in range(0, len(lst), n):
         yield lst[i : i + n]
+
+
+class UploadSummary(NamedTuple):
+    new: int
+    reused: int
+
+
+def _upload_counts(response: dict) -> UploadSummary:
+    """Read the engine's authoritative upload disposition."""
+    new = response.get("new")
+    reused = response.get("reused")
+    if not isinstance(new, int) or not isinstance(reused, int):
+        raise AethisAPIError(502, "The source upload response did not report integer new/reused counts.")
+    return UploadSummary(new=new, reused=reused)
 
 
 def _collect_source_files(project_dir: Path) -> list[Path]:
@@ -60,16 +75,17 @@ def _resolve_or_create_project(client: AethisClient, cfg, project_id: Optional[s
     return pid
 
 
-def _upload_sources(client: AethisClient, pid: str, project_dir: Path) -> int:
+def _upload_sources(client: AethisClient, pid: str, project_dir: Path) -> UploadSummary:
     """Upload source files new or changed since the last upload, batched in 5s.
 
     A per-file mtime ledger in ``.aethis/state.json`` keeps this idempotent, so a
     ``discover`` followed by a ``generate`` (or repeated generates) doesn't
-    re-push unchanged sources. Returns the number uploaded.
+    re-push unchanged sources. Edited files replace their active same-name
+    predecessor through the engine's reversible source lifecycle.
     """
     files = _collect_source_files(project_dir)
     if not files:
-        return 0
+        return UploadSummary(new=0, reused=0)
     root = (project_dir / "sources").resolve()
     ledger = dict(read_state(project_dir).get("uploaded_sources") or {})
     to_upload = []
@@ -80,12 +96,54 @@ def _upload_sources(client: AethisClient, pid: str, project_dir: Path) -> int:
             to_upload.append(f)
         ledger[rel] = mtime
     if not to_upload:
-        return 0
-    for batch in _chunks(to_upload, 5):
-        client.upload_sources(pid, batch)
+        return UploadSummary(new=0, reused=0)
+
+    listed = client.list_sources(pid) or {}
+    active_by_filename = {
+        source.get("filename"): source
+        for source in (listed.get("sources") or [])
+        if isinstance(source, dict) and source.get("filename") and source.get("status", "active") == "active"
+    }
+    replacements: list[tuple[Path, dict]] = []
+    ordinary: list[Path] = []
+    for path in to_upload:
+        active = active_by_filename.get(path.name)
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if active and active.get("raw_sha256") != digest:
+            replacements.append((path, active))
+        else:
+            ordinary.append(path)
+
+    summary = UploadSummary(new=0, reused=0)
+    for batch in _chunks(ordinary, 5):
+        counts = _upload_counts(client.upload_sources(pid, batch) or {})
+        summary = UploadSummary(new=summary.new + counts.new, reused=summary.reused + counts.reused)
+
+    for path, prior in replacements:
+        prior_id = prior.get("source_id")
+        if not isinstance(prior_id, str) or not prior_id:
+            raise AethisAPIError(502, f"The active source metadata for {path.name} has no source_id.")
+        client.update_source(pid, prior_id, status="superseded")
+        try:
+            response = client.upload_sources(pid, [path]) or {}
+        except Exception:
+            try:
+                client.update_source(pid, prior_id, status="active")
+            except Exception as rollback_error:  # noqa: BLE001 — preserve the upload failure
+                warn(f"Replacement upload failed and source {prior_id} could not be reactivated: {rollback_error}")
+            raise
+        sources = response.get("sources") or []
+        replacement_id = sources[0].get("source_id") if sources and isinstance(sources[0], dict) else None
+        if not isinstance(replacement_id, str) or not replacement_id:
+            client.update_source(pid, prior_id, status="active")
+            raise AethisAPIError(502, f"The replacement upload for {path.name} returned no source_id.")
+        client.update_source(pid, prior_id, status="superseded", superseded_by=replacement_id)
+        counts = _upload_counts(response)
+        summary = UploadSummary(new=summary.new + counts.new, reused=summary.reused + counts.reused)
+
     write_state(project_dir, {"uploaded_sources": ledger})
-    info(f"Uploaded {len(to_upload)} source(s)")
-    return len(to_upload)
+    info(f"Sources: {summary.new} new, {summary.reused} reused")
+    return summary
 
 
 def _load_yaml_file(path: Path) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.36.0"
+version = "0.36.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,6 +189,18 @@ def test_upload_sources(respx_mock, tmp_path):
 
 
 @respx.mock(base_url=BASE)
+def test_update_source_uses_project_scoped_patch(respx_mock):
+    route = respx_mock.patch("/api/v1/public/projects/proj_abc/sources/src_old").mock(
+        return_value=httpx.Response(200, json={"source_id": "src_old", "status": "superseded"})
+    )
+
+    result = AethisClient("ak", BASE).update_source("proj_abc", "src_old", status="superseded", superseded_by="src_new")
+
+    assert result["status"] == "superseded"
+    assert route.calls.last.request.content == b'{"status":"superseded","superseded_by":"src_new"}'
+
+
+@respx.mock(base_url=BASE)
 def test_add_tests(respx_mock):
     respx_mock.post("/api/v1/public/projects/proj_abc/tests").mock(
         return_value=httpx.Response(201, json={"added": 2, "test_case_ids": ["tc_1", "tc_2"]})

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -85,6 +85,12 @@ def _wire(monkeypatch, tmp_path, client) -> None:
 
 def _engine(status_payload: dict, schema: dict | None = None, schema_error: Exception | None = None) -> MagicMock:
     client = MagicMock()
+    client.list_sources.return_value = {"sources": []}
+    client.upload_sources.return_value = {
+        "new": 1,
+        "reused": 0,
+        "sources": [{"source_id": "src_1", "filename": "a.md", "reused": False}],
+    }
     client.generate.return_value = {"job_id": "job_1"}
     client.last_rate_limit = None
     client.get_status.return_value = status_payload

--- a/tests/test_generate_fields.py
+++ b/tests/test_generate_fields.py
@@ -222,20 +222,144 @@ def test_upload_sources_is_idempotent(tmp_path):
     src.mkdir()
     (src / "a.md").write_text("hello")
     client = MagicMock()
+    client.list_sources.return_value = {"sources": []}
+    client.upload_sources.return_value = {
+        "new": 1,
+        "reused": 0,
+        "sources": [{"source_id": "src_1", "filename": "a.md", "reused": False}],
+    }
 
     # First upload sends the file.
-    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == 1
+    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == generate_cmd.UploadSummary(new=1, reused=0)
     assert client.upload_sources.call_count == 1
 
     # Unchanged → nothing re-uploaded (the discover→generate double-upload fix).
-    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == 0
+    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == generate_cmd.UploadSummary(new=0, reused=0)
     assert client.upload_sources.call_count == 1
 
     # Editing the file (newer mtime) makes it upload again.
     (src / "a.md").write_text("changed")
     os.utime(src / "a.md", ns=(2_000_000_000, 2_000_000_000))
-    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == 1
+    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == generate_cmd.UploadSummary(new=1, reused=0)
     assert client.upload_sources.call_count == 2
+
+
+def test_upload_reports_exact_new_and_reused_counts_from_engine(tmp_path, capsys):
+    src = tmp_path / "sources"
+    src.mkdir()
+    (src / "a.md").write_text("same")
+    (src / "b.md").write_text("new")
+    client = MagicMock()
+    client.list_sources.return_value = {"sources": []}
+    client.upload_sources.return_value = {
+        "new": 1,
+        "reused": 1,
+        "sources": [
+            {"source_id": "src_a", "filename": "a.md", "reused": True},
+            {"source_id": "src_b", "filename": "b.md", "reused": False},
+        ],
+    }
+
+    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == generate_cmd.UploadSummary(new=1, reused=1)
+    assert "Sources: 1 new, 1 reused" in _flat(capsys)
+
+
+def test_all_reused_upload_never_says_the_sources_are_new(tmp_path, capsys):
+    src = tmp_path / "sources"
+    src.mkdir()
+    (src / "a.md").write_text("same")
+    client = MagicMock()
+    client.list_sources.return_value = {"sources": []}
+    client.upload_sources.return_value = {
+        "new": 0,
+        "reused": 1,
+        "sources": [{"source_id": "src_a", "filename": "a.md", "reused": True}],
+    }
+
+    assert generate_cmd._upload_sources(client, "proj_1", tmp_path) == generate_cmd.UploadSummary(new=0, reused=1)
+    rendered = _flat(capsys)
+    assert "Sources: 0 new, 1 reused" in rendered
+    assert "Uploaded 1" not in rendered
+
+
+def test_changed_source_is_superseded_then_linked_to_replacement(tmp_path):
+    src = tmp_path / "sources"
+    src.mkdir()
+    (src / "law.md").write_text("new law")
+    client = MagicMock()
+    client.list_sources.return_value = {
+        "sources": [
+            {
+                "source_id": "src_old",
+                "filename": "law.md",
+                "raw_sha256": "0" * 64,
+                "status": "active",
+            }
+        ]
+    }
+    client.upload_sources.return_value = {
+        "new": 1,
+        "reused": 0,
+        "sources": [{"source_id": "src_new", "filename": "law.md", "reused": False}],
+    }
+
+    summary = generate_cmd._upload_sources(client, "proj_1", tmp_path)
+
+    assert summary == generate_cmd.UploadSummary(new=1, reused=0)
+    assert client.update_source.call_args_list == [
+        (("proj_1", "src_old"), {"status": "superseded"}),
+        (("proj_1", "src_old"), {"status": "superseded", "superseded_by": "src_new"}),
+    ]
+
+
+def test_failed_replacement_upload_reactivates_old_source(tmp_path):
+    src = tmp_path / "sources"
+    src.mkdir()
+    (src / "law.md").write_text("new law")
+    client = MagicMock()
+    client.list_sources.return_value = {
+        "sources": [
+            {
+                "source_id": "src_old",
+                "filename": "law.md",
+                "raw_sha256": "0" * 64,
+                "status": "active",
+            }
+        ]
+    }
+    original = RuntimeError("upload failed")
+    client.upload_sources.side_effect = original
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        generate_cmd._upload_sources(client, "proj_1", tmp_path)
+
+    assert client.update_source.call_args_list == [
+        (("proj_1", "src_old"), {"status": "superseded"}),
+        (("proj_1", "src_old"), {"status": "active"}),
+    ]
+
+
+def test_failed_rollback_does_not_disguise_original_upload_error(tmp_path):
+    src = tmp_path / "sources"
+    src.mkdir()
+    (src / "law.md").write_text("new law")
+    client = MagicMock()
+    client.list_sources.return_value = {
+        "sources": [
+            {
+                "source_id": "src_old",
+                "filename": "law.md",
+                "raw_sha256": "0" * 64,
+                "status": "active",
+            }
+        ]
+    }
+    original = RuntimeError("original upload failure")
+    client.upload_sources.side_effect = original
+    client.update_source.side_effect = [None, RuntimeError("rollback failure")]
+
+    with pytest.raises(RuntimeError, match="original upload failure"):
+        generate_cmd._upload_sources(client, "proj_1", tmp_path)
 
 
 def test_safe_field_type_clamps_unknown_and_valueless_enum():

--- a/tests/test_generate_no_publish.py
+++ b/tests/test_generate_no_publish.py
@@ -66,6 +66,12 @@ def _wire(monkeypatch, tmp_path, client) -> None:
 
 def _engine(status_payload: dict, schema: dict | None = None) -> MagicMock:
     client = MagicMock()
+    client.list_sources.return_value = {"sources": []}
+    client.upload_sources.return_value = {
+        "new": 1,
+        "reused": 0,
+        "sources": [{"source_id": "src_1", "filename": "a.md", "reused": False}],
+    }
     client.generate.return_value = {"job_id": "job_1"}
     client.last_rate_limit = None
     client.get_status.return_value = status_payload

--- a/tests/test_guidance_cli.py
+++ b/tests/test_guidance_cli.py
@@ -27,7 +27,17 @@ def _setup_generate_mocks(mock_router, project_id: str = "proj_1") -> object:
         return_value=httpx.Response(201, json={"hint_id": "h1"})
     )
     mock_router.post(f"/api/v1/public/projects/{project_id}/sources").mock(
-        return_value=httpx.Response(201, json={"uploaded": 1})
+        return_value=httpx.Response(
+            201,
+            json={
+                "new": 1,
+                "reused": 0,
+                "sources": [{"source_id": "src_1", "filename": "policy.md", "reused": False}],
+            },
+        )
+    )
+    mock_router.get(f"/api/v1/public/projects/{project_id}/sources").mock(
+        return_value=httpx.Response(200, json={"sources": []})
     )
     mock_router.get(f"/api/v1/public/projects/{project_id}").mock(
         return_value=httpx.Response(200, json={"project_id": project_id})


### PR DESCRIPTION
## Outcome

The authoring loop now reports source uploads truthfully and can regenerate after a source file is edited without leaving two active same-name documents in the prompt.

- reports the engine's exact `new` / `reused` counts, including `0 new, N reused`;
- detects changed content by active filename + exact raw digest;
- supersedes the old source, uploads the replacement, and links the old identity to the new one;
- reactivates the old source if replacement upload fails, while preserving the original error if rollback also fails;
- bumps the public package to 0.36.1 and records the change.

Closes #115.
Closes #116.
Part of Aethis-ai/aethis-workspace#1081.
Requires Aethis-ai/aethis-core#455 live on `api.aethis.ai` before this consumer PR lands.

## TDD evidence

The new behavior was written as failing tests first:

- exact new/reused reporting;
- all-reused output never claims a new upload;
- successful supersede/upload/link ordering;
- failed upload reactivates the prior source;
- failed rollback cannot disguise the original upload error;
- project-scoped PATCH client request.

Local gates at the exact head:

- `uv run pytest tests/ --ignore=tests/e2e -q`: **624 passed, 10 deselected**;
- coverage: **78.94%** (required 45%);
- Ruff check: clean;
- Ruff format check: clean;
- `git diff --check`: clean.

## Surface propagation audit

This consumes existing project-source list/upload/PATCH routes; it does not change an engine route or response model. CLI is the only surface that owns the local edit-and-regenerate workflow. MCP, SDKs, docs, examples, staff console, and the public demo require no change for this PR. The engine-before-consumer deployment gate above remains binding.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789827786&installation_model_id=429844&pr_number=117&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F117&signature=64f2a537e147981d494adc2ba25cf38caced21e80c7dac25a3aed6caffaf6bf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->