### PR TITLE
feat: transport authoritative field-note pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
-## 0.38.1 (2026-09-10)
+## 0.39.0 (2026-09-10)
 
 - **feat(generate): field-note pins are now exact and explicit.** A field's
   optional `notes:` list is validated and sent on its project field-spec pin.
   Omit the key to retain legacy/model-owned notes; use `[]` to clear notes
   authoritatively. Each note requires `note_text`, accepts optional `source`
   and JSON-object `metadata`, and rejects unknown or ambiguous shapes before
-  any request is made. Engines that do not advertise the property are refused
-  before the pin could be silently discarded.
+  any request is made. Engines that do not advertise the property, or whose
+  schema cannot be read, are refused before any related authoring write could
+  silently discard the pin.
 
 ## 0.38.0 (2026-09-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.38.1 (2026-09-10)
+
+- **feat(generate): field-note pins are now exact and explicit.** A field's
+  optional `notes:` list is validated and sent on its project field-spec pin.
+  Omit the key to retain legacy/model-owned notes; use `[]` to clear notes
+  authoritatively. Each note requires `note_text`, accepts optional `source`
+  and JSON-object `metadata`, and rejects unknown or ambiguous shapes before
+  any request is made. Engines that do not advertise the property are refused
+  before the pin could be silently discarded.
+
 ## 0.38.0 (2026-09-02)
 
 - **feat: explicitly recover an authoring project from an abandoned generation.**

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.38.1"
+__version__ = "0.39.0"

--- a/aethis_cli/_version.py
+++ b/aethis_cli/_version.py
@@ -1,3 +1,3 @@
 """Version info — updated per release."""
 
-__version__ = "0.38.0"
+__version__ = "0.38.1"

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -749,6 +749,12 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
         expected_fields.append(spec)
         guidance_lines.extend(_field_guidance_lines(key, field))
 
+    # A declared note pin is exact, not best-effort. Check it before registry
+    # sync as well as before the spec POST: neither a value-space write nor a
+    # guidance write may happen when the engine cannot prove it keeps notes.
+    notes_declared = any("notes" in field for field in expected_fields)
+    check_authored_notes_support(client, expected_fields)
+
     # Registry sync BEFORE spec-set (aethis-core#424, design note DX-6): the
     # engine resolves a value_space reference at the spec-set boundary, so
     # every locally-authored space must exist there first — and a pre-#424
@@ -759,7 +765,9 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
     if referenced:
         _sync_value_spaces(client, project_dir, referenced)
 
-    check_display_metadata_support(client, expected_fields)
+    # Keep the pre-existing warn-and-proceed behaviour for all older metadata
+    # keys. Notes were already checked above, before any related write.
+    check_display_metadata_support(client, expected_fields, exclude_notes=notes_declared)
 
     client.set_field_spec(pid, expected_fields)
     for line in guidance_lines:
@@ -767,7 +775,34 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
     info(f"Set field spec ({len(expected_fields)} field(s))")
 
 
-def check_display_metadata_support(client: AethisClient, fields: list[dict], *, rulebook: bool = False) -> None:
+def check_authored_notes_support(client: AethisClient, fields: list[dict]) -> None:
+    """Fail closed before any related write when an exact note pin is unverifiable."""
+    if not any(isinstance(field, dict) and "notes" in field for field in fields):
+        return
+    advertised = client.expected_field_spec_properties()
+    if advertised is None:
+        console.print(
+            f"[red]Could not read the engine's field-spec schema, so it cannot confirm it keeps notes "
+            f"({client.base_url}).[/red]"
+        )
+        console.print(
+            "[red]Stopping before related writes: an engine that does not model notes accepts the upload and "
+            "discards an authoritative note pin silently. Restore schema access or use an engine that advertises "
+            "ExpectedFieldSpec.notes.[/red]"
+        )
+        raise typer.Exit(code=1)
+    if "notes" not in advertised:
+        console.print(f"[red]This engine does not carry notes on a field spec ({client.base_url}).[/red]")
+        console.print(
+            "[red]Stopping before related writes: the upload would succeed and the authored notes would be "
+            "dropped. Upgrade the engine, or remove notes from fields.yaml.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+
+def check_display_metadata_support(
+    client: AethisClient, fields: list[dict], *, rulebook: bool = False, exclude_notes: bool = False
+) -> None:
     """Refuse to push authored field metadata an engine will throw away.
 
     An engine that predates a field-spec property does not reject it — it
@@ -777,8 +812,9 @@ def check_display_metadata_support(client: AethisClient, fields: list[dict], *, 
     declare something: a project with none is untouched.
 
     An engine whose schema cannot be read at all is a different answer from one
-    that answered "no", and only the second is evidence. The first is reported
-    and the upload proceeds.
+    that answered "no". Existing metadata keeps its warn-and-proceed behaviour,
+    but declared ``notes`` fail closed: an exact note pin cannot be safely
+    written when the engine capability is unknown.
 
     ``rulebook`` selects which model the engine is asked about — a rulebook
     field entry and a project field pin are different models and an engine may
@@ -786,11 +822,24 @@ def check_display_metadata_support(client: AethisClient, fields: list[dict], *, 
     about the one it actually posts.
     """
     gated_keys = _RULEBOOK_GATED_FIELD_KEYS if rulebook else _ENGINE_GATED_FIELD_KEYS
+    if exclude_notes:
+        gated_keys = tuple(key for key in gated_keys if key != "notes")
     declared = sorted({k for f in fields if isinstance(f, dict) for k in gated_keys if k in f})
     if not declared:
         return
     advertised = client.rulebook_field_spec_properties() if rulebook else client.expected_field_spec_properties()
     if advertised is None:
+        if not rulebook and "notes" in declared:
+            console.print(
+                f"[red]Could not read the engine's field-spec schema, so it cannot confirm it keeps notes "
+                f"({client.base_url}).[/red]"
+            )
+            console.print(
+                "[red]Stopping before related writes: an engine that does not model notes accepts the upload and "
+                "discards an authoritative note pin silently. Restore schema access or use an engine that advertises "
+                "ExpectedFieldSpec.notes.[/red]"
+            )
+            raise typer.Exit(code=1)
         console.print(
             f"[yellow]Could not read the engine's field-spec schema, so it is unknown whether it "
             f"keeps {', '.join(declared)}. Proceeding — an engine that does not model them accepts "

--- a/aethis_cli/commands/generate_cmd.py
+++ b/aethis_cli/commands/generate_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 import time
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -249,6 +250,7 @@ _FIELD_KEY_ORDER = (
     "injection_phase",
     "recoverable_from",
     "x_ui_widget",
+    "notes",
     "hints",
 )
 
@@ -266,6 +268,7 @@ _ENGINE_GATED_FIELD_KEYS = (
     "injection_phase",
     "recoverable_from",
     "x_ui_widget",
+    "notes",
 )
 
 # Rulebook vocabulary is intentionally slimmer than a generation pin. Keep its
@@ -340,7 +343,85 @@ def validate_fields_list(fields: list) -> list[str]:
         if ftype == "enum" and not f.get("enum_values") and not f.get("value_space"):
             errors.append(f"Field {key!r} is type 'enum' but declares no enum_values (or value_space).")
         errors.extend(_validate_display_metadata(key, f, ftype))
+        errors.extend(_validate_field_notes(key, f))
     return errors
+
+
+def _validate_json_value(value: object, path: str) -> str | None:
+    """Return an error when a YAML value cannot be preserved as JSON."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return None
+    if isinstance(value, float):
+        return None if math.isfinite(value) else f"{path} is not a finite JSON number."
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            error = _validate_json_value(item, f"{path}[{index}]")
+            if error:
+                return error
+        return None
+    if isinstance(value, dict):
+        for item_key, item in value.items():
+            if not isinstance(item_key, str):
+                return f"{path} has a non-text object key {item_key!r}."
+            error = _validate_json_value(item, f"{path}.{item_key}")
+            if error:
+                return error
+        return None
+    return f"{path} is not JSON-compatible ({type(value).__name__})."
+
+
+def _validate_field_notes(key: str, field: dict) -> list[str]:
+    """Validate the exact structured note list on an authored field pin.
+
+    A missing ``notes`` key leaves legacy/model-owned notes untouched. An empty
+    list is deliberate, authoritative clearing. ``null`` is not a useful
+    field-note value and is refused locally rather than becoming an ambiguous
+    wire shape.
+    """
+    if "notes" not in field:
+        return []
+
+    notes = field["notes"]
+    if notes is None:
+        return [f"Field {key!r} declares notes: null; omit notes or use [] to clear them authoritatively."]
+    if not isinstance(notes, list):
+        return [f"Field {key!r} declares notes but it is not a list."]
+
+    errors: list[str] = []
+    allowed = {"note_text", "source", "metadata"}
+    for index, note in enumerate(notes):
+        path = f"Field {key!r} note #{index + 1}"
+        if not isinstance(note, dict):
+            errors.append(f"{path} is not a mapping.")
+            continue
+        unknown = sorted(str(note_key) for note_key in note.keys() - allowed)
+        if unknown:
+            errors.append(f"{path} has unknown key(s): {', '.join(unknown)}.")
+        if "note_text" not in note or not isinstance(note.get("note_text"), str):
+            errors.append(f"{path} must declare note_text as text.")
+        if "source" in note and not isinstance(note["source"], str):
+            errors.append(f"{path} declares source but it is not text.")
+        if "metadata" in note:
+            metadata = note["metadata"]
+            if not isinstance(metadata, dict):
+                errors.append(f"{path} declares metadata but it is not an object.")
+            else:
+                metadata_error = _validate_json_value(metadata, f"{path}.metadata")
+                if metadata_error:
+                    errors.append(metadata_error)
+    return errors
+
+
+def _normalise_field_notes(notes: list[dict]) -> list[dict]:
+    """Make optional FieldNote members explicit without changing metadata."""
+    return [
+        {
+            "note_text": note["note_text"],
+            "source": note.get("source", ""),
+            "metadata": note.get("metadata", {}),
+        }
+        for note in notes
+    ]
 
 
 def _validate_display_metadata(key: str, f: dict, ftype: str) -> list[str]:
@@ -655,7 +736,10 @@ def _upload_field_vocabulary(client: AethisClient, pid: str, project_dir: Path) 
         for prop in _ENGINE_GATED_FIELD_KEYS:
             if prop in field:
                 value = field[prop]
-                spec[prop] = dict(value) if isinstance(value, dict) else value
+                if prop == "notes":
+                    spec[prop] = _normalise_field_notes(value)
+                else:
+                    spec[prop] = dict(value) if isinstance(value, dict) else value
         # In fields.yaml, omitting a question on a declared non-applicant fact
         # is intentional: there is no applicant question. Make that absence
         # explicit on the wire so a model-invented question is cleared rather

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.38.0"
+version = "0.38.1"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aethis-cli"
-version = "0.38.1"
+version = "0.39.0"
 description = "CLI for the Aethis developer API — author, test, and publish rulesets"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/mutation-check.py
+++ b/scripts/mutation-check.py
@@ -314,7 +314,7 @@ MUTATIONS: List[Mutation] = [
     Mutation(
         "metadata-capability-guard-skipped",
         "aethis_cli/commands/generate_cmd.py",
-        "    check_display_metadata_support(client, expected_fields)\n",
+        "    check_display_metadata_support(client, expected_fields, exclude_notes=notes_declared)\n",
         "",
         "an engine that discards the metadata is written to anyway",
         detects=(
@@ -324,11 +324,27 @@ MUTATIONS: List[Mutation] = [
     Mutation(
         "unreadable-field-spec-schema-reads-as-unsupported",
         "aethis_cli/commands/generate_cmd.py",
-        "    if advertised is None:",
-        "    if advertised is None:\n        advertised = set()\n    if False:",
+        '        return\n'
+        '    missing = [k for k in declared if k not in advertised]\n',
+        '        advertised = set()\n'
+        '    missing = [k for k in declared if k not in advertised]\n',
         "an unreachable schema blocks an upload that would have worked",
         detects=(
             "tests/test_field_display_metadata_transport.py::test_upload_proceeds_but_says_so_when_the_engine_schema_is_unreadable",
+        ),
+    ),
+    Mutation(
+        "authored-notes-unreadable-schema-fails-open",
+        "aethis_cli/commands/generate_cmd.py",
+        '    if advertised is None:\n'
+        '        console.print(\n'
+        '            f"[red]Could not read the engine\'s field-spec schema, so it cannot confirm it keeps notes "\n',
+        '    if False:\n'
+        '        console.print(\n'
+        '            f"[red]Could not read the engine\'s field-spec schema, so it cannot confirm it keeps notes "\n',
+        "an exact authored note pin proceeds when its engine capability is unknown",
+        detects=(
+            "tests/test_field_behaviour_metadata_transport.py::test_declared_notes_abort_before_all_related_writes_when_support_is_not_proven[None-[]]",
         ),
     ),
     Mutation(

--- a/scripts/mutation-check.py
+++ b/scripts/mutation-check.py
@@ -245,7 +245,10 @@ MUTATIONS: List[Mutation] = [
         "        for prop in _ENGINE_GATED_FIELD_KEYS:\n"
         "            if prop in field:\n"
         "                value = field[prop]\n"
-        "                spec[prop] = dict(value) if isinstance(value, dict) else value\n",
+        "                if prop == \"notes\":\n"
+        "                    spec[prop] = _normalise_field_notes(value)\n"
+        "                else:\n"
+        "                    spec[prop] = dict(value) if isinstance(value, dict) else value\n",
         "",
         "authored wording and the storage-key pairing never reach the engine",
         detects=("tests/test_field_display_metadata_transport.py::test_upload_transmits_labels_and_canonical_field",),

--- a/tests/test_field_behaviour_metadata_transport.py
+++ b/tests/test_field_behaviour_metadata_transport.py
@@ -210,3 +210,35 @@ fields:
         generate_cmd._upload_field_vocabulary(client, "proj_1", project)
 
     client.set_field_spec.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "properties, notes",
+    [
+        (None, "[]"),
+        (None, "- note_text: Confirm the supplied record."),
+        (SUPPORTED - {"notes"}, "[]"),
+        (SUPPORTED - {"notes"}, "- note_text: Confirm the supplied record."),
+    ],
+)
+def test_declared_notes_abort_before_all_related_writes_when_support_is_not_proven(tmp_path, properties, notes):
+    client = _client(properties)
+    project = _project(
+        tmp_path,
+        f"""\
+fields:
+  - key: example.confirmed
+    type: enum
+    value_space: example/values
+    notes:
+      {notes}
+""",
+    )
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()
+    client.add_guidance.assert_not_called()
+    client.put_value_space.assert_not_called()
+    client.get_value_space.assert_not_called()

--- a/tests/test_field_behaviour_metadata_transport.py
+++ b/tests/test_field_behaviour_metadata_transport.py
@@ -25,6 +25,7 @@ SUPPORTED = {
     "injection_phase",
     "recoverable_from",
     "x_ui_widget",
+    "notes",
 }
 
 
@@ -125,6 +126,55 @@ fields:
     client.expected_field_spec_properties.assert_not_called()
 
 
+def test_notes_are_normalised_and_transmitted_as_an_authoritative_pin(tmp_path):
+    client = _client()
+    project = _project(
+        tmp_path,
+        """\
+fields:
+  - key: example.confirmed
+    type: bool
+    notes:
+      - note_text: Confirm the supplied record.
+      - note_text: Displayed only to reviewers.
+        source: example-policy#1
+        metadata:
+          type: rationale
+          nested: {approved: true, count: 2}
+""",
+    )
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    assert expected_fields == [
+        {
+            "key": "example.confirmed",
+            "sort": "bool",
+            "notes": [
+                {"note_text": "Confirm the supplied record.", "source": "", "metadata": {}},
+                {
+                    "note_text": "Displayed only to reviewers.",
+                    "source": "example-policy#1",
+                    "metadata": {"type": "rationale", "nested": {"approved": True, "count": 2}},
+                },
+            ],
+        }
+    ]
+    client.expected_field_spec_properties.assert_called_once()
+
+
+def test_empty_notes_transmits_authoritative_clear(tmp_path):
+    client = _client()
+    project = _project(tmp_path, "fields:\n  - key: example.confirmed\n    type: bool\n    notes: []\n")
+
+    generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    _, expected_fields = client.set_field_spec.call_args.args
+    assert expected_fields == [{"key": "example.confirmed", "sort": "bool", "notes": []}]
+    client.expected_field_spec_properties.assert_called_once()
+
+
 def test_missing_engine_capability_refuses_before_field_push(tmp_path):
     client = _client(SUPPORTED - {"elicitation_owner", "question"})
     project = _project(
@@ -134,6 +184,25 @@ fields:
   - key: case.review_date
     type: date
     elicitation_owner: caseworker
+""",
+    )
+
+    with pytest.raises(typer.Exit):
+        generate_cmd._upload_field_vocabulary(client, "proj_1", project)
+
+    client.set_field_spec.assert_not_called()
+
+
+def test_missing_notes_capability_refuses_before_field_push(tmp_path):
+    client = _client(SUPPORTED - {"notes"})
+    project = _project(
+        tmp_path,
+        """\
+fields:
+  - key: example.confirmed
+    type: bool
+    notes:
+      - note_text: Confirm the supplied record.
 """,
     )
 

--- a/tests/test_field_display_metadata_transport.py
+++ b/tests/test_field_display_metadata_transport.py
@@ -208,6 +208,29 @@ def test_validate_rejects_an_empty_canonical_field():
     assert any("canonical_field" in e for e in errors)
 
 
+@pytest.mark.parametrize(
+    "notes, expected",
+    [
+        (None, "notes: null"),
+        ({"note_text": "not-a-list"}, "not a list"),
+        (["not-a-mapping"], "not a mapping"),
+        ([{"note_text": "x", "unknown": True}], "unknown key"),
+        ([{"source": "missing text"}], "note_text"),
+        ([{"note_text": "x", "source": 1}], "source but it is not text"),
+        ([{"note_text": "x", "metadata": []}], "metadata but it is not an object"),
+        ([{"note_text": "x", "metadata": {1: "not-json-key"}}], "non-text object key"),
+    ],
+)
+def test_validate_rejects_invalid_structured_notes(notes, expected):
+    errors = generate_cmd.validate_fields_list([{"key": "example.confirmed", "type": "bool", "notes": notes}])
+    assert any(expected in error for error in errors)
+
+
+def test_validate_accepts_omitted_or_empty_notes_but_not_null():
+    assert generate_cmd.validate_fields_list([{"key": "example.legacy", "type": "bool"}]) == []
+    assert generate_cmd.validate_fields_list([{"key": "example.clear", "type": "bool", "notes": []}]) == []
+
+
 # --- engine capability ------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #135. Part of Aethis-ai/aethis-workspace#912; depends on Aethis-ai/aethis-core#533.

## Summary

- validates and transports optional structured `notes` on project field pins
- preserves omission (legacy/model-owned) versus `[]` (authoritative clear), rejects `null`, unknown note keys, and non-JSON metadata
- normalises omitted FieldNote `source` and `metadata` to their documented defaults, without interpreting content
- fails closed before field-spec, guidance, or value-space writes when declared notes are unsupported or the engine schema cannot be read; legacy metadata remains warn-and-proceed when its schema is unreadable
- bumps the public CLI to 0.39.0

## Validation

- `uv run ruff check .`
- `uv run pytest` — 679 passed, 24 deselected; 79.46% coverage
- `uv build`, then installed the built wheel in a clean temporary venv and ran `aethis --help`
- targeted mutation checks: existing metadata transport/guard detector and the new unreadable-notes fail-closed detector killed

## Landing gate

Draft only: do not merge, tag, or publish until core #533 is merged and `ExpectedFieldSpec.notes` is live and observable on `https://api.aethis.ai/openapi.json`. This client does not alter the served `/schema` notes shape.