### PR TITLE
feat: add generation recovery controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 0.38.0 (2026-09-02)
 
 - **feat: explicitly recover an authoring project from an abandoned generation.**
-  `aethis cancel [-p PROJECT]` calls the engine's cancellation endpoint after a
-  confirmation (`--yes` for automation), marks the current job failed, and
+  `aethis cancel [-p PROJECT]` first observes and displays the exact active job,
+  then calls the engine's job-bound cancellation endpoint after a confirmation
+  (`--yes` for automation), marks that job failed, and
   releases its ownership of the project. It reports the engine's honest
   limitation: an already-running worker may continue even though a new run can
   now be admitted. Polling never cancels automatically.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.38.0 (2026-09-02)
+
+- **feat: explicitly recover an authoring project from an abandoned generation.**
+  `aethis cancel [-p PROJECT]` calls the engine's cancellation endpoint after a
+  confirmation (`--yes` for automation), marks the current job failed, and
+  releases its ownership of the project. It reports the engine's honest
+  limitation: an already-running worker may continue even though a new run can
+  now be admitted. Polling never cancels automatically.
+- **feat: generation status shows live convergence and heartbeat telemetry.**
+  `aethis status` and the live `generate` progress line consume the engine's
+  turn count, best test pass rate, tool count, last tool, and
+  `seconds_since_progress`. Older engines remain compatible: absent telemetry
+  is omitted rather than guessed. A client-side timeout now names the exact
+  status and cancel recovery commands.
+
 ## 0.37.1 (2026-09-02)
 
 - **fix(generate): a dropped connection mid-poll no longer strands the run on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@
   (`--yes` for automation), marks that job failed, and
   releases its ownership of the project. It reports the engine's honest
   limitation: an already-running worker may continue even though a new run can
-  now be admitted. Polling never cancels automatically.
+  now be admitted. The idempotent response distinguishes `cancelled` from
+  `already_cancelled`. Polling never cancels automatically.
 - **feat: generation status shows live convergence and heartbeat telemetry.**
   `aethis status` and the live `generate` progress line consume the engine's
   turn count, best test pass rate, tool count, last tool, and
   `seconds_since_progress`. Older engines remain compatible: absent telemetry
   is omitted rather than guessed. A client-side timeout now names the exact
-  status and cancel recovery commands.
+  status and cancel recovery commands. Status also renders telemetry
+  availability, server-authoritative worker lifecycle, and retry readiness.
 
 ## 0.37.1 (2026-09-02)
 

--- a/README.md
+++ b/README.md
@@ -185,14 +185,16 @@ The same contract and the same exit codes apply to
 | `aethis generate [--poll]` | Upload sources + guidance, trigger generation. A successful `--poll` run publishes the ruleset, making it active |
 | `aethis generate --no-publish` | The same run, leaving the ruleset an unpublished draft — for workflows where activation is separately gated |
 | `aethis status [-p <project_id>]` | Check generation progress, turn/test convergence, last tool, and heartbeat age |
-| `aethis cancel [-p <project_id>] [--yes]` | Explicitly mark the in-flight job failed and release its project ownership |
+| `aethis cancel [-p <project_id>] [--job-id <observed_job_id>] [--yes]` | Observe and explicitly cancel that exact in-flight job, then release only its project ownership |
 | `aethis test` | Run test cases against the latest ruleset |
 | `aethis publish [--force]` | Set the latest ruleset as active |
 | `aethis publish --source-targets <file>` | Publish with citations resolved from a YAML/JSON targets file |
 
 If polling times out, inspect the server-side run with `aethis status`. A run
 whose heartbeat has stopped is not cancelled automatically: use `aethis cancel`
-only when you intend to abandon it. Cancellation releases the project so a new
+only when you intend to abandon it. The command observes and displays the exact
+active job before confirmation; `--job-id` additionally refuses if that target
+has changed. Cancellation releases the project so a new
 run can be admitted, but it may not stop an already-running worker. The command
 asks for confirmation; automation must pass `--yes` (or use the repository-wide
 `AETHIS_NONINTERACTIVE=1` / `CI=1` prompt bypass).

--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ only when you intend to abandon it. The command observes and displays the exact
 active job before confirmation; `--job-id` additionally refuses if that target
 has changed. Cancellation releases the project so a new
 run can be admitted, but it may not stop an already-running worker. The command
-asks for confirmation; automation must pass `--yes` (or use the repository-wide
-`AETHIS_NONINTERACTIVE=1` / `CI=1` prompt bypass).
+asks for confirmation; automation must pass `--yes`. Unlike other prompts, this
+destructive command deliberately refuses to treat `AETHIS_NONINTERACTIVE=1` or
+`CI=1` as approval.
 
 ### Citations at publish (`--source-targets`)
 

--- a/README.md
+++ b/README.md
@@ -184,10 +184,18 @@ The same contract and the same exit codes apply to
 | `aethis init` | Initialise a new project in the current directory |
 | `aethis generate [--poll]` | Upload sources + guidance, trigger generation. A successful `--poll` run publishes the ruleset, making it active |
 | `aethis generate --no-publish` | The same run, leaving the ruleset an unpublished draft — for workflows where activation is separately gated |
-| `aethis status` | Check generation job progress |
+| `aethis status [-p <project_id>]` | Check generation progress, turn/test convergence, last tool, and heartbeat age |
+| `aethis cancel [-p <project_id>] [--yes]` | Explicitly mark the in-flight job failed and release its project ownership |
 | `aethis test` | Run test cases against the latest ruleset |
 | `aethis publish [--force]` | Set the latest ruleset as active |
 | `aethis publish --source-targets <file>` | Publish with citations resolved from a YAML/JSON targets file |
+
+If polling times out, inspect the server-side run with `aethis status`. A run
+whose heartbeat has stopped is not cancelled automatically: use `aethis cancel`
+only when you intend to abandon it. Cancellation releases the project so a new
+run can be admitted, but it may not stop an already-running worker. The command
+asks for confirmation; automation must pass `--yes` (or use the repository-wide
+`AETHIS_NONINTERACTIVE=1` / `CI=1` prompt bypass).
 
 ### Citations at publish (`--source-targets`)
 

--- a/README.md
+++ b/README.md
@@ -184,14 +184,15 @@ The same contract and the same exit codes apply to
 | `aethis init` | Initialise a new project in the current directory |
 | `aethis generate [--poll]` | Upload sources + guidance, trigger generation. A successful `--poll` run publishes the ruleset, making it active |
 | `aethis generate --no-publish` | The same run, leaving the ruleset an unpublished draft — for workflows where activation is separately gated |
-| `aethis status [-p <project_id>]` | Check generation progress, turn/test convergence, last tool, and heartbeat age |
+| `aethis status [-p <project_id>]` | Check generation progress, telemetry availability, server-authoritative worker lifecycle, and retry readiness |
 | `aethis cancel [-p <project_id>] [--job-id <observed_job_id>] [--yes]` | Observe and explicitly cancel that exact in-flight job, then release only its project ownership |
 | `aethis test` | Run test cases against the latest ruleset |
 | `aethis publish [--force]` | Set the latest ruleset as active |
 | `aethis publish --source-targets <file>` | Publish with citations resolved from a YAML/JSON targets file |
 
-If polling times out, inspect the server-side run with `aethis status`. A run
-whose heartbeat has stopped is not cancelled automatically: use `aethis cancel`
+If polling times out, inspect the server-side run with `aethis status`. An old
+heartbeat is monitoring evidence, not proof that the worker died, and never
+triggers cancellation automatically: use `aethis cancel`
 only when you intend to abandon it. The command observes and displays the exact
 active job before confirmation; `--job-id` additionally refuses if that target
 has changed. Cancellation releases the project so a new

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.37.1"
+__version__ = "0.38.0"

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -456,6 +456,16 @@ class AethisClient:
     def get_status(self, project_id: str) -> dict:
         return self._request("GET", f"/api/v1/public/projects/{project_id}/status")
 
+    def cancel_generation(self, project_id: str) -> dict:
+        """Cancel the latest in-flight generation and release the project.
+
+        The engine deliberately does not claim that this stops an already
+        running worker; the response's ``detail`` carries that limitation to
+        callers. Cancellation is an explicit operator recovery action, never
+        something polling invokes automatically.
+        """
+        return self._request("POST", f"/api/v1/public/projects/{project_id}/generate/cancel")
+
     def run_tests(self, project_id: str) -> dict:
         return self._request("POST", f"/api/v1/public/projects/{project_id}/test-run")
 

--- a/aethis_cli/client.py
+++ b/aethis_cli/client.py
@@ -456,15 +456,19 @@ class AethisClient:
     def get_status(self, project_id: str) -> dict:
         return self._request("GET", f"/api/v1/public/projects/{project_id}/status")
 
-    def cancel_generation(self, project_id: str) -> dict:
-        """Cancel the latest in-flight generation and release the project.
+    def cancel_generation(self, project_id: str, job_id: str) -> dict:
+        """Cancel the observed generation and release only its project ownership.
 
         The engine deliberately does not claim that this stops an already
         running worker; the response's ``detail`` carries that limitation to
         callers. Cancellation is an explicit operator recovery action, never
         something polling invokes automatically.
         """
-        return self._request("POST", f"/api/v1/public/projects/{project_id}/generate/cancel")
+        return self._request(
+            "POST",
+            f"/api/v1/public/projects/{project_id}/generate/cancel",
+            params={"job_id": job_id},
+        )
 
     def run_tests(self, project_id: str) -> dict:
         return self._request("POST", f"/api/v1/public/projects/{project_id}/test-run")

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -32,7 +32,12 @@ def cancel(
         None,
         "--project-id",
         "-p",
-        help="Project whose latest in-flight generation should be cancelled (defaults to aethis.yaml).",
+        help="Project whose observed in-flight generation should be cancelled (defaults to aethis.yaml).",
+    ),
+    job_id: Optional[str] = typer.Option(
+        None,
+        "--job-id",
+        help="Expected active job. Refuses if the project's current job differs.",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ) -> None:
@@ -42,14 +47,30 @@ def cancel(
     action is never invoked automatically by ``generate`` or ``status``.
     """
     pid = _resolve_project_id(project_id)
+    _cfg, client = load_client_or_fallback()
+    try:
+        status = client.get_status(pid)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+    current_job = status.get("job") if isinstance(status, dict) else None
+    observed_job_id = current_job.get("job_id") if isinstance(current_job, dict) else None
+    observed_status = current_job.get("status") if isinstance(current_job, dict) else None
+    if not isinstance(observed_job_id, str) or observed_status not in ("queued", "running"):
+        console.print("[red]No in-flight generation job was observed for this project.[/red]")
+        raise typer.Exit(code=1)
+    if job_id is not None and job_id != observed_job_id:
+        console.print(
+            f"[red]Refusing: expected job {job_id}, but the project currently reports {observed_job_id}.[/red]"
+        )
+        raise typer.Exit(code=1)
     confirm_or_abort(
-        f"Cancel the in-flight generation for {pid}? This marks the job failed and releases the project",
+        f"Cancel generation {observed_job_id} for {pid}? This marks that job failed and releases its ownership",
         assume_yes=yes,
     )
 
-    _cfg, client = load_client_or_fallback()
     try:
-        result = client.cancel_generation(pid)
+        result = client.cancel_generation(pid, observed_job_id)
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -1,0 +1,68 @@
+"""aethis cancel — explicitly release an in-flight generation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from aethis_cli.config import load_client_or_fallback, load_project_config
+from aethis_cli.errors import AethisAPIError, ConfigError
+from aethis_cli.output import console, error_panel, success, warn
+from aethis_cli.prompts import confirm_or_abort
+from aethis_cli.render import emit, is_json_requested
+
+
+def _resolve_project_id(project_id: Optional[str]) -> str:
+    if project_id:
+        return project_id
+    try:
+        cfg = load_project_config()
+    except ConfigError:
+        console.print("[red]No project ID. Run from an Aethis project or pass --project-id.[/red]")
+        raise typer.Exit(code=1)
+    if not cfg.project_id:
+        console.print("[red]This project has no project_id yet. Pass --project-id.[/red]")
+        raise typer.Exit(code=1)
+    return cfg.project_id
+
+
+def cancel(
+    project_id: Optional[str] = typer.Option(
+        None,
+        "--project-id",
+        "-p",
+        help="Project whose latest in-flight generation should be cancelled (defaults to aethis.yaml).",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+) -> None:
+    """Mark the current job failed and release its project ownership.
+
+    Worker shutdown may be cooperative rather than immediate. This recovery
+    action is never invoked automatically by ``generate`` or ``status``.
+    """
+    pid = _resolve_project_id(project_id)
+    confirm_or_abort(
+        f"Cancel the in-flight generation for {pid}? This marks the job failed and releases the project",
+        assume_yes=yes,
+    )
+
+    _cfg, client = load_client_or_fallback()
+    try:
+        result = client.cancel_generation(pid)
+    except AethisAPIError as e:
+        error_panel(e)
+        raise typer.Exit(code=1)
+
+    if is_json_requested():
+        emit(result)
+        return
+
+    job_id = result.get("job_id", "unknown")
+    if result.get("project_released") is True:
+        success(f"Generation {job_id} cancelled; project {pid} released.")
+    else:
+        warn(f"Generation {job_id} was marked failed, but project {pid} was not released by this request.")
+    detail = result.get("detail")
+    if detail:
+        console.print(str(detail), style="yellow", markup=False, highlight=False)

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -78,18 +78,14 @@ def cancel(
             f"[red]Refusing: expected job {job_id}, but the project currently reports {observed_job_id}.[/red]"
         )
         raise typer.Exit(code=1)
-    if observed_status not in ("queued", "running") and not (
-        job_id == observed_job_id and already_cancelled
-    ):
+    if observed_status not in ("queued", "running") and not (job_id == observed_job_id and already_cancelled):
         console.print(
             "[red]No cancellable generation was observed. To retry an ambiguous prior cancellation, "
             "pass the exact terminal --job-id; only generation_cancelled is replayable.[/red]"
         )
         raise typer.Exit(code=1)
     if not yes and is_noninteractive():
-        console.print(
-            "[red]Cancellation in a non-interactive environment requires explicit --yes.[/red]"
-        )
+        console.print("[red]Cancellation in a non-interactive environment requires explicit --yes.[/red]")
         raise typer.Exit(code=1)
     confirm_or_abort(
         f"Cancel generation {observed_job_id} for {pid}? This marks that job failed and releases its ownership",

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -53,6 +53,11 @@ def cancel(
     except AethisAPIError as e:
         error_panel(e)
         raise typer.Exit(code=1)
+    if status.get("generation_contract_version") != 1:
+        console.print(
+            "[red]Cancellation is unavailable: this engine has not advertised the job-bound recovery contract.[/red]"
+        )
+        raise typer.Exit(code=1)
     current_job = status.get("job") if isinstance(status, dict) else None
     observed_job_id = current_job.get("job_id") if isinstance(current_job, dict) else None
     observed_status = current_job.get("status") if isinstance(current_job, dict) else None
@@ -80,8 +85,9 @@ def cancel(
         return
 
     job_id = result.get("job_id", "unknown")
+    outcome = result.get("outcome", "cancelled")
     if result.get("project_released") is True:
-        success(f"Generation {job_id} cancelled; project {pid} released.")
+        success(f"Generation {job_id} {outcome.replace('_', ' ')}; project {pid} released.")
     else:
         warn(f"Generation {job_id} was marked failed, but project {pid} was not released by this request.")
     detail = result.get("detail")

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -9,7 +9,7 @@ import typer
 from aethis_cli.config import load_client_or_fallback, load_project_config
 from aethis_cli.errors import AethisAPIError, ConfigError
 from aethis_cli.output import console, error_panel, success, warn
-from aethis_cli.prompts import confirm_or_abort
+from aethis_cli.prompts import confirm_or_abort, is_noninteractive
 from aethis_cli.render import emit, is_json_requested
 
 
@@ -61,12 +61,31 @@ def cancel(
     current_job = status.get("job") if isinstance(status, dict) else None
     observed_job_id = current_job.get("job_id") if isinstance(current_job, dict) else None
     observed_status = current_job.get("status") if isinstance(current_job, dict) else None
-    if not isinstance(observed_job_id, str) or observed_status not in ("queued", "running"):
+    error_detail = current_job.get("error_detail") if isinstance(current_job, dict) else None
+    already_cancelled = (
+        observed_status == "failed"
+        and isinstance(error_detail, dict)
+        and error_detail.get("reason_code") == "generation_cancelled"
+    )
+    if not isinstance(observed_job_id, str):
         console.print("[red]No in-flight generation job was observed for this project.[/red]")
         raise typer.Exit(code=1)
     if job_id is not None and job_id != observed_job_id:
         console.print(
             f"[red]Refusing: expected job {job_id}, but the project currently reports {observed_job_id}.[/red]"
+        )
+        raise typer.Exit(code=1)
+    if observed_status not in ("queued", "running") and not (
+        job_id == observed_job_id and already_cancelled
+    ):
+        console.print(
+            "[red]No cancellable generation was observed. To retry an ambiguous prior cancellation, "
+            "pass the exact terminal --job-id; only generation_cancelled is replayable.[/red]"
+        )
+        raise typer.Exit(code=1)
+    if not yes and is_noninteractive():
+        console.print(
+            "[red]Cancellation in a non-interactive environment requires explicit --yes.[/red]"
         )
         raise typer.Exit(code=1)
     confirm_or_abort(

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -85,9 +85,12 @@ def cancel(
         return
 
     job_id = result.get("job_id", "unknown")
-    outcome = result.get("outcome", "cancelled")
+    outcome = result.get("outcome")
     if result.get("project_released") is True:
-        success(f"Generation {job_id} {outcome.replace('_', ' ')}; project {pid} released.")
+        if outcome in ("cancelled", "already_cancelled"):
+            success(f"Generation {job_id} {outcome.replace('_', ' ')}; project {pid} released.")
+        else:
+            warn(f"Generation {job_id} returned an unknown cancellation outcome; project {pid} released.")
     else:
         warn(f"Generation {job_id} was marked failed, but project {pid} was not released by this request.")
     detail = result.get("detail")

--- a/aethis_cli/commands/cancel_cmd.py
+++ b/aethis_cli/commands/cancel_cmd.py
@@ -37,7 +37,10 @@ def cancel(
     job_id: Optional[str] = typer.Option(
         None,
         "--job-id",
-        help="Expected active job. Refuses if the project's current job differs.",
+        help=(
+            "Expected generation job. Refuses if the project's current job differs; "
+            "the exact cancelled job may be supplied to replay an ambiguous prior request."
+        ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ) -> None:

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -22,6 +22,7 @@ from aethis_cli.config import (
     write_state,
 )
 from aethis_cli.errors import AethisAPIError, ConfigError
+from aethis_cli.generation_status import format_poll_description
 from aethis_cli.output import console, error_panel, info, render_transport_error, success, warn
 
 
@@ -1361,8 +1362,10 @@ def _poll_until_done(
             blips = 0
             job = result.get("job") or {}
             pct = job.get("progress_percent", 0)
+            if isinstance(pct, bool) or not isinstance(pct, (int, float)):
+                pct = 0
             job_status = job.get("status", "unknown")
-            progress.update(task, completed=pct, description=f"[cyan]{job_status}[/cyan] — {pct}%")
+            progress.update(task, completed=pct, description=f"[cyan]{format_poll_description(job)}[/cyan]")
 
             if job_status == "success":
                 progress.update(task, completed=100)
@@ -1450,7 +1453,14 @@ def _poll_until_done(
 
             time.sleep(3)
 
-    console.print(f"\n[bold red]Timed out after {timeout}s.[/bold red] Use 'aethis status' to check progress.")
+    console.print(
+        f"\n[bold red]Timed out after {timeout}s.[/bold red] "
+        f"Use 'aethis status -p {pid}' to inspect the server heartbeat and convergence."
+    )
+    console.print(
+        f"[dim]If you intend to abandon a stale run, use 'aethis cancel -p {pid}'. "
+        "Cancellation releases the project but may not stop an already-running worker.[/dim]"
+    )
     if total_blips:
         # Without this, a flapping link is indistinguishable from a slow job —
         # which sends the author to look at the engine rather than the network.

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -192,6 +192,11 @@ def _print_generation_section(project_id: str) -> None:
     color = {"ready": "green", "failed": "red", "generating": "yellow"}.get(ps, "white")
     console.print(f"\n[bold]Generation[/bold] — {project_id}")
     console.print(f"  Project: [bold {color}]{ps}[/bold {color}]")
+    if result.get("generation_contract_version") == 1:
+        console.print(f"  Worker:  {result.get('worker_lifecycle', 'unknown')}")
+        console.print(f"  Retry:   {result.get('retry_readiness', 'unknown')}")
+    else:
+        console.print("  Worker:  [dim]lifecycle telemetry unavailable for this engine[/dim]")
     job = result.get("job")
     if job:
         console.print(f"  Job:     {job.get('status')} ({job.get('progress_percent', 0)}%)")

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -19,6 +19,7 @@ from aethis_cli.config import (
     resolve_base_url_with_source,
 )
 from aethis_cli.errors import AethisAPIError, ConfigError
+from aethis_cli.generation_status import format_heartbeat, format_progress_detail
 from aethis_cli.output import console, error_panel
 from aethis_cli.render import emit, is_json_requested
 
@@ -194,6 +195,12 @@ def _print_generation_section(project_id: str) -> None:
     job = result.get("job")
     if job:
         console.print(f"  Job:     {job.get('status')} ({job.get('progress_percent', 0)}%)")
+        progress_detail = format_progress_detail(job)
+        if progress_detail:
+            console.print(f"  Progress: {progress_detail}")
+        heartbeat = format_heartbeat(job)
+        if heartbeat:
+            console.print(f"  Heartbeat: {heartbeat}")
         if job.get("error_message"):
             console.print(f"  Error:   [red]{job['error_message']}[/red]")
     bid = result.get("latest_ruleset_id")

--- a/aethis_cli/commands/status_cmd.py
+++ b/aethis_cli/commands/status_cmd.py
@@ -193,6 +193,7 @@ def _print_generation_section(project_id: str) -> None:
     console.print(f"\n[bold]Generation[/bold] — {project_id}")
     console.print(f"  Project: [bold {color}]{ps}[/bold {color}]")
     if result.get("generation_contract_version") == 1:
+        console.print(f"  Telemetry: {result.get('telemetry_availability', 'unknown')}")
         console.print(f"  Worker:  {result.get('worker_lifecycle', 'unknown')}")
         console.print(f"  Retry:   {result.get('retry_readiness', 'unknown')}")
     else:

--- a/aethis_cli/generation_status.py
+++ b/aethis_cli/generation_status.py
@@ -1,0 +1,71 @@
+"""Pure formatting helpers for generation progress and heartbeat telemetry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _non_negative_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        return None
+    return float(value)
+
+
+def format_progress_detail(job: dict[str, Any]) -> str:
+    """Compact, truthful convergence detail for a status payload.
+
+    Every member is optional because this CLI remains compatible with engines
+    from before the live-telemetry fields were added.
+    """
+    parts: list[str] = []
+    turn = job.get("current_turn")
+    max_turns = job.get("max_turns")
+    if isinstance(turn, int) and not isinstance(turn, bool):
+        parts.append(f"turn {turn}/{max_turns}" if isinstance(max_turns, int) else f"turn {turn}")
+
+    best = job.get("best_passed")
+    total = job.get("test_total")
+    if isinstance(best, int) and not isinstance(best, bool):
+        parts.append(f"best {best}/{total} tests" if isinstance(total, int) else f"best {best} tests")
+
+    calls = job.get("tool_calls")
+    if isinstance(calls, int) and not isinstance(calls, bool):
+        noun = "call" if calls == 1 else "calls"
+        parts.append(f"{calls} tool {noun}")
+    return " · ".join(parts)
+
+
+def format_heartbeat(job: dict[str, Any]) -> str:
+    """Describe the server-computed heartbeat age without inventing a stall."""
+    seconds = _non_negative_number(job.get("seconds_since_progress"))
+    if seconds is not None:
+        rounded = int(seconds)
+        if rounded < 60:
+            age = f"{rounded}s ago"
+        elif rounded < 3600:
+            age = f"{rounded // 60}m {rounded % 60}s ago"
+        else:
+            age = f"{rounded // 3600}h {(rounded % 3600) // 60}m ago"
+        tool = job.get("last_tool")
+        return f"last progress {age}" + (f" · {tool}" if isinstance(tool, str) and tool else "")
+
+    timestamp = job.get("last_progress_at")
+    if isinstance(timestamp, str) and timestamp:
+        return f"last progress {timestamp}"
+    return ""
+
+
+def format_poll_description(job: dict[str, Any]) -> str:
+    """One progress-bar line carrying status, convergence, and heartbeat."""
+    status = str(job.get("status", "unknown"))
+    pct = job.get("progress_percent", 0)
+    if isinstance(pct, bool) or not isinstance(pct, (int, float)):
+        pct = 0
+    parts = [f"{status} — {pct:g}%"]
+    progress = format_progress_detail(job)
+    heartbeat = format_heartbeat(job)
+    if progress:
+        parts.append(progress)
+    if heartbeat:
+        parts.append(heartbeat)
+    return " — ".join(parts)

--- a/aethis_cli/main.py
+++ b/aethis_cli/main.py
@@ -25,6 +25,7 @@ from aethis_cli.commands.projects_cmd import projects_app
 from aethis_cli.commands.init_cmd import init
 from aethis_cli.commands.login_cmd import login
 from aethis_cli.commands.generate_cmd import generate
+from aethis_cli.commands.cancel_cmd import cancel
 from aethis_cli.commands.refine_cmd import refine
 from aethis_cli.commands.status_cmd import status
 from aethis_cli.commands.test_cmd import test
@@ -71,6 +72,7 @@ https://aethis.ai/developer-access:
     aethis projects list                # see all projects + latest rulesets
     aethis init                         # scaffold a new project dir
     aethis generate --poll              # generate + poll until done
+    aethis cancel --project-id <id> --yes  # explicitly release a stuck run
     aethis test && aethis publish       # gate on tests, then publish
 
 Exit codes: 0 success · 1 the call failed · 3 an input was rejected, so no
@@ -183,6 +185,7 @@ app.add_typer(fields_app, name="fields")
 app.command()(init)
 app.command()(login)
 app.command()(generate)
+app.command()(cancel)
 app.command()(refine)
 app.command()(status)
 app.command(name="test")(test)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.37.1"
+version = "0.38.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cancel_cmd.py
+++ b/tests/test_cancel_cmd.py
@@ -1,0 +1,84 @@
+"""Tests for explicit, non-automatic generation cancellation."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from aethis_cli.main import app
+
+
+def _client(response: dict | None = None) -> MagicMock:
+    client = MagicMock()
+    client.cancel_generation.return_value = response or {
+        "job_id": "job_1",
+        "status": "failed",
+        "project_released": True,
+        "detail": "Ownership released. An already-running worker may continue.",
+    }
+    return client
+
+
+def test_cancel_with_yes_uses_explicit_project_and_reports_worker_limitation():
+    client = _client()
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback", return_value=(MagicMock(), client)):
+        result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc", "--yes"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    client.cancel_generation.assert_called_once_with("proj_abc")
+    assert "project proj_abc released" in result.output
+    assert "worker may continue" in result.output
+
+
+def test_cancel_declined_never_loads_a_client_or_calls_the_api():
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback") as load_client:
+        result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc"], input="n\n")
+
+    assert result.exit_code == 1
+    load_client.assert_not_called()
+
+
+def test_cancel_in_ci_never_blocks_on_stdin_and_announces_the_bypass():
+    client = _client()
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback", return_value=(MagicMock(), client)):
+        result = CliRunner().invoke(
+            app,
+            ["cancel", "-p", "proj_ci"],
+            env={"CI": "1"},
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Non-interactive (CI set)" in result.output
+    client.cancel_generation.assert_called_once_with("proj_ci")
+
+
+def test_cancel_json_emits_the_server_contract_without_human_prose():
+    response = {
+        "job_id": "job_json",
+        "status": "failed",
+        "project_released": True,
+        "detail": "An already-running worker may continue.",
+    }
+    client = _client(response)
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback", return_value=(MagicMock(), client)):
+        result = CliRunner().invoke(
+            app,
+            ["--output", "json", "cancel", "-p", "proj_json", "--yes"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == response
+
+
+def test_cancel_without_project_context_fails_before_auth_or_network(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback") as load_client:
+        result = CliRunner().invoke(app, ["cancel", "--yes"], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert "No project ID" in result.output
+    load_client.assert_not_called()

--- a/tests/test_cancel_cmd.py
+++ b/tests/test_cancel_cmd.py
@@ -13,6 +13,8 @@ from aethis_cli.main import app
 def _client(response: dict | None = None) -> MagicMock:
     client = MagicMock()
     client.get_status.return_value = {
+        "generation_contract_version": 1,
+        "retry_readiness": "blocked",
         "project_status": "generating",
         "job": {"job_id": "job_1", "status": "running"},
     }
@@ -109,4 +111,19 @@ def test_cancel_refuses_when_expected_job_differs_from_observed_job():
     assert result.exit_code == 1
     assert "expected job job_old" in result.output
     assert "currently reports job_1" in result.output
+    client.cancel_generation.assert_not_called()
+
+
+def test_cancel_refuses_engine_without_job_bound_contract():
+    client = _client()
+    client.get_status.return_value.pop("generation_contract_version")
+    with patch(
+        "aethis_cli.commands.cancel_cmd.load_client_or_fallback",
+        return_value=(MagicMock(), client),
+    ):
+        result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc", "--yes"])
+
+    assert result.exit_code == 1
+    assert "Cancellation is unavailable" in result.output
+    assert "recovery contract" in result.output
     client.cancel_generation.assert_not_called()

--- a/tests/test_cancel_cmd.py
+++ b/tests/test_cancel_cmd.py
@@ -53,7 +53,7 @@ def test_cancel_declined_observes_target_but_never_calls_cancel():
     client.cancel_generation.assert_not_called()
 
 
-def test_cancel_in_ci_never_blocks_on_stdin_and_announces_the_bypass():
+def test_cancel_in_ci_requires_explicit_yes_and_never_calls_cancel():
     client = _client()
     with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback", return_value=(MagicMock(), client)):
         result = CliRunner().invoke(
@@ -63,9 +63,9 @@ def test_cancel_in_ci_never_blocks_on_stdin_and_announces_the_bypass():
             catch_exceptions=False,
         )
 
-    assert result.exit_code == 0, result.output
-    assert "Non-interactive (CI set)" in result.output
-    client.cancel_generation.assert_called_once_with("proj_ci", "job_1")
+    assert result.exit_code == 1, result.output
+    assert "requires explicit --yes" in result.output
+    client.cancel_generation.assert_not_called()
 
 
 def test_cancel_json_emits_the_server_contract_without_human_prose():
@@ -102,6 +102,33 @@ def test_cancel_renders_idempotent_already_cancelled_outcome():
         result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc", "--yes"], catch_exceptions=False)
 
     assert result.exit_code == 0, result.output
+    assert "already cancelled" in result.output
+
+
+def test_cancel_replays_exact_already_cancelled_job_after_lost_response():
+    client = _client(
+        {
+            "job_id": "job_1",
+            "status": "failed",
+            "outcome": "already_cancelled",
+            "project_released": True,
+            "detail": "The exact job was already cancelled.",
+        }
+    )
+    client.get_status.return_value["job"] = {
+        "job_id": "job_1",
+        "status": "failed",
+        "error_detail": {"reason_code": "generation_cancelled"},
+    }
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback", return_value=(MagicMock(), client)):
+        result = CliRunner().invoke(
+            app,
+            ["cancel", "-p", "proj_abc", "--job-id", "job_1", "--yes"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    client.cancel_generation.assert_called_once_with("proj_abc", "job_1")
     assert "already cancelled" in result.output
 
 

--- a/tests/test_cancel_cmd.py
+++ b/tests/test_cancel_cmd.py
@@ -12,6 +12,10 @@ from aethis_cli.main import app
 
 def _client(response: dict | None = None) -> MagicMock:
     client = MagicMock()
+    client.get_status.return_value = {
+        "project_status": "generating",
+        "job": {"job_id": "job_1", "status": "running"},
+    }
     client.cancel_generation.return_value = response or {
         "job_id": "job_1",
         "status": "failed",
@@ -27,17 +31,23 @@ def test_cancel_with_yes_uses_explicit_project_and_reports_worker_limitation():
         result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc", "--yes"], catch_exceptions=False)
 
     assert result.exit_code == 0, result.output
-    client.cancel_generation.assert_called_once_with("proj_abc")
+    client.cancel_generation.assert_called_once_with("proj_abc", "job_1")
+    assert "job_1" in result.output
     assert "project proj_abc released" in result.output
     assert "worker may continue" in result.output
 
 
-def test_cancel_declined_never_loads_a_client_or_calls_the_api():
-    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback") as load_client:
+def test_cancel_declined_observes_target_but_never_calls_cancel():
+    client = _client()
+    with patch(
+        "aethis_cli.commands.cancel_cmd.load_client_or_fallback",
+        return_value=(MagicMock(), client),
+    ):
         result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc"], input="n\n")
 
     assert result.exit_code == 1
-    load_client.assert_not_called()
+    client.get_status.assert_called_once_with("proj_abc")
+    client.cancel_generation.assert_not_called()
 
 
 def test_cancel_in_ci_never_blocks_on_stdin_and_announces_the_bypass():
@@ -52,7 +62,7 @@ def test_cancel_in_ci_never_blocks_on_stdin_and_announces_the_bypass():
 
     assert result.exit_code == 0, result.output
     assert "Non-interactive (CI set)" in result.output
-    client.cancel_generation.assert_called_once_with("proj_ci")
+    client.cancel_generation.assert_called_once_with("proj_ci", "job_1")
 
 
 def test_cancel_json_emits_the_server_contract_without_human_prose():
@@ -82,3 +92,21 @@ def test_cancel_without_project_context_fails_before_auth_or_network(tmp_path, m
     assert result.exit_code == 1
     assert "No project ID" in result.output
     load_client.assert_not_called()
+
+
+def test_cancel_refuses_when_expected_job_differs_from_observed_job():
+    client = _client()
+    with patch(
+        "aethis_cli.commands.cancel_cmd.load_client_or_fallback",
+        return_value=(MagicMock(), client),
+    ):
+        result = CliRunner().invoke(
+            app,
+            ["cancel", "-p", "proj_abc", "--job-id", "job_old", "--yes"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 1
+    assert "expected job job_old" in result.output
+    assert "currently reports job_1" in result.output
+    client.cancel_generation.assert_not_called()

--- a/tests/test_cancel_cmd.py
+++ b/tests/test_cancel_cmd.py
@@ -21,6 +21,7 @@ def _client(response: dict | None = None) -> MagicMock:
     client.cancel_generation.return_value = response or {
         "job_id": "job_1",
         "status": "failed",
+        "outcome": "cancelled",
         "project_released": True,
         "detail": "Ownership released. An already-running worker may continue.",
     }
@@ -71,6 +72,7 @@ def test_cancel_json_emits_the_server_contract_without_human_prose():
     response = {
         "job_id": "job_json",
         "status": "failed",
+        "outcome": "already_cancelled",
         "project_released": True,
         "detail": "An already-running worker may continue.",
     }
@@ -84,6 +86,23 @@ def test_cancel_json_emits_the_server_contract_without_human_prose():
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == response
+
+
+def test_cancel_renders_idempotent_already_cancelled_outcome():
+    client = _client(
+        {
+            "job_id": "job_1",
+            "status": "failed",
+            "outcome": "already_cancelled",
+            "project_released": True,
+            "detail": "The exact job was already cancelled.",
+        }
+    )
+    with patch("aethis_cli.commands.cancel_cmd.load_client_or_fallback", return_value=(MagicMock(), client)):
+        result = CliRunner().invoke(app, ["cancel", "-p", "proj_abc", "--yes"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "already cancelled" in result.output
 
 
 def test_cancel_without_project_context_fails_before_auth_or_network(tmp_path, monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -276,10 +276,11 @@ def test_cancel_generation(respx_mock):
         )
     )
 
-    result = AethisClient("ak", BASE).cancel_generation("proj_abc")
+    result = AethisClient("ak", BASE).cancel_generation("proj_abc", "job_1")
 
     assert result["project_released"] is True
     assert route.called
+    assert route.calls.last.request.url.params["job_id"] == "job_1"
     assert route.calls.last.request.content in (b"", None)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -263,6 +263,27 @@ def test_get_status(respx_mock):
 
 
 @respx.mock(base_url=BASE)
+def test_cancel_generation(respx_mock):
+    route = respx_mock.post("/api/v1/public/projects/proj_abc/generate/cancel").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "job_id": "job_1",
+                "status": "failed",
+                "project_released": True,
+                "detail": "The worker may continue.",
+            },
+        )
+    )
+
+    result = AethisClient("ak", BASE).cancel_generation("proj_abc")
+
+    assert result["project_released"] is True
+    assert route.called
+    assert route.calls.last.request.content in (b"", None)
+
+
+@respx.mock(base_url=BASE)
 def test_run_tests(respx_mock):
     respx_mock.post("/api/v1/public/projects/proj_abc/test-run").mock(
         return_value=httpx.Response(

--- a/tests/test_generate_failure_reporting.py
+++ b/tests/test_generate_failure_reporting.py
@@ -259,6 +259,9 @@ def test_a_timeout_keeps_the_recorded_id_but_names_it_as_stale(tmp_path, monkeyp
     )
     out = _flat(capsys)
     assert "Timed out" in out
+    assert "aethis status -p" in out
+    assert "aethis cancel -p" in out
+    assert "may not stop an already-running worker" in out
     assert "rs_from_an_earlier_run" in out, "the stale pointer must be named rather than left to be discovered"
 
 

--- a/tests/test_generation_status.py
+++ b/tests/test_generation_status.py
@@ -1,0 +1,25 @@
+"""Generation telemetry formatting remains backward-compatible and truthful."""
+
+from aethis_cli.generation_status import format_heartbeat, format_poll_description, format_progress_detail
+
+
+def test_formats_turn_convergence_and_tool_count():
+    job = {"current_turn": 11, "max_turns": 20, "best_passed": 31, "test_total": 42, "tool_calls": 27}
+    assert format_progress_detail(job) == "turn 11/20 · best 31/42 tests · 27 tool calls"
+
+
+def test_formats_server_computed_heartbeat_age_and_last_tool():
+    job = {"seconds_since_progress": 3725.8, "last_tool": "compile_and_test"}
+    assert format_heartbeat(job) == "last progress 1h 2m ago · compile_and_test"
+
+
+def test_old_engine_payload_has_no_invented_heartbeat_or_convergence():
+    job = {"status": "running", "progress_percent": 20}
+    assert format_progress_detail(job) == ""
+    assert format_heartbeat(job) == ""
+    assert format_poll_description(job) == "running — 20%"
+
+
+def test_bad_numeric_values_are_not_rendered_as_heartbeat_age():
+    assert format_heartbeat({"seconds_since_progress": -1}) == ""
+    assert format_heartbeat({"seconds_since_progress": True}) == ""

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -214,7 +214,17 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
     }
     fake_gen = {
         "project_status": "ready",
-        "job": {"status": "completed", "progress_percent": 100},
+        "job": {
+            "status": "completed",
+            "progress_percent": 100,
+            "current_turn": 11,
+            "max_turns": 20,
+            "best_passed": 31,
+            "test_total": 42,
+            "tool_calls": 27,
+            "last_tool": "compile_and_test",
+            "seconds_since_progress": 72,
+        },
         "latest_ruleset_id": "test:20260419-abc1234",
     }
 
@@ -230,3 +240,8 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
     assert "proj_abc" in clean
     assert "ready" in clean
     assert "test:20260419-abc1234" in clean
+    assert "turn 11/20" in clean
+    assert "best 31/42 tests" in clean
+    assert "27 tool calls" in clean
+    assert "last progress 1m 12s ago" in clean
+    assert "compile_and_test" in clean

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -213,6 +213,9 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
         "can_author": False,
     }
     fake_gen = {
+        "generation_contract_version": 1,
+        "worker_lifecycle": "terminal",
+        "retry_readiness": "ready",
         "project_status": "ready",
         "job": {
             "status": "completed",
@@ -239,6 +242,7 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
     assert "Generation" in clean
     assert "proj_abc" in clean
     assert "ready" in clean
+    assert "terminal" in clean
     assert "test:20260419-abc1234" in clean
     assert "turn 11/20" in clean
     assert "best 31/42 tests" in clean

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -214,6 +214,7 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
     }
     fake_gen = {
         "generation_contract_version": 1,
+        "telemetry_availability": "current",
         "worker_lifecycle": "terminal",
         "retry_readiness": "ready",
         "project_status": "ready",
@@ -243,6 +244,7 @@ def test_status_with_project_id_shows_generation_progress(tmp_project, monkeypat
     assert "proj_abc" in clean
     assert "ready" in clean
     assert "terminal" in clean
+    assert "current" in clean
     assert "test:20260419-abc1234" in clean
     assert "turn 11/20" in clean
     assert "best 31/42 tests" in clean


### PR DESCRIPTION
## Summary

- add job-bound `generate cancel` and actionable stalled/failed status output
- gate mutation on the engine recovery capability and require explicit `--yes` in automation
- make exact cancelled-response replay idempotent without permitting arbitrary terminal-job mutation

Consumer for Aethis-ai/aethis-core#481. Merge/release is dependency-gated on the engine contract being live.

## Test plan

- [x] 663 tests passed (non-E2E)
- [x] Ruff clean
- [x] package build green
- [x] fresh adversarial review GO

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Aethis-ai/codesmith/aethis-cli/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790985729&installation_model_id=429844&pr_number=127&repository=Aethis-ai%2Faethis-cli&return_to=https%3A%2F%2Fgithub.com%2FAethis-ai%2Faethis-cli%2Fpull%2F127&signature=ff95210811b36cdf1cf045aed1d379795e0593b16b0d168aa7eefa629fd1daff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->