### PR TITLE
fix(generate): carry authoritative field behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.37.0 (2026-08-22)
+
+- **fix(generate): authored field behaviour is deterministic.** Generation
+  uploads now carry explicitly authored labels, questions, ownership,
+  injection source/phase, ordering weight, recovery capabilities, and UI hints
+  on the field pin. The engine's normalisation seam can therefore preserve the
+  authoring contract instead of accepting model-invented replacements.
+- **fix(generate): an omitted question on a non-applicant field is explicit.**
+  When a field declares a caseworker, system, or derived owner and has no
+  `question`, the CLI sends `question: null`; this clears any question invented
+  by the generation model. Legacy fields that declare none of the new metadata
+  retain their previous upload shape.
+- **fix(generate): capability checks cover behavioural metadata.** An older
+  engine that would silently discard any declared property is refused before
+  the field-spec push, just as it already was for enum labels and canonical
+  storage mappings.
+
 ## 0.36.1 (2026-08-20)
 
 - **fix(generate): source upload results are truthful.** Generation reports the

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.36.1"
+__version__ = "0.37.0"

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -266,6 +266,12 @@ _ENGINE_GATED_FIELD_KEYS = (
     "x_ui_widget",
 )
 
+# Rulebook vocabulary is intentionally slimmer than a generation pin. Keep its
+# capability gate scoped to properties that RulebookFieldSpec actually carries;
+# otherwise a project-only property in a shared authoring file would make the
+# rulebook command refuse an engine that is fully compatible with that route.
+_RULEBOOK_GATED_FIELD_KEYS = ("enum_labels", "canonical_field")
+
 
 def _normalise_field_type(t: Optional[str]) -> str:
     """Fold a server/long type name into the short ``fields.yaml`` form."""
@@ -693,7 +699,8 @@ def check_display_metadata_support(client: AethisClient, fields: list[dict], *, 
     carry the properties on one and not the other, so each upload path asks
     about the one it actually posts.
     """
-    declared = sorted({k for f in fields if isinstance(f, dict) for k in _ENGINE_GATED_FIELD_KEYS if k in f})
+    gated_keys = _RULEBOOK_GATED_FIELD_KEYS if rulebook else _ENGINE_GATED_FIELD_KEYS
+    declared = sorted({k for f in fields if isinstance(f, dict) for k in gated_keys if k in f})
     if not declared:
         return
     advertised = client.rulebook_field_spec_properties() if rulebook else client.expected_field_spec_properties()

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -202,8 +202,8 @@ def _parse_fields_yaml(path: Path) -> dict:
 def _field_guidance_lines(key: str, field: dict) -> list[str]:
     """Natural-language guidance derived from a field's label/question/hints.
 
-    The ``/fields/spec`` endpoint only fixes key + type, so the human-facing
-    phrasing and the "why we ask" notes ride along as guidance instead.
+    Guidance remains useful context for the model, but explicitly authored
+    behaviour also rides the field pin and wins deterministically downstream.
     """
     lines: list[str] = []
     if field.get("question"):
@@ -241,13 +241,30 @@ _FIELD_KEY_ORDER = (
     "value_space",
     "enum_labels",
     "canonical_field",
+    "weight",
+    "elicitation_owner",
+    "injection_source",
+    "injection_phase",
+    "recoverable_from",
+    "x_ui_widget",
     "hints",
 )
 
 # Field-spec properties the engine must advertise before an authored value for
 # them is worth sending. An engine that does not model a property ignores it,
 # so the upload succeeds and the metadata is gone.
-_ENGINE_GATED_FIELD_KEYS = ("enum_labels", "canonical_field")
+_ENGINE_GATED_FIELD_KEYS = (
+    "enum_labels",
+    "canonical_field",
+    "label",
+    "question",
+    "weight",
+    "elicitation_owner",
+    "injection_source",
+    "injection_phase",
+    "recoverable_from",
+    "x_ui_widget",
+)
 
 
 def _normalise_field_type(t: Optional[str]) -> str:
@@ -631,6 +648,12 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
             if prop in field:
                 value = field[prop]
                 spec[prop] = dict(value) if isinstance(value, dict) else value
+        # In fields.yaml, omitting a question on a declared non-applicant fact
+        # is intentional: there is no applicant question. Make that absence
+        # explicit on the wire so a model-invented question is cleared rather
+        # than mistaken for legacy abstention.
+        if field.get("elicitation_owner") not in (None, "applicant") and "question" not in field:
+            spec["question"] = None
         expected_fields.append(spec)
         guidance_lines.extend(_field_guidance_lines(key, field))
 
@@ -653,11 +676,11 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
 
 
 def check_display_metadata_support(client: AethisClient, fields: list[dict], *, rulebook: bool = False) -> None:
-    """Refuse to push authored display metadata an engine will throw away.
+    """Refuse to push authored field metadata an engine will throw away.
 
     An engine that predates a field-spec property does not reject it — it
     ignores it, so the upload succeeds, the generation runs, and the labels
-    (or the canonical pairing) are simply gone. That is the one failure this
+    (or the ownership/question contract) are simply gone. That is the one failure this
     guard exists to make loud, and it fires only for the fields that actually
     declare something: a project with none is untouched.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.36.1"
+version = "0.37.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/mutation-check.py
+++ b/scripts/mutation-check.py
@@ -377,8 +377,8 @@ MUTATIONS: List[Mutation] = [
     Mutation(
         "metadata-missing-from-canonical-key-order",
         "aethis_cli/commands/generate_cmd.py",
-        '    "enum_labels",\n    "canonical_field",\n    "hints",',
-        '    "hints",',
+        '    "value_space",\n    "enum_labels",\n    "canonical_field",\n    "weight",',
+        '    "value_space",\n    "weight",',
         "a pull rewrites the metadata out of its modelled place in fields.yaml",
         detects=("tests/test_field_display_metadata_transport.py::test_fields_yaml_write_back_preserves_the_metadata",),
     ),

--- a/tests/test_field_behaviour_metadata_transport.py
+++ b/tests/test_field_behaviour_metadata_transport.py
@@ -1,0 +1,143 @@
+"""Authored field behaviour reaches the engine on the deterministic pin (#118)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from aethis_cli.commands import generate_cmd
+
+
+SUPPORTED = {
+    "key",
+    "sort",
+    "enum_values",
+    "value_space",
+    "enum_labels",
+    "canonical_field",
+    "label",
+    "question",
+    "weight",
+    "elicitation_owner",
+    "injection_source",
+    "injection_phase",
+    "recoverable_from",
+    "x_ui_widget",
+}
+
+
+def _project(tmp_path, body: str):
+    fields = tmp_path / "fields" / "fields.yaml"
+    fields.parent.mkdir(parents=True)
+    fields.write_text(body)
+    return tmp_path
+
+
+def _client(properties=SUPPORTED):
+    client = MagicMock()
+    client.expected_field_spec_properties.return_value = properties
+    client.base_url = "https://engine.example"
+    return client
+
+
+def test_non_applicant_field_transmits_explicit_no_question_and_metadata(tmp_path):
+    client = _client()
+    project = _project(
+        tmp_path,
+        """\
+fields:
+  - key: case.review_date
+    type: date
+    label: Review date
+    weight: 17
+    elicitation_owner: caseworker
+    injection_source: supervising_adviser
+    injection_phase: pre_submission
+    recoverable_from: [case_plan]
+    x_ui_widget: free_text
+""",
+    )
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    assert expected_fields == [
+        {
+            "key": "case.review_date",
+            "sort": "date",
+            "label": "Review date",
+            "weight": 17,
+            "elicitation_owner": "caseworker",
+            "injection_source": "supervising_adviser",
+            "injection_phase": "pre_submission",
+            "recoverable_from": ["case_plan"],
+            "x_ui_widget": "free_text",
+            "question": None,
+        }
+    ]
+
+
+def test_applicant_question_is_transmitted_exactly(tmp_path):
+    client = _client()
+    project = _project(
+        tmp_path,
+        """\
+fields:
+  - key: person.has_degree
+    type: bool
+    label: Degree held
+    question: Do you have a degree?
+    elicitation_owner: applicant
+""",
+    )
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    assert expected_fields == [
+        {
+            "key": "person.has_degree",
+            "sort": "bool",
+            "label": "Degree held",
+            "question": "Do you have a degree?",
+            "elicitation_owner": "applicant",
+        }
+    ]
+
+
+def test_legacy_field_payload_is_unchanged(tmp_path):
+    client = _client()
+    project = _project(
+        tmp_path,
+        """\
+fields:
+  - key: legacy.answer
+    type: string
+""",
+    )
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    assert expected_fields == [{"key": "legacy.answer", "sort": "string"}]
+    client.expected_field_spec_properties.assert_not_called()
+
+
+def test_missing_engine_capability_refuses_before_field_push(tmp_path):
+    client = _client(SUPPORTED - {"elicitation_owner", "question"})
+    project = _project(
+        tmp_path,
+        """\
+fields:
+  - key: case.review_date
+    type: date
+    elicitation_owner: caseworker
+""",
+    )
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()

--- a/tests/test_field_display_metadata_transport.py
+++ b/tests/test_field_display_metadata_transport.py
@@ -375,6 +375,24 @@ def test_set_fields_is_unaffected_when_the_file_declares_nothing():
     client.rulebook_field_spec_properties.assert_not_called()
 
 
+def test_set_fields_does_not_gate_on_project_only_behaviour_metadata():
+    """Project pins and rulebook vocabulary advertise different models."""
+    client = _rulebook_client(ENGINE_WITHOUT_SUPPORT)
+    fields = [
+        {
+            "key": "case.review_date",
+            "sort": "Date",
+            "elicitation_owner": "caseworker",
+            "injection_source": "adviser_selected",
+            "injection_phase": "pre_submission",
+        }
+    ]
+
+    generate_cmd.check_display_metadata_support(client, fields, rulebook=True)
+
+    client.rulebook_field_spec_properties.assert_not_called()
+
+
 def test_set_fields_asks_about_the_rulebook_model_not_the_project_one():
     """The two models are distinct and can disagree on one engine, so asking
     the wrong one would clear a push the engine will not honour."""

--- a/tests/test_generate_fields.py
+++ b/tests/test_generate_fields.py
@@ -55,6 +55,15 @@ fields:
     question: "Please give your date of birth."
 """
 
+FIELD_SPEC_PROPERTIES = {
+    "key",
+    "sort",
+    "enum_values",
+    "value_space",
+    "label",
+    "question",
+}
+
 
 # --- pure parsing ----------------------------------------------------------
 
@@ -93,6 +102,7 @@ def test_parent_rulebook_dir_detection(tmp_path):
 def test_upload_field_vocabulary_standalone(tmp_path):
     _write_fields(tmp_path / "fields" / "fields.yaml", RULESET_FIELDS)
     client = MagicMock()
+    client.expected_field_spec_properties.return_value = FIELD_SPEC_PROPERTIES
     generate_cmd._upload_field_vocabulary(client, "proj_1", tmp_path)
 
     client.set_field_spec.assert_called_once()
@@ -111,6 +121,7 @@ def test_upload_field_vocabulary_rulebook_wins(tmp_path):
     _write_fields(child / "fields" / "fields.yaml", RULESET_FIELDS)
 
     client = MagicMock()
+    client.expected_field_spec_properties.return_value = FIELD_SPEC_PROPERTIES
     generate_cmd._upload_field_vocabulary(client, "proj_1", child)
 
     _, expected_fields = client.set_field_spec.call_args.args

--- a/tests/test_value_space_transport.py
+++ b/tests/test_value_space_transport.py
@@ -63,6 +63,12 @@ members:
   - germany
 """
 
+FIELD_SPEC_PROPERTIES = {"key", "sort", "enum_values", "value_space", "question"}
+
+
+def _advertise_field_spec(client: MagicMock) -> None:
+    client.expected_field_spec_properties.return_value = FIELD_SPEC_PROPERTIES
+
 
 def _write(path, body: str):
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -113,6 +119,7 @@ def test_validate_rejects_value_space_on_non_enum():
 def test_upload_transmits_value_space_on_the_pin(tmp_path):
     project = _project_with_reference(tmp_path)
     client = MagicMock()
+    _advertise_field_spec(client)
     client.put_value_space.return_value = {"name": "form-an/countries", "version": 1, "created": True}
 
     generate_cmd._upload_field_vocabulary(client, "proj_1", project)
@@ -127,6 +134,7 @@ def test_upload_transmits_value_space_on_the_pin(tmp_path):
 def test_registry_sync_puts_before_spec_set(tmp_path):
     project = _project_with_reference(tmp_path)
     client = MagicMock()
+    _advertise_field_spec(client)
     client.put_value_space.return_value = {"name": "form-an/countries", "version": 1, "created": True}
 
     generate_cmd._upload_field_vocabulary(client, "proj_1", project)
@@ -180,6 +188,7 @@ def test_registry_sync_uses_and_records_base_version(tmp_path):
     project = _project_with_reference(tmp_path)
     write_state(project, {"value_space_sync": {"form-an/countries": 3}})
     client = MagicMock()
+    _advertise_field_spec(client)
     client.put_value_space.return_value = {"name": "form-an/countries", "version": 4, "created": True}
 
     generate_cmd._upload_field_vocabulary(client, "proj_1", project)
@@ -196,6 +205,7 @@ def test_reference_without_local_file_probes_the_engine_then_proceeds(tmp_path, 
     resolution, and only then does spec-set proceed."""
     project = _project_with_reference(tmp_path, space_file=False)
     client = MagicMock()
+    _advertise_field_spec(client)
     client.get_value_space.return_value = {
         "name": "form-an/countries",
         "version": 3,


### PR DESCRIPTION
Closes #118

Part of Aethis-ai/aethis-workspace#1067. Companion to Aethis-ai/aethis-core#470; merge/deploy the engine first.

## What changed
- transmit explicitly authored labels, questions, ownership, injection source/phase, ordering weight, recovery capabilities and UI hints on the field pin
- send `question: null` when a non-applicant owner intentionally has no applicant question
- refuse an older engine that would silently discard declared metadata
- preserve the exact legacy payload when no new metadata is authored
- bump the public CLI to 0.37.0 and update the changelog

## Verification
- full suite: 628 passed, 24 deselected, 79.01% coverage
- focused transport/compatibility suite: 95 passed
- Ruff check and format check — clean
- `git diff --check` — clean

No Form AN or immigration-specific logic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789982330&installation_model_id=429844&pr_number=119&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F119&signature=48d606a124fb3ba664477a6729c79c7cb231bd9ebf278e5c8828c8748c8f85f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->