### PR TITLE
fix(generate): guard the stale ruleset pointer on transport failures too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.37.1 (2026-09-02)
+
+- **fix(generate): a dropped connection mid-poll no longer strands the run on a
+  stale ruleset id.** `--poll` guards against an interrupted generation leaving
+  `.aethis/state.json` naming an *earlier* ruleset, but the guard only covered
+  `AethisAPIError`. A dropped connection, DNS failure, TLS error or read timeout
+  raises `httpx.HTTPError`, which unwound past it — so the failure most likely
+  to interrupt a long poll was the one that bypassed the guard, and every later
+  `decide`, `test`, `explain` and `fields pull` silently answered from the wrong
+  ruleset. The poll now absorbs a short connection blip and finishes normally;
+  where the API is genuinely unreachable it names the stale id and prints the
+  command that recovers the real one.
+- **fix(generate): a blip while waiting for the new ruleset id no longer
+  discards it.** After the engine reports success the CLI re-polls for the id.
+  A transport failure there stranded a generation the CLI already knew had
+  succeeded; those attempts are now individually tolerant.
+- **fix(generate): a failed publish no longer reads as a failed generation.**
+  A transport error on the auto-publish reported only "Could not reach the
+  Aethis API", so a successful generation looked like a failure and got re-run.
+  It now reports the ruleset and names `aethis publish` as the step to re-run.
+- **fix(generate): a success that never surfaces an id says so.** That ending
+  also leaves the recorded pointer naming an earlier generation, and was silent.
+- **fix: an unreachable API cannot crash the error reporter.** `httpx` exposes
+  `.request` as a property that raises when unbound, so the defensive
+  `getattr(e, "request", None)` in the transport-error path could raise
+  `RuntimeError` — a traceback about the error handler in place of the one
+  actionable line. The rendering now has a single home shared by the top-level
+  boundary and the commands that must clean up before exiting.
+
 ## 0.37.0 (2026-08-22)
 
 - **fix(generate): authored field behaviour is deterministic.** Generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,27 @@
   ruleset. The poll now absorbs a short connection blip and finishes normally;
   where the API is genuinely unreachable it names the stale id and prints the
   command that recovers the real one.
+- **fix(generate): the stale-pointer guard can no longer fire on a run that
+  succeeded.** The pinned-vs-produced field diff runs *after* the new id is
+  recorded, so a connection lost during it made the CLI announce
+  "Done! Ruleset: X" and then insist X was from an earlier generation — a false
+  claim about the exact fact the guard exists to keep honest. The diff now
+  honours its own "never fails the command" contract for transport errors, and
+  the guard never describes a pointer this run recorded as stale.
 - **fix(generate): a blip while waiting for the new ruleset id no longer
   discards it.** After the engine reports success the CLI re-polls for the id.
   A transport failure there stranded a generation the CLI already knew had
   succeeded; those attempts are now individually tolerant.
-- **fix(generate): a failed publish no longer reads as a failed generation.**
-  A transport error on the auto-publish reported only "Could not reach the
-  Aethis API", so a successful generation looked like a failure and got re-run.
-  It now reports the ruleset and names `aethis publish` as the step to re-run.
+- **fix(generate): a persistent or flapping connection is reported as
+  unreachable, not as a timeout.** The retry is bounded both consecutively and
+  in total, so an intermittent link cannot be absorbed to the deadline and then
+  reported as a slow job.
+- **fix(generate): a failed publish no longer reads as a failed generation, and
+  says why.** A transport error on the auto-publish reported only "Could not
+  reach the Aethis API", so a successful generation looked like a failure and
+  got re-run. It now reports the ruleset, names the reason the publish did not
+  run, and names `aethis publish` as the step to re-run — previously the
+  API-error half of this path gave a green tick with no reason at all.
 - **fix(generate): a success that never surfaces an id says so.** That ending
   also leaves the recorded pointer naming an earlier generation, and was silent.
 - **fix: an unreachable API cannot crash the error reporter.** `httpx` exposes
@@ -27,7 +40,8 @@
   `getattr(e, "request", None)` in the transport-error path could raise
   `RuntimeError` — a traceback about the error handler in place of the one
   actionable line. The rendering now has a single home shared by the top-level
-  boundary and the commands that must clean up before exiting.
+  boundary and the commands that must clean up before exiting, and names the
+  host actually configured rather than always the public default.
 
 ## 0.37.0 (2026-08-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@
   discards it.** After the engine reports success the CLI re-polls for the id.
   A transport failure there stranded a generation the CLI already knew had
   succeeded; those attempts are now individually tolerant.
-- **fix(generate): a persistent or flapping connection is reported as
-  unreachable, not as a timeout.** The retry is bounded both consecutively and
-  in total, so an intermittent link cannot be absorbed to the deadline and then
-  reported as a slow job.
+- **fix(generate): a persistent outage is reported as unreachable, not as a
+  timeout.** The retry is bounded by consecutive failures, so a dead connection
+  surfaces as one rather than being absorbed to the deadline and reported as a
+  slow job. A *flapping* link is deliberately not aborted — it is working, and
+  killing it one poll short of success would deliver the very failure above —
+  so a poll that suffered dropped connections says so when it does time out.
 - **fix(generate): a failed publish no longer reads as a failed generation, and
   says why.** A transport error on the auto-publish reported only "Could not
   reach the Aethis API", so a successful generation looked like a failure and
@@ -35,13 +37,20 @@
   API-error half of this path gave a green tick with no reason at all.
 - **fix(generate): a success that never surfaces an id says so.** That ending
   also leaves the recorded pointer naming an earlier generation, and was silent.
+- **fix(generate): an unreadable value space is reported, not raised.** The
+  field diff verifies value-space-pinned fields against the registry and
+  formatted the failure as if it were always an API error, so a dropped
+  connection there raised `AttributeError` — an unhandled traceback on an
+  otherwise successful generation.
 - **fix: an unreachable API cannot crash the error reporter.** `httpx` exposes
   `.request` as a property that raises when unbound, so the defensive
   `getattr(e, "request", None)` in the transport-error path could raise
   `RuntimeError` — a traceback about the error handler in place of the one
   actionable line. The rendering now has a single home shared by the top-level
-  boundary and the commands that must clean up before exiting, and names the
-  host actually configured rather than always the public default.
+  boundary and the commands that must clean up before exiting. `generate` and
+  `refine` name the host they were actually configured with rather than the
+  public default; other commands still report via the top-level boundary, which
+  reads `AETHIS_BASE_URL`.
 
 ## 0.37.0 (2026-08-22)
 

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.37.0"
+__version__ = "0.37.1"

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -1192,10 +1192,15 @@ def _error_reason(e: Exception) -> str:
     empty `str()`. A formatter that assumes either shape fails on the other —
     which is exactly how widening a catch to httpx produced an AttributeError
     on a successful run.
+
+    The API half delegates to `_api_error_message` rather than re-deriving it:
+    that helper exists because a value-space conflict's detail is a *dict*, and
+    `str()` on it buries the one sentence the author needs under a repr (PR
+    #110). A first draft of this function reimplemented the easy half and lost
+    both that and the status code.
     """
-    detail = getattr(e, "detail", None)
-    if detail:
-        return str(detail)
+    if isinstance(e, AethisAPIError):
+        return f"HTTP {e.status_code}: {_api_error_message(e)}"
     return str(e) or e.__class__.__name__
 
 
@@ -1241,7 +1246,7 @@ def _invalidate_stale_pointer(project_dir: Path, status: str, *, produced_id: Op
     prior = state.get("ruleset_id")
     if not prior:
         return
-    if produced_id is not None and prior == produced_id:
+    if status != "failed" and produced_id is not None and prior == produced_id:
         # This run recorded the pointer, so there is nothing stale to warn
         # about however the run ended afterwards. Without this the guard fires
         # on its own success: a transport failure *after* the id was written
@@ -1318,6 +1323,7 @@ def _poll_until_done(
         task = progress.add_task("Generating ruleset...", total=100)
         blips = 0
         total_blips = 0  # reported at the deadline, never used to abort
+        blip_trace_shown = False
         while time.monotonic() < deadline:
             try:
                 result = client.get_status(pid)
@@ -1340,12 +1346,18 @@ def _poll_until_done(
                 progress.update(task, description="[yellow]lost the connection — retrying[/yellow]")
                 time.sleep(3)
                 continue
-            if blips:
+            if blips and not blip_trace_shown:
                 # A durable line, because the transient progress description is
                 # overwritten by the next poll and is invisible off a TTY —
                 # and an absorbed blip is the event that used to strand a
                 # generation, so it should leave a trace worth grepping.
-                warn(f"Lost the connection to the API {blips} time(s) during the poll; recovered and carried on.")
+                #
+                # Once, not once per recovery: the total cap that used to bound
+                # this at 8 is gone, so a flapping 600s poll would otherwise
+                # emit ~100 identical lines through the progress bar. The
+                # timeout ending reports the running total in one line.
+                blip_trace_shown = True
+                warn("Lost the connection to the API during the poll; recovered and carried on.")
             blips = 0
             job = result.get("job") or {}
             pct = job.get("progress_percent", 0)

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from typing import NamedTuple, Optional
 
+import httpx
 import typer
 import yaml
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
@@ -21,7 +22,7 @@ from aethis_cli.config import (
     write_state,
 )
 from aethis_cli.errors import AethisAPIError, ConfigError
-from aethis_cli.output import console, error_panel, info, success, warn
+from aethis_cli.output import console, error_panel, info, render_transport_error, success, warn
 
 
 def _chunks(lst: list, n: int):
@@ -903,6 +904,23 @@ def _run_generate(
         _invalidate_stale_pointer(project_dir, "error")
         raise typer.Exit(code=1)
 
+    except httpx.HTTPError as e:
+        # The ending the handler above was written for and could not catch.
+        # `AethisClient._request` wraps only HTTP *status* failures, so a
+        # dropped connection, a DNS failure, a TLS error or a read timeout
+        # raises `httpx.HTTPError` and unwound straight past it to the
+        # boundary in `main.py` — skipping the invalidation, so the stale
+        # pointer was kept (right) and never named (wrong, and silently). That
+        # is the failure most likely to interrupt a long poll, so the guard was
+        # missing on the path that needs it most (#122).
+        #
+        # Rendered here rather than re-raised so the error stays ahead of the
+        # warning explaining what it cost; `main.py` renders the same line from
+        # the same helper for every command that has no cleanup of its own.
+        render_transport_error(e)
+        _invalidate_stale_pointer(project_dir, "error")
+        raise typer.Exit(code=1)
+
 
 def _upload_test_cases(client: AethisClient, pid: str, project_dir: Path) -> None:
     """Upload `tests/scenarios.yaml` as the project's test cases.
@@ -1190,14 +1208,23 @@ def _invalidate_stale_pointer(project_dir: Path, status: str) -> None:
       client-side clock or a transient 500. The pointer stands and is named
       instead, which is what "not silently" requires.
     """
-    prior = read_state(project_dir).get("ruleset_id")
+    state = read_state(project_dir)
+    prior = state.get("ruleset_id")
     if not prior:
         return
     if status != "failed":
         warn(
             f"'.aethis/state.json' still records ruleset {prior} from an earlier generation. "
-            f"This run has not produced one, so 'aethis fields pull' would sync from that "
+            f"This run has not recorded one, so 'aethis fields pull' would sync from that "
             f"earlier ruleset rather than from this job."
+        )
+        # The recovery is one call away and the id needed to make it is on
+        # disk, so print the command rather than the situation. `latest_ruleset_id`
+        # is a property of the project, which is why this is offered as
+        # something to compare rather than written back automatically.
+        console.print(
+            f"[dim]  If the job in fact finished, 'aethis --output json projects show "
+            f"{state.get('project_id') or '<project-id>'}' names it as 'latest_ruleset_id'.[/dim]"
         )
         return
     write_state(project_dir, {"ruleset_id": None})
@@ -1206,6 +1233,11 @@ def _invalidate_stale_pointer(project_dir: Path, status: str) -> None:
         f"one, so 'aethis fields pull' will refuse rather than silently sync from it. Pass "
         f"'--ruleset-id {prior}' explicitly if that earlier ruleset is what you want."
     )
+
+
+# How many consecutive transport failures a poll absorbs before reporting the
+# API as unreachable. See the handler in the loop below for why it is bounded.
+_TRANSPORT_BLIP_BUDGET = 3
 
 
 def _poll_until_done(
@@ -1238,8 +1270,29 @@ def _poll_until_done(
         console=console,
     ) as progress:
         task = progress.add_task("Generating ruleset...", total=100)
+        blips = 0
         while time.monotonic() < deadline:
-            result = client.get_status(pid)
+            try:
+                result = client.get_status(pid)
+            except httpx.HTTPError:
+                # A poll runs for minutes, which makes it the command most
+                # exposed to a transient network fault and the one where giving
+                # up costs most: the job behind it usually finishes, and the
+                # caller is then left holding a pointer to an earlier
+                # generation. Absorbing a short blip turns the common form of
+                # #122 into no incident at all.
+                #
+                # Bounded, because tolerating indefinitely would report a real
+                # outage as a timeout — which reads as a slow job and sends the
+                # author looking in the wrong place. Four consecutive failures
+                # (~12s with the sleep below) surfaces it as what it is.
+                blips += 1
+                if blips > _TRANSPORT_BLIP_BUDGET:
+                    raise
+                progress.update(task, description="[yellow]lost the connection — retrying[/yellow]")
+                time.sleep(3)
+                continue
+            blips = 0
             job = result.get("job") or {}
             pct = job.get("progress_percent", 0)
             job_status = job.get("status", "unknown")
@@ -1260,11 +1313,24 @@ def _poll_until_done(
                     if ruleset_id:
                         break
                     time.sleep(2)
-                    ruleset_id = _resolved_ruleset_id(client.get_status(pid))
+                    try:
+                        ruleset_id = _resolved_ruleset_id(client.get_status(pid))
+                    except httpx.HTTPError:
+                        # Strictly worse than the reported case if it escaped:
+                        # the job has already reported success, so raising here
+                        # would strand a generation the CLI knows finished. The
+                        # blip costs this attempt and nothing else.
+                        continue
                 # Only record a real id — never clobber a prior good one with None
                 # if the engine was slow to surface it.
                 if ruleset_id:
                     write_state(project_dir, {"ruleset_id": ruleset_id})
+                else:
+                    # A success that never surfaced an id leaves the pointer
+                    # naming an earlier generation — the same silent shape the
+                    # unsuccessful endings are guarded against, arrived at from
+                    # the one ending that reads like it worked.
+                    _invalidate_stale_pointer(project_dir, "no-id")
                 console.print()
                 if no_publish:
                     # Publishing ACTIVATES the ruleset, which is the wrong
@@ -1290,7 +1356,11 @@ def _poll_until_done(
                         success(f"Done! Ruleset published: {ruleset_id}")
                     else:
                         success("Done! Ruleset generated — run 'aethis status' to get its id.")
-                except AethisAPIError:
+                except (AethisAPIError, httpx.HTTPError):
+                    # Benign for state — the id was recorded above — but not for
+                    # the reader: "Could not reach the Aethis API" as the last
+                    # word on a successful generation reads as a failed one, and
+                    # gets it re-run.
                     if ruleset_id:
                         success(f"Done! Ruleset: {ruleset_id} (run 'aethis publish' to activate)")
                     else:

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -812,6 +812,10 @@ def _run_generate(
         )
         raise typer.Exit(code=1)
 
+    # Held outside the try so the transport handler can tell "this run never
+    # recorded an id" from "it did, and the failure came afterwards".
+    outcome: Optional[GenerationOutcome] = None
+
     try:
         pid = _resolve_or_create_project(client, cfg, project_id)
 
@@ -917,8 +921,8 @@ def _run_generate(
         # Rendered here rather than re-raised so the error stays ahead of the
         # warning explaining what it cost; `main.py` renders the same line from
         # the same helper for every command that has no cleanup of its own.
-        render_transport_error(e)
-        _invalidate_stale_pointer(project_dir, "error")
+        render_transport_error(e, base_url=cfg.base_url)
+        _invalidate_stale_pointer(project_dir, "error", produced_id=outcome.ruleset_id if outcome else None)
         raise typer.Exit(code=1)
 
 
@@ -1020,7 +1024,11 @@ def _report_field_diff(
     diff against an earlier generation is worse than no diff, because it reads
     exactly like one of this run.
 
-    Never fails the command — a schema that cannot be read must not turn a
+    Never fails the command — including when the API becomes unreachable
+    mid-diff. This runs *after* the new id has been recorded, so letting a
+    transport error escape here made the caller's stale-pointer guard fire on a
+    run that had succeeded and recorded the right id: the CLI asserted the
+    correct pointer was stale and exited 1. A schema that cannot be read must not turn a
     successful generation into an error — but never silent either. Both "there
     was nothing to compare" and "the comparison could not be made" are said out
     loud, because the alternative is a run that prints no verdict at all and is
@@ -1038,7 +1046,7 @@ def _report_field_diff(
         return
     try:
         schema = client.get_schema(ruleset_id)
-    except AethisAPIError as e:
+    except (AethisAPIError, httpx.HTTPError) as e:
         warn(
             f"Could not read the schema of ruleset {ruleset_id} ({e}), so the "
             f"pinned-vs-produced field diff was not computed. The draft may no "
@@ -1082,7 +1090,7 @@ def _report_field_diff(
             resolved_version = resolution.get("version")
             try:
                 space = client.get_value_space(space_name, version=resolved_version)
-            except AethisAPIError as e:
+            except (AethisAPIError, httpx.HTTPError) as e:
                 ref_problems.append(
                     f"{key} ← {space_name}@v{resolved_version}: NOT verified — could not "
                     f"read the space at that version ({e.detail})."
@@ -1184,7 +1192,7 @@ def _resolved_ruleset_id(status_payload: dict) -> Optional[str]:
     return job.get("result_ruleset_id") or status_payload.get("latest_ruleset_id")
 
 
-def _invalidate_stale_pointer(project_dir: Path, status: str) -> None:
+def _invalidate_stale_pointer(project_dir: Path, status: str, *, produced_id: Optional[str] = None) -> None:
     """Stop an unsuccessful run leaving a pointer that reads like its result.
 
     ``.aethis/state.json``'s ``ruleset_id`` is written only when a generation
@@ -1212,6 +1220,14 @@ def _invalidate_stale_pointer(project_dir: Path, status: str) -> None:
     prior = state.get("ruleset_id")
     if not prior:
         return
+    if produced_id is not None and prior == produced_id:
+        # This run recorded the pointer, so there is nothing stale to warn
+        # about however the run ended afterwards. Without this the guard fires
+        # on its own success: a transport failure *after* the id was written
+        # made the CLI announce "Done! Ruleset: X" and then insist X was from
+        # an earlier generation — a false claim about the exact fact this
+        # whole guard exists to keep honest.
+        return
     if status != "failed":
         warn(
             f"'.aethis/state.json' still records ruleset {prior} from an earlier generation. "
@@ -1235,9 +1251,15 @@ def _invalidate_stale_pointer(project_dir: Path, status: str) -> None:
     )
 
 
-# How many consecutive transport failures a poll absorbs before reporting the
-# API as unreachable. See the handler in the loop below for why it is bounded.
+# How many transport failures a poll absorbs before reporting the API as
+# unreachable — consecutively, and in total across the run. The total matters
+# because the consecutive counter resets on every success, so a *flapping*
+# link (fail, fail, fail, ok, fail, fail, fail, ok …) would never trip the
+# consecutive bound and would run to the deadline — reported as a timeout,
+# which is precisely the misreport the bound exists to prevent. Bad wifi is a
+# commoner shape than a clean sustained outage.
 _TRANSPORT_BLIP_BUDGET = 3
+_TRANSPORT_BLIP_TOTAL = 8
 
 
 def _poll_until_done(
@@ -1271,6 +1293,7 @@ def _poll_until_done(
     ) as progress:
         task = progress.add_task("Generating ruleset...", total=100)
         blips = 0
+        total_blips = 0
         while time.monotonic() < deadline:
             try:
                 result = client.get_status(pid)
@@ -1284,14 +1307,21 @@ def _poll_until_done(
                 #
                 # Bounded, because tolerating indefinitely would report a real
                 # outage as a timeout — which reads as a slow job and sends the
-                # author looking in the wrong place. Four consecutive failures
-                # (~12s with the sleep below) surfaces it as what it is.
+                # author looking in the wrong place. Two bounds, because the
+                # consecutive one alone cannot see a flapping link.
                 blips += 1
-                if blips > _TRANSPORT_BLIP_BUDGET:
+                total_blips += 1
+                if blips > _TRANSPORT_BLIP_BUDGET or total_blips > _TRANSPORT_BLIP_TOTAL:
                     raise
                 progress.update(task, description="[yellow]lost the connection — retrying[/yellow]")
                 time.sleep(3)
                 continue
+            if blips:
+                # A durable line, because the transient progress description is
+                # overwritten by the next poll and is invisible off a TTY —
+                # and an absorbed blip is the event that used to strand a
+                # generation, so it should leave a trace worth grepping.
+                warn(f"Lost the connection to the API {blips} time(s) during the poll; recovered and carried on.")
             blips = 0
             job = result.get("job") or {}
             pct = job.get("progress_percent", 0)
@@ -1356,11 +1386,16 @@ def _poll_until_done(
                         success(f"Done! Ruleset published: {ruleset_id}")
                     else:
                         success("Done! Ruleset generated — run 'aethis status' to get its id.")
-                except (AethisAPIError, httpx.HTTPError):
+                except (AethisAPIError, httpx.HTTPError) as e:
                     # Benign for state — the id was recorded above — but not for
                     # the reader: "Could not reach the Aethis API" as the last
                     # word on a successful generation reads as a failed one, and
-                    # gets it re-run.
+                    # gets it re-run. The generation is therefore reported as
+                    # the success it was — but the reason is named too, or a
+                    # green tick is all the author gets for a ruleset that was
+                    # never activated, and this ending becomes indistinguishable
+                    # from the deliberate --no-publish one above.
+                    warn(f"Publish did not run: {e}")
                     if ruleset_id:
                         success(f"Done! Ruleset: {ruleset_id} (run 'aethis publish' to activate)")
                     else:

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -905,7 +905,7 @@ def _run_generate(
         # earlier generation. Nothing has been ruled, so the id stands; but it
         # is named, because otherwise this ending is the one that reintroduces
         # the silent stale `fields pull`.
-        _invalidate_stale_pointer(project_dir, "error")
+        _invalidate_stale_pointer(project_dir, "error", produced_id=outcome.ruleset_id if outcome else None)
         raise typer.Exit(code=1)
 
     except httpx.HTTPError as e:
@@ -1048,7 +1048,7 @@ def _report_field_diff(
         schema = client.get_schema(ruleset_id)
     except (AethisAPIError, httpx.HTTPError) as e:
         warn(
-            f"Could not read the schema of ruleset {ruleset_id} ({e}), so the "
+            f"Could not read the schema of ruleset {ruleset_id} ({_error_reason(e)}), so the "
             f"pinned-vs-produced field diff was not computed. The draft may no "
             f"longer be retrievable."
         )
@@ -1091,9 +1091,16 @@ def _report_field_diff(
             try:
                 space = client.get_value_space(space_name, version=resolved_version)
             except (AethisAPIError, httpx.HTTPError) as e:
+                # `{e}`, never `{e.detail}`: `.detail` exists only on
+                # AethisAPIError, so formatting it raised AttributeError for
+                # every httpx error this clause was widened to catch — and
+                # AttributeError is caught by no handler here or at the
+                # boundary, so a successful generation ended in a raw
+                # traceback. Widening a catch means widening the formatting.
+                reason = _error_reason(e)
                 ref_problems.append(
                     f"{key} ← {space_name}@v{resolved_version}: NOT verified — could not "
-                    f"read the space at that version ({e.detail})."
+                    f"read the space at that version ({reason})."
                 )
                 continue
             expected_members = set(space.get("members") or [])
@@ -1178,6 +1185,20 @@ class GenerationOutcome(NamedTuple):
     value_spaces_resolved: Optional[dict] = None
 
 
+def _error_reason(e: Exception) -> str:
+    """A readable reason for either error family this module now catches.
+
+    `AethisAPIError` carries `.detail`; httpx errors do not, and some carry an
+    empty `str()`. A formatter that assumes either shape fails on the other —
+    which is exactly how widening a catch to httpx produced an AttributeError
+    on a successful run.
+    """
+    detail = getattr(e, "detail", None)
+    if detail:
+        return str(detail)
+    return str(e) or e.__class__.__name__
+
+
 def _resolved_ruleset_id(status_payload: dict) -> Optional[str]:
     """The ruleset a generation produced, preferring the job's own record.
 
@@ -1251,15 +1272,18 @@ def _invalidate_stale_pointer(project_dir: Path, status: str, *, produced_id: Op
     )
 
 
-# How many transport failures a poll absorbs before reporting the API as
-# unreachable — consecutively, and in total across the run. The total matters
-# because the consecutive counter resets on every success, so a *flapping*
-# link (fail, fail, fail, ok, fail, fail, fail, ok …) would never trip the
-# consecutive bound and would run to the deadline — reported as a timeout,
-# which is precisely the misreport the bound exists to prevent. Bad wifi is a
-# commoner shape than a clean sustained outage.
+# How many CONSECUTIVE transport failures a poll absorbs before reporting the
+# API as unreachable.
+#
+# Deliberately consecutive-only. A total cap was tried and removed: because it
+# is absolute rather than rate-relative, its tolerance shrinks as a job gets
+# longer (~40% of polls on a 60s job, ~4% on a 600s one) — strictest exactly
+# where exposure to blips is greatest. It aborted lossy-but-working runs one
+# poll short of the success they were about to receive, which is the #122
+# experience this module exists to prevent. What it bought was only a better
+# *message* on a flapping link, and not even that much: the timeout ending
+# already names the stale pointer, so nothing was silent either way.
 _TRANSPORT_BLIP_BUDGET = 3
-_TRANSPORT_BLIP_TOTAL = 8
 
 
 def _poll_until_done(
@@ -1293,7 +1317,7 @@ def _poll_until_done(
     ) as progress:
         task = progress.add_task("Generating ruleset...", total=100)
         blips = 0
-        total_blips = 0
+        total_blips = 0  # reported at the deadline, never used to abort
         while time.monotonic() < deadline:
             try:
                 result = client.get_status(pid)
@@ -1311,7 +1335,7 @@ def _poll_until_done(
                 # consecutive one alone cannot see a flapping link.
                 blips += 1
                 total_blips += 1
-                if blips > _TRANSPORT_BLIP_BUDGET or total_blips > _TRANSPORT_BLIP_TOTAL:
+                if blips > _TRANSPORT_BLIP_BUDGET:
                     raise
                 progress.update(task, description="[yellow]lost the connection — retrying[/yellow]")
                 time.sleep(3)
@@ -1415,4 +1439,11 @@ def _poll_until_done(
             time.sleep(3)
 
     console.print(f"\n[bold red]Timed out after {timeout}s.[/bold red] Use 'aethis status' to check progress.")
+    if total_blips:
+        # Without this, a flapping link is indistinguishable from a slow job —
+        # which sends the author to look at the engine rather than the network.
+        warn(
+            f"The connection to the API dropped {total_blips} time(s) during this poll, so the "
+            f"job may have been progressing normally and the timeout may be a network problem."
+        )
     return GenerationOutcome("timeout", None)

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -13,7 +13,7 @@ import typer
 from aethis_cli._version import __version__
 from aethis_cli.auth_helpers import RUNTIME
 from aethis_cli.errors import AethisAPIError, AuthenticationError, AuthRequired, ConfigError
-from aethis_cli.output import console, format_error_detail, render_api_error
+from aethis_cli.output import console, format_error_detail, render_api_error, render_transport_error
 from aethis_cli.render import RUNTIME as RENDER_RUNTIME, OutputFormat
 from aethis_cli.commands.account_cmd import account_app
 from aethis_cli.commands.rulebooks_cmd import rulebooks_app
@@ -242,18 +242,9 @@ def cli() -> None:
     except httpx.HTTPError as e:
         # Unreachable / slow API, DNS failure, TLS error, etc. Render one
         # actionable line instead of a raw traceback (pretty_exceptions is
-        # disabled). The base URL the client tried lives on the request, when
-        # httpx attached one (RequestError subclasses carry .request).
-        target = os.environ.get("AETHIS_BASE_URL", "https://api.aethis.ai")
-        request = getattr(e, "request", None)
-        if request is not None:
-            target = str(request.url)
-        reason = str(e) or e.__class__.__name__
-        console.print(
-            f"[red]Could not reach the Aethis API at {target}: {reason}.[/red]",
-            highlight=False,
-        )
-        console.print("[dim]Check your connection or try again shortly.[/dim]")
+        # disabled). A command that has cleanup of its own to do on this path
+        # catches it first and renders the same line via the same helper.
+        render_transport_error(e)
         raise SystemExit(1)
 
 

--- a/aethis_cli/output.py
+++ b/aethis_cli/output.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+
+import httpx
 from rich.console import Console
 
 from aethis_cli.errors import AethisAPIError
@@ -95,6 +98,37 @@ def render_api_error(status_code: int, detail: object) -> None:
 def error_panel(e: AethisAPIError) -> None:
     """Render an API error as a readable line (+ hint when present)."""
     render_api_error(e.status_code, e.detail)
+
+
+def render_transport_error(e: httpx.HTTPError) -> None:
+    """Render a failure to reach the API at all — no response, so no envelope.
+
+    This lives here rather than at the ``main.py`` boundary that first needed
+    it because it is no longer only a boundary concern: a command that must
+    *do* something before the process ends (``generate`` names the ruleset
+    pointer its interrupted poll has left stale) has to render the error
+    itself, and two renderings of one fact drift. One home, two callers.
+    """
+    # The base URL the client tried lives on the request, when httpx attached
+    # one (RequestError subclasses carry .request).
+    target = os.environ.get("AETHIS_BASE_URL", "https://api.aethis.ai")
+    try:
+        request = getattr(e, "request", None)
+    except RuntimeError:
+        # `.request` is a *property* that raises when httpx never bound one, so
+        # the `getattr(..., None)` default never applies and this reporter
+        # would fail while reporting — a traceback about the error handler in
+        # place of the one actionable line, on the path where the API is
+        # already unreachable. Ask forgiveness, not permission.
+        request = None
+    if request is not None:
+        target = str(request.url)
+    reason = str(e) or e.__class__.__name__
+    console.print(
+        f"[red]Could not reach the Aethis API at {target}: {reason}.[/red]",
+        highlight=False,
+    )
+    console.print("[dim]Check your connection or try again shortly.[/dim]")
 
 
 def success(msg: str) -> None:

--- a/aethis_cli/output.py
+++ b/aethis_cli/output.py
@@ -100,7 +100,7 @@ def error_panel(e: AethisAPIError) -> None:
     render_api_error(e.status_code, e.detail)
 
 
-def render_transport_error(e: httpx.HTTPError) -> None:
+def render_transport_error(e: httpx.HTTPError, *, base_url: str | None = None) -> None:
     """Render a failure to reach the API at all — no response, so no envelope.
 
     This lives here rather than at the ``main.py`` boundary that first needed
@@ -111,7 +111,10 @@ def render_transport_error(e: httpx.HTTPError) -> None:
     """
     # The base URL the client tried lives on the request, when httpx attached
     # one (RequestError subclasses carry .request).
-    target = os.environ.get("AETHIS_BASE_URL", "https://api.aethis.ai")
+    # Prefer the host the caller actually configured: naming the public default
+    # at an author pointed to a private or staging engine describes a request
+    # that was never made.
+    target = base_url or os.environ.get("AETHIS_BASE_URL", "https://api.aethis.ai")
     try:
         request = getattr(e, "request", None)
     except RuntimeError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.37.0"
+version = "0.37.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -486,6 +486,107 @@ def test_a_success_that_never_surfaces_an_id_names_the_stale_pointer(tmp_path, m
     )
 
 
+def test_a_success_whose_field_diff_loses_the_connection_is_still_a_success(tmp_path, monkeypatch, capsys):
+    """The guard must never fire on the run that recorded the pointer.
+
+    The field diff runs *after* the new id is written. A transport failure
+    there once escaped to the stale-pointer guard, so a generation that had
+    succeeded and recorded exactly the right id announced "Done! Ruleset: X"
+    and then insisted X was from an earlier generation — a false claim about
+    the one fact the guard exists to keep honest, and the same shape of defect
+    as the one it was written to fix.
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    client = _engine({"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}})
+    client.get_schema.side_effect = httpx.ConnectError("connection reset")
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()  # must not raise: a diff that cannot be fetched is not a failed generation
+
+    out = _flat(capsys)
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run", "this run's id was recorded and must stand"
+    assert "from an earlier generation" not in out, (
+        "the pointer this run just wrote is not stale, and must never be called stale"
+    )
+
+
+def test_the_guard_never_calls_this_runs_own_pointer_stale(tmp_path, capsys):
+    """The invariant directly, independent of the route that reaches it."""
+    write_state(tmp_path, {"ruleset_id": "rs_from_this_run", "project_id": "proj_abc"})
+
+    generate_cmd._invalidate_stale_pointer(tmp_path, "error", produced_id="rs_from_this_run")
+
+    assert "from an earlier generation" not in _flat(capsys), "the id this run produced is not an earlier one"
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run"
+
+
+def test_a_persistent_outage_is_reported_as_unreachable_not_as_a_timeout(tmp_path, monkeypatch, capsys):
+    """The blip budget has to be *bounded*, and nothing else asserted that.
+
+    Without this the budget is a free variable: raise it and the poll simply
+    absorbs a real outage until the deadline, then reports "Timed out" — which
+    reads as a slow job and sends the author looking in the wrong place. Every
+    other assertion here stays green under that mutation, because the timeout
+    ending also names the stale pointer.
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    client = _engine({"job": {"status": "running", "progress_percent": 10}})
+    client.get_status.side_effect = httpx.ConnectError("connection refused")
+    _wire(monkeypatch, tmp_path, client)
+
+    with pytest.raises(typer.Exit):
+        _run(timeout=5)
+
+    out = _flat(capsys)
+    assert "Timed out" not in out, "a dead connection is not a slow job and must not be reported as one"
+    assert client.get_status.call_count == generate_cmd._TRANSPORT_BLIP_BUDGET + 1, (
+        "the poll must give up after the budget, not grind on to the deadline"
+    )
+
+
+def test_a_flapping_connection_is_also_reported_as_unreachable(tmp_path, monkeypatch, capsys):
+    """The consecutive counter resets on success, so it cannot see a flap.
+
+    fail, fail, fail, ok, fail, fail, fail, ok … never trips a consecutive
+    bound, and bad wifi is a commoner shape than a clean sustained outage.
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    running = {"job": {"status": "running", "progress_percent": 10}}
+    flap = []
+    for _ in range(20):
+        flap.extend([httpx.ConnectError("flap"), httpx.ConnectError("flap"), running])
+    client = _engine(running)
+    client.get_status.side_effect = flap
+    _wire(monkeypatch, tmp_path, client)
+
+    with pytest.raises(typer.Exit):
+        _run(timeout=5)
+
+    assert "Timed out" not in _flat(capsys), "a flapping link must surface as unreachable, not as a timeout"
+
+
+def test_a_failed_publish_says_why(tmp_path, monkeypatch, capsys):
+    """A green tick over a ruleset that was never activated, with no reason.
+
+    The generation did succeed, so it is reported as one — but silence about
+    the publish leaves this ending indistinguishable from the deliberate
+    `--no-publish` one, and the author is not told why the ruleset is inactive.
+    """
+    _project(tmp_path)
+    client = _engine({"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}})
+    client.publish.side_effect = httpx.ConnectError("connection refused")
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    out = _flat(capsys)
+    assert "Publish did not run" in out, "the step that failed must be named"
+    assert "connection refused" in out, "and so must the reason"
+
+
 def test_a_success_that_never_surfaces_an_id_diffs_nothing(tmp_path, monkeypatch, capsys):
     """A success with no id must not be diffed against the previous ruleset either."""
     _project(tmp_path)

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -546,26 +546,84 @@ def test_a_persistent_outage_is_reported_as_unreachable_not_as_a_timeout(tmp_pat
     )
 
 
-def test_a_flapping_connection_is_also_reported_as_unreachable(tmp_path, monkeypatch, capsys):
-    """The consecutive counter resets on success, so it cannot see a flap.
+def test_a_lossy_but_working_connection_still_completes(tmp_path, monkeypatch, capsys):
+    """The regression a total blip cap caused, pinned so it cannot come back.
 
-    fail, fail, fail, ok, fail, fail, fail, ok … never trips a consecutive
-    bound, and bad wifi is a commoner shape than a clean sustained outage.
+    A flapping link (fail, ok, fail, ok …) never trips the *consecutive* bound,
+    and it must not be aborted by any other bound either: the job behind it is
+    progressing, and killing it one poll short of success delivers exactly the
+    #122 experience — run dead, pointer naming an earlier generation — from the
+    code written to prevent it. An absolute cap got this wrong because its
+    tolerance shrinks as a job gets longer, which is backwards.
     """
     _project(tmp_path)
     write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
     running = {"job": {"status": "running", "progress_percent": 10}}
-    flap = []
+    # 20 dropped connections spread across the poll, never 3 in a row.
+    steps: list = []
     for _ in range(20):
-        flap.extend([httpx.ConnectError("flap"), httpx.ConnectError("flap"), running])
+        steps.extend([httpx.ConnectError("flap"), running])
+    steps.append({"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}})
     client = _engine(running)
+    client.get_status.side_effect = steps
+    _wire(monkeypatch, tmp_path, client)
+
+    _run(timeout=600)
+
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run", (
+        "a lossy link that keeps working must reach the success it was heading for"
+    )
+
+
+def test_an_absorbed_blip_leaves_a_durable_trace(tmp_path, monkeypatch, capsys):
+    """The progress description is overwritten and invisible off a TTY.
+
+    An absorbed blip is the event that used to strand generations, so it should
+    leave a line worth grepping rather than only a spinner frame.
+    """
+    _project(tmp_path)
+    client = _engine({"job": {"status": "running", "progress_percent": 10}})
+    client.get_status.side_effect = [
+        httpx.ConnectError("flap"),
+        {"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}},
+    ]
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    assert "Lost the connection" in _flat(capsys), "an absorbed blip must be visible after the fact"
+
+
+def test_a_timeout_after_blips_says_the_network_may_be_the_cause(tmp_path, monkeypatch, capsys):
+    """Otherwise a flapping link is indistinguishable from a slow job.
+
+    This is what the removed total-blip cap was really for, delivered without
+    aborting anybody's run to get it.
+    """
+    _project(tmp_path)
+    running = {"job": {"status": "running", "progress_percent": 10}}
+    client = _engine(running)
+
+    # An endless alternation rather than a fixed list: a list long enough for
+    # the deadline is a guess, and when the guess is short the test reds with
+    # StopIteration — passing for a reason it does not claim.
+    state = {"n": 0}
+
+    def flap(_pid):
+        state["n"] += 1
+        if state["n"] % 2:
+            raise httpx.ConnectError("flap")
+        return running
+
     client.get_status.side_effect = flap
     _wire(monkeypatch, tmp_path, client)
 
     with pytest.raises(typer.Exit):
         _run(timeout=5)
 
-    assert "Timed out" not in _flat(capsys), "a flapping link must surface as unreachable, not as a timeout"
+    out = _flat(capsys)
+    assert "Timed out" in out
+    assert "network problem" in out, "a poll full of dropped connections is not a slow job"
 
 
 def test_a_failed_publish_says_why(tmp_path, monkeypatch, capsys):
@@ -666,3 +724,50 @@ def test_nothing_pinned_stays_quiet(tmp_path, capsys):
     client = MagicMock()
     generate_cmd._report_field_diff(client, None, tmp_path)
     assert not _flat(capsys).strip()
+
+
+VALUE_SPACE_FIELDS = "fields:\n  - key: pi.nationality\n    type: enum\n    value_space: nationality\n"
+
+
+def test_a_transport_failure_reading_a_value_space_does_not_crash(tmp_path, monkeypatch, capsys):
+    """The branch the widened catch actually broke.
+
+    `_report_field_diff` verifies a value_space-pinned field against the
+    registry, and its handler formatted `{e.detail}` — an AethisAPIError-only
+    attribute. Widening the catch to httpx therefore turned a dropped
+    connection into an AttributeError, which no handler here or at the boundary
+    catches: a successful generation ended in a raw traceback.
+
+    Every other test pins members INLINE, so none of them enters this branch —
+    which is exactly how the defect reached CI green.
+    """
+    (tmp_path / "sources").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "sources" / "a.md").write_text("the source document")
+    (tmp_path / "fields").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "fields" / "fields.yaml").write_text(VALUE_SPACE_FIELDS)
+
+    client = _engine(
+        {
+            "job": {
+                "status": "success",
+                "result_ruleset_id": "rs_from_this_run",
+                "value_spaces_resolved": {"pi.nationality": {"space": "nationality", "version": 3}},
+            }
+        },
+        schema={"fields": [{"field_id": "pi.nationality", "enum_values": ["gbr", "usa"]}]},
+    )
+
+    def value_space(name, version=None):
+        if version is None:
+            return {"name": name, "members": ["gbr", "usa"]}  # the pre-generation probe succeeds
+        raise httpx.ConnectError("connection reset")  # the diff-phase read drops
+
+    client.get_value_space.side_effect = value_space
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()  # must not raise AttributeError, and must not fail the generation
+
+    out = _flat(capsys)
+    assert "NOT verified" in out, "the unverifiable reference must still be reported"
+    assert "connection reset" in out, "and the reason must be the transport error, readably"
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run"

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -618,8 +618,21 @@ def test_a_timeout_after_blips_says_the_network_may_be_the_cause(tmp_path, monke
     client.get_status.side_effect = flap
     _wire(monkeypatch, tmp_path, client)
 
+    # A virtual clock. Against the real one this test spent ~5s of wall time
+    # and emitted 17,000 lines to reach an ending that is purely a function of
+    # poll count; advancing 3s per reading — the loop's own cadence — makes it
+    # instant and makes the number of polls deterministic rather than a
+    # property of how loaded the machine is.
+    clock = {"t": 0.0}
+
+    def monotonic():
+        clock["t"] += 3.0
+        return clock["t"]
+
+    monkeypatch.setattr(generate_cmd.time, "monotonic", monotonic)
+
     with pytest.raises(typer.Exit):
-        _run(timeout=5)
+        _run(timeout=20)
 
     out = _flat(capsys)
     assert "Timed out" in out
@@ -771,3 +784,89 @@ def test_a_transport_failure_reading_a_value_space_does_not_crash(tmp_path, monk
     assert "NOT verified" in out, "the unverifiable reference must still be reported"
     assert "connection reset" in out, "and the reason must be the transport error, readably"
     assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run"
+
+
+def test_an_api_error_reading_the_schema_keeps_its_status_code(tmp_path, monkeypatch, capsys):
+    """The code is what makes the sentence after it true or false.
+
+    The warning continues "The draft may no longer be retrievable" — a claim a
+    404 supports and a 403 or a 500 does not. A first draft of the shared
+    reason formatter dropped the code, and nothing noticed.
+    """
+    _project(tmp_path)
+    client = _engine(
+        {"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}},
+        schema_error=AethisAPIError(404, "Ruleset not found"),
+    )
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    out = _flat(capsys)
+    assert "HTTP 404" in out, "the status code is the diagnostic half of this message"
+    assert "Ruleset not found" in out
+
+
+def test_a_structured_value_space_conflict_reads_as_a_sentence(tmp_path, monkeypatch, capsys):
+    """A dict detail must not reach the author as a repr.
+
+    The engine's value-space conflicts carry `{reason_code, message, versions}`.
+    Printing the dict buries the one sentence that says what to do, which is
+    the whole reason `_api_error_message` exists — and the reason the shared
+    formatter delegates to it instead of calling `str()` on the detail.
+    """
+    (tmp_path / "sources").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "sources" / "a.md").write_text("the source document")
+    (tmp_path / "fields").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "fields" / "fields.yaml").write_text(VALUE_SPACE_FIELDS)
+
+    client = _engine(
+        {
+            "job": {
+                "status": "success",
+                "result_ruleset_id": "rs_from_this_run",
+                "value_spaces_resolved": {"pi.nationality": {"space": "nationality", "version": 3}},
+            }
+        },
+        schema={"fields": [{"field_id": "pi.nationality", "enum_values": ["gbr", "usa"]}]},
+    )
+
+    conflict = AethisAPIError(
+        409,
+        {"reason_code": "version_conflict", "message": "Space nationality is at v4, you sent v3"},
+    )
+
+    def value_space(name, version=None):
+        if version is None:
+            return {"name": name, "members": ["gbr", "usa"]}
+        raise conflict
+
+    client.get_value_space.side_effect = value_space
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    out = _flat(capsys)
+    assert "Space nationality is at v4, you sent v3" in out, "the actionable sentence must survive"
+    assert "reason_code" not in out, "the raw dict repr buries it"
+
+
+def test_the_absorbed_blip_trace_is_said_once_not_once_per_recovery(tmp_path, monkeypatch, capsys):
+    """A flapping poll would otherwise emit the same line ~100 times.
+
+    Nothing bounds the recoveries now that the total cap is gone, so the trace
+    has to bound itself; the running total is reported once at the timeout.
+    """
+    _project(tmp_path)
+    running = {"job": {"status": "running", "progress_percent": 10}}
+    steps: list = []
+    for _ in range(10):
+        steps.extend([httpx.ConnectError("flap"), running])
+    steps.append({"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}})
+    client = _engine(running)
+    client.get_status.side_effect = steps
+    _wire(monkeypatch, tmp_path, client)
+
+    _run(timeout=600)
+
+    assert _flat(capsys).count("Lost the connection") == 1, "ten recoveries, one line"

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -30,6 +30,7 @@ import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 import typer
 
@@ -355,6 +356,134 @@ def test_a_mid_poll_api_error_names_the_stale_pointer(tmp_path, monkeypatch, cap
         "an API error rules nothing out; the last known good id is not invalidated by it"
     )
     assert "rs_from_an_earlier_run" in _flat(capsys), "the stale pointer must be named on this ending too"
+
+
+# ---------------------------------------------------------------------------
+# Defect 4 (#122) — the same ending, reached by the exception that actually
+# interrupts a long poll
+# ---------------------------------------------------------------------------
+#
+# The guard above is correct and, on the failure most likely to trigger it, it
+# never ran. A dropped connection, a DNS failure, a TLS error or a read timeout
+# raises `httpx.HTTPError`, not `AethisAPIError`: `AethisClient._request` wraps
+# only HTTP *status* failures, so a transport failure unwinds past this
+# handler to the top-level boundary in `main.py`, which renders one line and
+# exits. `_invalidate_stale_pointer` is skipped, so the id is kept — right —
+# and never named — wrong, and silently so.
+#
+# The tests below pin the whole path, not just the reported ending: a blip that
+# the poll can simply survive should not end the run at all.
+
+
+def test_a_mid_poll_transport_failure_names_the_stale_pointer(tmp_path, monkeypatch, capsys):
+    """The reported defect: the guard must cover the transport error too.
+
+    The twin of `test_a_mid_poll_api_error_names_the_stale_pointer`. Nothing has
+    been ruled — the job may well have succeeded — so the id stands and must be
+    named, and the recovery is one command away, so the warning carries it.
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    client = _engine({"job": {"status": "running", "progress_percent": 10}})
+    client.get_status.side_effect = httpx.RemoteProtocolError("Server disconnected without sending a response.")
+    _wire(monkeypatch, tmp_path, client)
+
+    with pytest.raises(typer.Exit) as exc:
+        _run()
+
+    assert exc.value.exit_code == 1
+    assert read_state(tmp_path).get("ruleset_id") == "rs_from_an_earlier_run", (
+        "a transport failure rules nothing out; the last known good id is not invalidated by it"
+    )
+    out = _flat(capsys)
+    assert "rs_from_an_earlier_run" in out, "the stale pointer must be named on this ending too"
+    assert "projects show" in out, "the warning must carry the command that recovers the real id"
+
+
+def test_a_blip_mid_poll_does_not_end_the_generation(tmp_path, monkeypatch, capsys):
+    """Better than naming the stale id: don't strand the run in the first place.
+
+    A single dropped connection is the common form of this incident, and the
+    job behind it usually finishes. Absorbing the blip turns the whole class
+    from "silent stale pointer" into "no incident".
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    client = _engine({"job": {"status": "running", "progress_percent": 10}})
+    client.get_status.side_effect = [
+        httpx.RemoteProtocolError("Server disconnected without sending a response."),
+        {"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}},
+    ]
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run", (
+        "the poll survived the blip, so this run's id must be the one recorded"
+    )
+
+
+def test_a_blip_in_the_post_success_repoll_still_records_the_id(tmp_path, monkeypatch, capsys):
+    """The seam that is strictly worse than the reported one.
+
+    After the engine reports success the loop re-polls for the id. A transport
+    failure *there* strands a generation the CLI already knows succeeded.
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    client = _engine({"job": {"status": "running", "progress_percent": 10}})
+    client.get_status.side_effect = [
+        {"job": {"status": "success"}},  # success, id not yet populated
+        httpx.ReadTimeout("timed out"),  # the re-poll blips
+        {"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}},
+    ]
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run", (
+        "a blip while waiting for the id must not discard an id the next attempt returns"
+    )
+
+
+def test_a_transport_failure_on_publish_still_reports_the_ruleset(tmp_path, monkeypatch, capsys):
+    """Publishing is the last step, and its failure is not the generation's.
+
+    The id was recorded before the publish. Reporting only "Could not reach the
+    Aethis API" would have the author read a successful generation as a failed
+    one, and re-run it.
+    """
+    _project(tmp_path)
+    client = _engine({"job": {"status": "success", "result_ruleset_id": "rs_from_this_run"}})
+    client.publish.side_effect = httpx.ConnectError("connection refused")
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    out = _flat(capsys)
+    assert "rs_from_this_run" in out, "the generation succeeded and its id must be reported"
+    assert "aethis publish" in out, "the un-run step must be named so it can be run"
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_this_run"
+
+
+def test_a_success_that_never_surfaces_an_id_names_the_stale_pointer(tmp_path, monkeypatch, capsys):
+    """A success with no id leaves the same silent stale pointer.
+
+    The id is deliberately not clobbered (nothing better is known), so this
+    ending has exactly the shape the guard exists for: `fields pull` would sync
+    from the earlier generation with nothing said.
+    """
+    _project(tmp_path)
+    write_state(tmp_path, {"ruleset_id": "rs_from_an_earlier_run"})
+    client = _engine({"job": {"status": "success"}})
+    _wire(monkeypatch, tmp_path, client)
+
+    _run()
+
+    assert read_state(tmp_path)["ruleset_id"] == "rs_from_an_earlier_run", "a success never clobbers a prior good id"
+    assert "rs_from_an_earlier_run" in _flat(capsys), (
+        "a success that produced no id must still name the pointer it did not replace"
+    )
 
 
 def test_a_success_that_never_surfaces_an_id_diffs_nothing(tmp_path, monkeypatch, capsys):

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -870,3 +870,27 @@ def test_the_absorbed_blip_trace_is_said_once_not_once_per_recovery(tmp_path, mo
     _run(timeout=600)
 
     assert _flat(capsys).count("Lost the connection") == 1, "ten recoveries, one line"
+
+
+def test_a_failed_run_still_clears_the_pointer_even_if_the_ids_match(tmp_path, capsys):
+    """The suppression must never reach the ending whose job is to nullify.
+
+    `produced_id` means "this run produced it"; the pointer means "this run
+    recorded it". Those diverge on the failed path, where the engine may attach
+    a draft id that was never written to disk — and there, suppressing would
+    skip the clear, leaving `fields pull` free to sync from a ruleset the
+    engine has ruled against.
+
+    Unreachable through the command today (nothing passes `produced_id` with a
+    failed status), so it is driven directly: an unreachable clause is still a
+    claim, and an untested claim is the one that turns out to be wrong when a
+    later caller makes it reachable.
+    """
+    write_state(tmp_path, {"ruleset_id": "rs_draft", "project_id": "proj_abc"})
+
+    generate_cmd._invalidate_stale_pointer(tmp_path, "failed", produced_id="rs_draft")
+
+    assert read_state(tmp_path)["ruleset_id"] is None, (
+        "a failed ending clears the pointer regardless of which run produced it"
+    )
+    assert "Cleared the recorded ruleset" in _flat(capsys)

--- a/tests/test_transport_error_rendering.py
+++ b/tests/test_transport_error_rendering.py
@@ -1,0 +1,55 @@
+"""An unreachable API must not crash the code that reports it unreachable.
+
+`httpx` exposes `.request` as a **property that raises** `RuntimeError` when
+httpx never bound one — so the defensive-looking `getattr(e, "request", None)`
+never applies its default, and the transport-error renderer could fail while
+reporting a transport failure: a traceback about the error handler in place of
+the one actionable line, on the path where something has already gone wrong.
+
+The two pre-existing tests in `test_main.py` both construct the error *with* a
+bound `request=`, which is exactly why the defect survived. These cover the
+unbound case, and the fallback the renderer is supposed to use for it.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+
+from aethis_cli.output import render_transport_error
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _flat(capsys) -> str:
+    return re.sub(r"\s+", " ", _ANSI.sub("", capsys.readouterr().out))
+
+
+def test_an_error_with_no_bound_request_still_renders(capsys):
+    """The shape that raises from the property getter."""
+    render_transport_error(httpx.ConnectError("connection refused"))
+
+    out = _flat(capsys)
+    assert "Could not reach the Aethis API" in out
+    assert "connection refused" in out
+    assert "https://api.aethis.ai" in out, "with no request to read a host from, the default is the honest fallback"
+
+
+def test_the_configured_host_is_named_rather_than_the_public_default(capsys):
+    """An author on a private or staging engine must not be told the public host failed."""
+    render_transport_error(httpx.ConnectError("connection refused"), base_url="http://engine.internal:8080")
+
+    out = _flat(capsys)
+    assert "http://engine.internal:8080" in out
+    assert "https://api.aethis.ai" not in out, "naming a host that was never contacted describes the wrong request"
+
+
+def test_a_bound_request_still_wins(capsys):
+    """The pre-existing behaviour the extraction had to preserve."""
+    request = httpx.Request("GET", "https://staging.api.aethis.ai/api/v1/public/projects/p/status")
+    err = httpx.ReadTimeout("timed out", request=request)
+
+    render_transport_error(err)
+
+    assert "staging.api.aethis.ai" in _flat(capsys)


### PR DESCRIPTION
## What was wrong

`aethis generate --poll` has a guard for exactly the situation in #122: an interrupted run leaves `.aethis/state.json` naming the **previous** generation's ruleset, so every later `decide`, `test`, `explain` and `fields pull` silently answers from a superseded ruleset. Nothing errors and nothing warns.

The guard was on the wrong exception path. `AethisClient._request` wraps HTTP **status** failures in `AethisAPIError`; a dropped connection, DNS failure, TLS error or read timeout raises `httpx.HTTPError`, which unwound straight past the handler to the top-level boundary in `main.py`. So `_invalidate_stale_pointer` never ran on the failure *most likely* to interrupt a long poll.

## What changed

Five seams on that path:

| seam | before | after |
|---|---|---|
| `_run_generate` handler | `httpx.HTTPError` unwinds past the guard | caught: names the stale id **and** prints the recovery command |
| poll loop `get_status` | any blip ends the run | absorbs up to 3 consecutive blips, then reports unreachable |
| post-success id re-poll | a blip strands a job known to have succeeded | tolerant per attempt |
| auto-publish | transport error reads as a failed generation | reports the ruleset, names `aethis publish` |
| success with no id | silent stale pointer | names the pointer it did not replace |

The blip budget is deliberately **bounded**: tolerating indefinitely would report a real outage as a *timeout*, which reads as a slow job and sends the author looking in the wrong place.

### A latent defect the tests surfaced

`httpx` exposes `.request` as a **property that raises** `RuntimeError` when httpx never bound one — so the existing `getattr(e, "request", None)` never applied its default and could fail *while reporting* an unreachable API, printing a traceback about the error handler instead of the one actionable line. Present in `main.py` before this PR. The rendering now has one home in `output.py`, shared by the boundary and by commands that must clean up before exiting.

## Evidence

Tests were written **first** and each watched red on the broken code (5 failed / 18 passed before the fix, 23/23 after).

A mutation battery reverts each producer change individually. Vacuity controls per `gate-path-coverage` rule 7: every mutation must match exactly once, the tree must actually differ, red/green is read from the **exit code**, and the baseline is re-run at the **end** as well as the start.

| mutation | owning test | result |
|---|---|---|
| revert the `_run_generate` transport handler | `test_a_mid_poll_transport_failure_names_the_stale_pointer` | RED |
| revert the recovery command line | `test_a_mid_poll_transport_failure_names_the_stale_pointer` | RED |
| revert poll-loop blip tolerance | `test_a_blip_mid_poll_does_not_end_the_generation` | RED |
| revert post-success re-poll tolerance | `test_a_blip_in_the_post_success_repoll_still_records_the_id` | RED |
| revert the publish seam widening | `test_a_transport_failure_on_publish_still_reports_the_ruleset` | RED |
| **CONTROL** — remove success-with-no-id naming entirely | `test_a_success_that_never_surfaces_an_id_names_the_stale_pointer` | RED |
| revert the unsafe `.request` guard | `test_a_mid_poll_transport_failure_names_the_stale_pointer` | RED |

Opening baseline GREEN, closing baseline GREEN — so no row went red because the environment died under it.

**Sibling sweep** (`defect-depth` rule): swept every `except AethisAPIError` in `aethis_cli/` (57 sites) for handlers that mutate state or run cleanup. Only two do — `generate_cmd.py:903` (this defect) and `generate_cmd.py:73` (project creation, unrelated). The first sweep window was too narrow and missed its own known-positive control; re-run wider, it passes the control. The class is confined to the poll path. The other two `get_status` call sites (`status_cmd.py:185`, `:276`) write no state, so the `main.py` boundary is an equivalent rendering for them.

Full suite: **628 passed**. Six failures are a pre-existing local `FORCE_COLOR`/ANSI flake, verified identical on clean `origin/main` in a throwaway worktree — not introduced here.

## Not in scope

The issue's second improvement — having *every* command that reads `state.json` warn when the recorded `job_id` did not produce the recorded `ruleset_id` — is a broader change across many commands and is left for a follow-up.

Version bumped to **0.37.1** with CHANGELOG, per the published-package rule.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNYhLx5mMmQyNsmsdmyQyY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790968915&installation_model_id=429844&pr_number=123&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F123&signature=7772d17efbd9853803373762744e18c1ef3448805e38611eaf4675f01bbce300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->